### PR TITLE
Add hashbang to run bespoke on OSX

### DIFF
--- a/Builds/MacOSX/build/Release/run_bespoke.command
+++ b/Builds/MacOSX/build/Release/run_bespoke.command
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 cd `dirname $0`
 pwd
 ./Bespoke.app/Contents/MacOS/Bespoke 


### PR DESCRIPTION
👋 Hey! 

I was trying to run bespoke on my MacOS. Turns out there's no hashbang at the start of the file, so it cannot be executed by the system:

```
~/Bespoke ~> ./run_bespoke.command
Failed to execute process './run_bespoke.command'. Reason:
exec: Exec format error
The file './run_bespoke.command' is marked as an executable but could not be run by the operating system.
```

This is a very small fix, so that it's possible to run `./run_bespoke.command`.