### PR TITLE
Added check for isSysEx for OnMidi

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -410,7 +410,7 @@ void MidiController::OnMidiPitchBend(MidiPitchBend& pitchBend)
 
 void MidiController::OnMidi(const MidiMessage& message)
 {
-   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter))
+   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !message.isSysEx()))
       return;
    mNoteOutput.SendMidi(message);
 }


### PR DESCRIPTION
SysEx messages don't contain channel information and so cannot be filtered on a per channel basis. To enable sending thru sysex messages, even when channel filtering is enabled, I added a check to allow sysex messages to be forwarded on.