### PR TITLE
align paths in userprefs window, align vocoder ui, add jack, disable curl

### DIFF
--- a/BespokeSynth.jucer
+++ b/BespokeSynth.jucer
@@ -1149,7 +1149,7 @@
     <MODULE id="juce_video" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
   </MODULES>
   <JUCEOPTIONS JUCE_PLUGINHOST_VST3="1" JUCE_PLUGINHOST_VST="1" JUCE_WEB_BROWSER="0"
-               JUCE_USE_MP3AUDIOFORMAT="1"/>
+               JUCE_USE_CURL="0" JUCE_JACK="1" JUCE_USE_MP3AUDIOFORMAT="1"/>
   <LIVE_SETTINGS>
     <OSX headerPath="" systemHeaderPath=""/>
     <WINDOWS headerPath="" systemHeaderPath="&#10;"/>

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -40,10 +40,10 @@ void UserPrefsEditor::CreateUIControls()
    FLOATSLIDER(mScrollMultiplierVerticalSlider, "scroll_multiplier_vertical", &mScrollMultiplierVertical, -2, 2);
    FLOATSLIDER(mScrollMultiplierHorizontalSlider, "scroll_multiplier_horizontal", &mScrollMultiplierHorizontal, -2, 2);
    CHECKBOX(mAutosaveCheckbox, "autosave", &mAutosave);
-   TEXTENTRY(mTooltipsFilePathEntry, "tooltips", 100, &mTooltipsFilePath);
-   TEXTENTRY(mDefaultLayoutPathEntry, "layout", 100, &mDefaultLayoutPath);
-   TEXTENTRY(mYoutubeDlPathEntry, "youtube-dl_path", 100, &mYoutubeDlPath);
-   TEXTENTRY(mFfmpegPathEntry, "ffmpeg_path", 100, &mFfmpegPath);
+   TEXTENTRY(mTooltipsFilePathEntry, "tooltips        ", 100, &mTooltipsFilePath);
+   TEXTENTRY(mDefaultLayoutPathEntry, "layout          ", 100, &mDefaultLayoutPath);
+   TEXTENTRY(mYoutubeDlPathEntry, "youtube-dl_path ", 100, &mYoutubeDlPath);
+   TEXTENTRY(mFfmpegPathEntry, "ffmpeg_path     ", 100, &mFfmpegPath);
    UIBLOCK_SHIFTDOWN();
    BUTTON(mSaveButton, "save and exit bespoke");
    BUTTON(mCancelButton, "cancel");

--- a/Source/Vocoder.cpp
+++ b/Source/Vocoder.cpp
@@ -55,15 +55,15 @@ Vocoder::Vocoder()
 void Vocoder::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mInputSlider = new FloatSlider(this,"input", 5, 29, 100, 15, &mInputPreamp, 0, 2);
-   mCarrierSlider = new FloatSlider(this,"carrier", 5, 47, 100, 15, &mCarrierPreamp, 0, 2);
-   mVolumeSlider = new FloatSlider(this,"volume", 5, 65, 100, 15, &mVolume, 0, 2);
-   mDryWetSlider = new FloatSlider(this,"dry/wet", 5, 83, 100, 15, &mDryWet, 0, 1);
-   mFricativeSlider = new FloatSlider(this,"fric thresh", 5, 101, 100, 15, &mFricativeThresh, 0, 1);
-   mWhisperSlider = new FloatSlider(this,"whisper", 5, 119, 100, 15, &mWhisper, 0, 1);
-   mPhaseOffsetSlider = new FloatSlider(this,"phase off", 5, 137, 100, 15, &mPhaseOffset, 0, FTWO_PI);
-   mCutSlider = new IntSlider(this,"cut",5,155,100,15,&mCut,0,100);
-   
+   mInputSlider = new FloatSlider(this,"input", 5, 2, 100, 15, &mInputPreamp, 0, 2);
+   mCarrierSlider = new FloatSlider(this,"carrier", mInputSlider, kAnchor_Below, 100, 15, &mCarrierPreamp, 0, 2);
+   mVolumeSlider = new FloatSlider(this,"volume", mCarrierSlider, kAnchor_Below, 100, 15, &mVolume, 0, 2);
+   mDryWetSlider = new FloatSlider(this,"dry/wet", mVolumeSlider, kAnchor_Below, 100, 15, &mDryWet, 0, 1);
+   mFricativeSlider = new FloatSlider(this,"fric thresh", mDryWetSlider, kAnchor_Below, 100, 15, &mFricativeThresh, 0, 1);
+   mWhisperSlider = new FloatSlider(this,"whisper", mFricativeSlider, kAnchor_Below, 100, 15, &mWhisper, 0, 1);
+   mPhaseOffsetSlider = new FloatSlider(this,"phase off", mWhisperSlider, kAnchor_Below, 100, 15, &mPhaseOffset, 0, FTWO_PI);
+   mCutSlider = new IntSlider(this,"cut", mPhaseOffsetSlider, kAnchor_Below,100,15,&mCut,0,100);
+
    mGate.CreateUIControls();
 }
 

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -51,7 +51,7 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   void GetModuleDimensions(float& w, float& h) override { w=235; h=170; }
+   void GetModuleDimensions(float& w, float& h) override { w=235; h=140; }
    bool Enabled() const override { return mEnabled; }
 
    FFTData mFFTData;


### PR DESCRIPTION
I've made winword-newbie-allign with spaces. Maybe there is more right way to do this:

![изображение](https://user-images.githubusercontent.com/4686351/111093670-3a49ed00-8585-11eb-8106-ffd97b713db3.png)

Also added support for Jack audio subsystem for Linux and remove curl dependency.
Vocoder sliders aligned.