### PR TITLE
user another trick to pass JACK Client name, suitable for 5.4.7

### DIFF
--- a/BespokeSynth.jucer
+++ b/BespokeSynth.jucer
@@ -1323,7 +1323,7 @@
         <MODULEPATH id="juce_audio_basics" path="..\JUCE\modules"/>
       </MODULEPATHS>
     </VS2015>
-    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="GLEW_STATIC&#10;GL_GLEXT_PROTOTYPES&#10;BESPOKE_LINUX&#10;JUCE_JACK_CLIENT_NAME=&quot;BespokeSynth&quot;"
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="GLEW_STATIC&#10;GL_GLEXT_PROTOTYPES&#10;BESPOKE_LINUX&#10;"
                 externalLibraries="usb-1.0" extraCompilerFlags="&#96;python3-config --cflags&#96; -fvisibility=hidden -fPIE"
                 extraLinkerFlags="&#96;python3-config --ldflags&#96;" smallIcon="h1Eo7f"
                 bigIcon="h1Eo7f" linuxExtraPkgConfig="python3-embed">

--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -18,6 +18,8 @@
 
 // (You can add your own code in this section, and the Projucer will not overwrite it)
 
+#define JUCE_JACK_CLIENT_NAME "BespokeSynth"
+
 // [END_USER_CODE_SECTION]
 
 /*


### PR DESCRIPTION
previous worked in Projucer 6.0.8 only
quoting seems tricky in 5.4.7
i think adding that in  AppConfig.h user's sections is the "best" workaround for now
