### PR TITLE
Improve sample player user experience

### DIFF
--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -25,6 +25,7 @@
   ==============================================================================
 */
 
+#include "ModularSynth.h"
 #if BESPOKE_WINDOWS
 #define ssize_t ssize_t_undef_hack  //fixes conflict with ssize_t typedefs between python and juce
 #endif
@@ -933,7 +934,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       if (mCaretPosition != mCaretPosition2)
          RemoveSelectedText();
       
-      juce::String clipboard = SystemClipboard::getTextFromClipboard();
+      juce::String clipboard = TheSynth->GetTextFromClipboard();
       AddString(clipboard.toStdString());
    }
    else if (toupper(key) == 'V' && (GetKeyModifiers() == (kModifier_Command | kModifier_Shift)))
@@ -958,7 +959,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       {
          int caretStart = MIN(mCaretPosition, mCaretPosition2);
          int caretEnd = MAX(mCaretPosition, mCaretPosition2);
-         SystemClipboard::copyTextToClipboard(mString.substr(caretStart,caretEnd-caretStart));
+         TheSynth->CopyTextToClipboard(mString.substr(caretStart,caretEnd-caretStart));
          
          if (toupper(key) == 'X')
             RemoveSelectedText();

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -459,7 +459,12 @@ private:
       }
       return true;
    }
-   
+
+   void focusGained(FocusChangeType cause) override
+   {
+      mSynth.Focus();
+   }
+
    bool isInterestedInFileDrag(const StringArray& files) override
    {
       //TODO_PORT(Ryan)

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -857,6 +857,11 @@ void ModularSynth::Exit()
    ofExit();
 }
 
+void ModularSynth::Focus()
+{
+   ReadClipboardTextFromSystem();
+}
+
 IDrawableModule* ModularSynth::GetLastClickedModule() const
 {
    return mLastClickedModule;
@@ -2747,6 +2752,19 @@ void ModularSynth::SaveOutput()
    
    mGlobalRecordBuffer->ClearBuffer();
    mRecordingLength = 0;
+}
+
+const String& ModularSynth::GetTextFromClipboard() const {
+   return clipboard;
+}
+
+void ModularSynth::CopyTextToClipboard(const String& text) {
+   clipboard = text;
+   SystemClipboard::copyTextToClipboard(text);
+}
+
+void ModularSynth::ReadClipboardTextFromSystem() {
+   clipboard = SystemClipboard::getTextFromClipboard();
 }
 
 void ModularSynth::SetFatalError(string error)

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2755,16 +2755,16 @@ void ModularSynth::SaveOutput()
 }
 
 const String& ModularSynth::GetTextFromClipboard() const {
-   return clipboard;
+   return mClipboard;
 }
 
 void ModularSynth::CopyTextToClipboard(const String& text) {
-   clipboard = text;
+   mClipboard = text;
    SystemClipboard::copyTextToClipboard(text);
 }
 
 void ModularSynth::ReadClipboardTextFromSystem() {
-   clipboard = SystemClipboard::getTextFromClipboard();
+   mClipboard = SystemClipboard::getTextFromClipboard();
 }
 
 void ModularSynth::SetFatalError(string error)

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -64,7 +64,9 @@ public:
    void PostRender();
    
    void Exit();
-   
+
+   void Focus();
+
    void KeyPressed(int key, bool isRepeat);
    void KeyReleased(int key);
    void MouseMoved(int x, int y );
@@ -207,6 +209,9 @@ public:
 
    ofxJSONElement GetUserPrefs() { return mUserPrefs; }
    UserPrefsEditor* GetUserPrefsEditor() { return mUserPrefsEditor; }
+
+   const String& GetTextFromClipboard() const;
+   void CopyTextToClipboard(const String& text);
    
    void SetFatalError(string error);
 
@@ -227,6 +232,8 @@ private:
    void TriggerClapboard();
    void DoAutosave();
    IDrawableModule* GetModuleAtCursor();
+
+   void ReadClipboardTextFromSystem();
    
    ofSoundStream mSoundStream;
    int mIOBufferSize;
@@ -352,6 +359,8 @@ private:
 
    vector<float*> mInputBuffers;
    vector<float*> mOutputBuffers;
+
+   String clipboard;
 };
 
 extern ModularSynth* TheSynth;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -360,7 +360,7 @@ private:
    vector<float*> mInputBuffers;
    vector<float*> mOutputBuffers;
 
-   String clipboard;
+   String mClipboard;
 };
 
 extern ModularSynth* TheSynth;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1336,14 +1336,18 @@ bool SamplePlayer::MouseScrolled(int x, int y, float scrollX, float scrollY)
    //horizontal scroll
    mZoomOffset = ofClamp(mZoomOffset + scrollX*.005f, 0, 1);
 
-   //zoom scroll
+   // zoom scroll
    float oldZoomLevel = mZoomLevel;
-   mZoomLevel = ofClamp(mZoomLevel + scrollY*.2f, 1, 40);
+   if (scrollY > 0.)
+      mZoomLevel = ofClamp(mZoomLevel*scrollY, 1., 40.);
+   else
+      mZoomLevel = ofClamp(mZoomLevel/(-1. * scrollY), 1., 40.);
+
    float zoomAmount = (mZoomLevel - oldZoomLevel) / oldZoomLevel; //find actual adjusted amount
-   float zoomCenter = ofMap(x, 5, mWidth-10, 0, 1, true)/oldZoomLevel;
+   float zoomCenter = ofMap(x, 5., mWidth-10., 0., 1., true)/oldZoomLevel;
    mZoomOffset += zoomCenter * zoomAmount;
-   if (mZoomLevel == 1)
-      mZoomOffset = 0;
+   if (mZoomLevel == 1.)
+      mZoomOffset = 0.;
 
    return false;
 }

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -175,7 +175,7 @@ void SamplePlayer::Poll()
 {
    IDrawableModule::Poll();
    
-   juce::String clipboard = SystemClipboard::getTextFromClipboard();
+   const juce::String& clipboard = TheSynth->GetTextFromClipboard();
    if (clipboard.contains("youtube"))
    {
       juce::String clipId = clipboard.substring(clipboard.indexOf("v=")+2, clipboard.length());

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -911,23 +911,36 @@ bool SamplePlayer::MouseMoved(float x, float y)
       mHoveredCuePointIndex = -1;
       if (y > 60 && y < mHeight - 20 && mSample != nullptr)
       {
+         float seconds = GetSecondsForMouse(x);
+
+         // find cue point closest to but not exceeding the cursor position
+         int bestCuePointIndex = -1;
+         float bestCuePointStart = 0.;
          for (size_t i = 0; i < mSampleCuePoints.size(); ++i)
          {
-            if (mSampleCuePoints[i].lengthSeconds > 0)
+            float startSeconds = mSampleCuePoints[i].startSeconds;
+            float lengthSeconds = mSampleCuePoints[i].lengthSeconds;
+
+            if (lengthSeconds > 0.)
             {
-               float seconds = GetSecondsForMouse(x);
-               if (seconds >= mSampleCuePoints[i].startSeconds && seconds <= mSampleCuePoints[i].startSeconds + mSampleCuePoints[i].lengthSeconds)
+               if (seconds >= startSeconds && seconds <= startSeconds + lengthSeconds &&
+                   startSeconds > bestCuePointStart)
                {
-                  mHoveredCuePointIndex = (int)i;
-                  mActiveCuePointIndex = (int)i;
-                  UpdateActiveCuePoint();
-                  break;
+                  bestCuePointIndex = i;
+                  bestCuePointStart = startSeconds;
                }
             }
          }
+
+         if (bestCuePointIndex != -1)
+         {
+            mHoveredCuePointIndex = bestCuePointIndex;
+            mActiveCuePointIndex = bestCuePointIndex;
+            UpdateActiveCuePoint();
+         }
       }
    }
-   
+
    return true;
 }
 

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1336,18 +1336,14 @@ bool SamplePlayer::MouseScrolled(int x, int y, float scrollX, float scrollY)
    //horizontal scroll
    mZoomOffset = ofClamp(mZoomOffset + scrollX*.005f, 0, 1);
 
-   // zoom scroll
+   //zoom scroll
    float oldZoomLevel = mZoomLevel;
-   if (scrollY > 0.)
-      mZoomLevel = ofClamp(mZoomLevel*scrollY, 1., 40.);
-   else
-      mZoomLevel = ofClamp(mZoomLevel/(-1. * scrollY), 1., 40.);
-
+   mZoomLevel = ofClamp(mZoomLevel + scrollY*.2f, 1, 40);
    float zoomAmount = (mZoomLevel - oldZoomLevel) / oldZoomLevel; //find actual adjusted amount
-   float zoomCenter = ofMap(x, 5., mWidth-10., 0., 1., true)/oldZoomLevel;
+   float zoomCenter = ofMap(x, 5, mWidth-10, 0, 1, true)/oldZoomLevel;
    mZoomOffset += zoomCenter * zoomAmount;
-   if (mZoomLevel == 1.)
-      mZoomOffset = 0.;
+   if (mZoomLevel == 1)
+      mZoomOffset = 0;
 
    return false;
 }

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -25,6 +25,7 @@
 //
 
 #include "TextEntry.h"
+#include "ModularSynth.h"
 #include "SynthGlobals.h"
 #include "IDrawableModule.h"
 #include "FileStream.h"
@@ -349,7 +350,7 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
    }
    else if (toupper(key) == 'V' && GetKeyModifiers() == kModifier_Command)
    {
-      juce::String clipboard = SystemClipboard::getTextFromClipboard();
+      juce::String clipboard = TheSynth->GetTextFromClipboard();
       for (int i=0; i<clipboard.length(); ++i)
          AddCharacter(clipboard[i]);
    }


### PR DESCRIPTION
This PR makes three changes:
- When hovering over cue points in the sample player, select the cue point closest to _but not exceeding_ the cursor position. This fixes an issue where a cue point cannot be selected if it overlaps with another cue point of a lower index.
- Use exponential scroll zooming. I'm looking for feedback on this, but it feels more natural to me and in line with other audio editors.
- Fix sample player lag caused by repeated system clipboard checks.

Thank you!