### PR TITLE
Disable non-main output busses for now

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -328,6 +328,15 @@ void VSTPlugin::LoadVST(juce::PluginDescription desc)
    if (mPlugin != nullptr)
    {
       mPlugin->enableAllBuses();
+
+      // DIsable all non-main output busses
+      auto layouts = mPlugin->getBusesLayout();
+
+      for (int busIndex = 1; busIndex < layouts.outputBuses.size(); ++busIndex)
+          layouts.outputBuses.getReference(busIndex) = AudioChannelSet::disabled();
+
+      mPlugin->setBusesLayout(layouts);
+
       mPlugin->prepareToPlay(gSampleRate, gBufferSize);
       mPlugin->setPlayHead(&mPlayhead);
       mNumInputs = MIN(mPlugin->getTotalNumInputChannels(), 4);


### PR DESCRIPTION
Until Bespoke gets multi-output support, synths which have it
(SurgeXT, Pianotec, some samplers) need the aux busses disabled
and just to have the main. This code accomplishes that.

Closes #148