### PR TITLE
Fix Shift+Hover to connect modules

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1079,8 +1079,8 @@ void ModularSynth::MouseMoved(int intX, int intY )
                         mMoveModule->SetTarget(patchCableSource->GetTarget());
                         patchCableSource->SetTarget(mMoveModule);
                         PatchCableSource::sAllowInsert = true;
+                        break;
                      }
-                     break;
                   }
                }
             }


### PR DESCRIPTION
While watching Benn's video [1] about Bespoke, I noticed he had issues
with the shift+hover interaction. I gave it a try and was able to
reproduce by pressing shift before clicking the module I want to hover
another to make a connection.

Seems like it's just exiting too early in the iteration over patch
cables. We should only exit if we've made a successful connection.

[1] : https://www.youtube.com/watch?v=5jbKs9wmzoM