### PR TITLE
Mac Resource Location Changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,26 @@ if (APPLE)
             )
     target_link_libraries(BespokeSynth PRIVATE
             "-framework CoreAudioKit")
+
+    # Post install tasks - copy resources to the bundle
+    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+    add_custom_command(TARGET BespokeSynth
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/BespokeSynth.app/Contents/Resources/resource)
+
+    add_custom_target(BespokeSynth-Installer)
+    add_dependencies(BespokeSynth-Installer BespokeSynth)
+    set(InstallerName BespokeSynth-${PROJECT_VERSION})
+    add_custom_command(TARGET BespokeSynth-Installer
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMAND ${CMAKE_COMMAND} -E make_directory installer/BespokeSynth
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${OUTDIR}/BespokeSynth.app installer/BespokeSynth/BespokeSynth.app
+            COMMAND hdiutil create /tmp/tmp.dmg -ov -volname "BespokeSynth" -fs HFS+ -srcfolder "installer/BespokeSynth"
+            COMMAND hdiutil convert /tmp/tmp.dmg -format UDZO -o installer/${InstallerName}.dmg
+            )
+
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE
             BESPOKE_WINDOWS=1


### PR DESCRIPTION
1. The 'resource' directory lives in the bundle and CMake copies
   them at build time
2. The cmake commands can create a DMG
3. That DMG contains just the app, which runs from the DMG
   with no install

Closes #117