### PR TITLE
Resource Cmake Changes; Mac Resource Location Changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,9 @@ elseif (WIN32)
     endif ()
 
     # Post install tasks - copy resources to the exe output directory
+    set_target_properties(BespokeSynth PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:BespokeSynth>"
+                                    VS_DEBUGGER_COMMAND           "$<TARGET_FILE:BespokeSynth>"
+                                    VS_DEBUGGER_ENVIRONMENT       "PATH=%PATH%;${CMAKE_PREFIX_PATH}/bin")
     get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
     add_custom_command(TARGET BespokeSynth
             POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ if (NOT DEFINED PYBIND11_FINDPYTHON)
     endif()  
 endif()
 add_subdirectory(libs/pybind11 CONFIG)
+message(STATUS "Bespoke: Python Executable is ${PYTHON_EXECUTABLE}")
 
 if (NOT BESPOKE_JUCE_LOCATION)
     set(BESPOKE_JUCE_LOCATION "libs/JUCE" CACHE STRING "" FORCE)
@@ -438,6 +439,14 @@ if (APPLE)
             )
     target_link_libraries(BespokeSynth PRIVATE
             "-framework CoreAudioKit")
+
+    # Post install tasks - copy resources to the bundle
+    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+    add_custom_command(TARGET BespokeSynth
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/BespokeSynth.app/Contents/Resources/resource)
+
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE
             BESPOKE_WINDOWS=1
@@ -463,6 +472,13 @@ elseif (WIN32)
         target_link_libraries(BespokeSynth PRIVATE
                 ${CMAKE_SOURCE_DIR}/Source/3DxWare/Lib/x64/siapp.lib)
     endif ()
+
+    # Post install tasks - copy resources to the exe output directory
+    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+    add_custom_command(TARGET BespokeSynth
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/resource)
 else ()
     target_compile_definitions(BespokeSynth PRIVATE
             BESPOKE_LINUX=1
@@ -485,6 +501,13 @@ else ()
     message(STATUS "Bespoke: Using USB from ${LIBUSB_1_LIBRARY}")
 
     target_link_libraries(BespokeSynth PRIVATE ${LIBUSB_1_LIBRARY})
+
+    # Ant put resources with the exe
+    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+    add_custom_command(TARGET BespokeSynth
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/resource)
 
 endif ()
 


### PR DESCRIPTION
On Win/Lin:
- To make dev easier, the resource directory is copied next
  to the dev exe on win and lin, and the existing local
  relative resource directory scan works, avoiding all the
  ../../../ stuff being hardcoded to relative paths

On Mac:
- The 'resource' directory lives in the bundle and CMake copies
  them at build time
- Use CFBundle API to find our bindle and resolve the path
- This defacto means the mac app is fully senf contained and
  can be copied anywhere.

Closes #117

cml

rb