### PR TITLE
Open state files on app startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ juce_add_gui_app(BespokeSynth
         BLUETOOTH_PERMISSION_ENABLED    TRUE
         FILE_SHARING_ENABLED            TRUE
         DOCUMENT_BROWSER_ENABLED        TRUE
+        DOCUMENT_EXTENSIONS             .bsk
         )
 
 juce_generate_juce_header(BespokeSynth)

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -11,6 +11,7 @@
 #include <JuceHeader.h>
 
 Component* createMainContentComponent();
+void setInitialState(const String& statePath, Component* mainComponent);
 
 //==============================================================================
 class BespokeApplication  : public JUCEApplication
@@ -51,6 +52,11 @@ public:
       // When another instance of the app is launched while this one is running,
       // this method is invoked, and the commandLine parameter tells you what
       // the other instance's command-line arguments were.
+
+      // This is also called when opening the app with a file.
+      if(commandLine.isNotEmpty() && commandLine.endsWith(".bsk")) {
+        setInitialState(commandLine, mainWindow->getContentComponent());
+      }
    }
    
    //==============================================================================

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -321,6 +321,10 @@ public:
       nvgDeleteGLES2(mVG);
       nvgDeleteGLES2(mFontBoundsVG);
    }
+
+   void setInitialState(const String& statePath) {
+       mSynth.SetInitialState(statePath.toStdString());
+   }
    
    void render() override
    {
@@ -530,6 +534,15 @@ private:
 
 // (This function is called by the app startup code to create our main component)
 Component* createMainContentComponent()     { return new MainContentComponent(); }
+
+// This function is called when opening the app with a state file.
+void setInitialState(const String& statePath, Component* component) {
+    auto* mainComponent = dynamic_cast<MainContentComponent*>(component);
+    if(mainComponent == nullptr){
+        ofLog() << "Non main component sent to setInitialState";
+    }
+    mainComponent->setInitialState(statePath);
+}
 
 
 #endif  // MAINCOMPONENT_H_INCLUDED

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -343,7 +343,11 @@ void ModularSynth::Poll()
       
       if (!mInitialized && sFrameCount > 3) //let some frames render before blocking for a load
       {
-         LoadLayoutFromFile(ofToDataPath(defaultLayout));
+         if(!mInitialSaveStatePath.empty()) {
+             LoadState(mInitialSaveStatePath);
+         }else {
+            LoadLayoutFromFile(ofToDataPath(defaultLayout));
+         }
          mInitialized = true;
       }
 
@@ -2291,6 +2295,10 @@ void ModularSynth::SaveState(string file, bool autosave)
    mModuleContainer.SaveState(out);
    
    mAudioThreadMutex.Unlock();
+}
+
+void ModularSynth::SetInitialState(string file){
+    mInitialSaveStatePath = std::move(file);
 }
 
 void ModularSynth::LoadState(string file)

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1704,6 +1704,11 @@ void ModularSynth::TriggerClapboard()
    mLastClapboardTime = gTime; //for synchronizing internally recorded audio and externally recorded video
 }
 
+bool endsWith(std::string_view str, std::string_view suffix)
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
 void ModularSynth::FilesDropped(vector<string> files, int intX, int intY)
 {
    if (files.size() > 0)
@@ -1712,6 +1717,11 @@ void ModularSynth::FilesDropped(vector<string> files, int intX, int intY)
       float y = GetMouseY(&mModuleContainer, intY);
       IDrawableModule* target = GetModuleAtCursor();
 
+      if (files.size() == 1 && endsWith(files[0], ".bsk"))
+      {
+          LoadState(files[0]);
+          return;
+      }
       if (target != nullptr)
       {
          float moduleX, moduleY;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -199,6 +199,8 @@ public:
    void SaveOutput();
    void SaveState(string file, bool autosave);
    void LoadState(string file);
+   // Set a state file to be loaded when the synth is initialized.
+   void SetInitialState(string file);
    void SaveCurrentState();
    void SaveStatePopup();
    void LoadStatePopup();
@@ -294,6 +296,7 @@ private:
    string mLoadedLayoutPath;
    bool mWantReloadInitialLayout;
    string mCurrentSaveStatePath;
+   string mInitialSaveStatePath;
    double mLastSaveTime;
    
    Sample* mHeldSample;


### PR DESCRIPTION
This pull request allows to 

- Open state files on app startup
- Open state files by dragging into an existing 

Opening as a draft because there seems to be a bug with the "Reset Layout" button not doing anything when opening a file from startup, and because I've only tested on MacOS

Closes #209 