### PR TITLE
Fix subpixel rendering issue in quick spawn menu

### DIFF
--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -29,6 +29,7 @@
 #include "ModularSynth.h"
 #include "ModuleFactory.h"
 #include "TitleBar.h"
+#include <cmath>
 
 QuickSpawnMenu* TheQuickSpawnMenu = nullptr;
 
@@ -82,8 +83,8 @@ void QuickSpawnMenu::KeyPressed(int key, bool isRepeat)
          float maxX = ofGetWidth() / GetOwningContainer()->GetDrawScale() - mWidth- 5;
          float minY = TheTitleBar->GetRect().height + 5;
          float maxY = ofGetHeight() / GetOwningContainer()->GetDrawScale() - mHeight - 5;
-         SetPosition(ofClamp(TheSynth->GetMouseX(GetOwningContainer()) - mWidth / 2, minX, maxX),
-                     ofClamp(TheSynth->GetMouseY(GetOwningContainer()) - mHeight / 2, minY, maxY));
+         SetPosition(ofClamp(TheSynth->GetMouseX(GetOwningContainer()) - trunc(mWidth / 2), minX, maxX),
+                     ofClamp(TheSynth->GetMouseY(GetOwningContainer()) - trunc(mHeight / 2), minY, maxY));
          SetShowing(true);
       }
    }


### PR DESCRIPTION
When there are an odd number of items in the quick spawn menu, the height of the module ends up having a fractional half left over, resulting in a subpixel offset that makes the text render blurry on some displays. This PR fixes that issue by truncating the fractional part of the height and width of the quick spawn menu when it is first shown. The effect is shown below:

<p align="center">
  <img src="https://user-images.githubusercontent.com/21976313/134283571-49b8e617-379d-4081-bb77-5418e6d5b92b.png">
  <img src="https://user-images.githubusercontent.com/21976313/134283575-8e8ea66d-599c-460d-a986-923f02feabbd.png">
</p>