### PR TITLE
Make Linux Bespoke aware of CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif ()
 
 
-project(BespokeSynth VERSION 0.9.0 LANGUAGES C CXX ASM)
+project(BespokeSynth VERSION 1.0.1 LANGUAGES C CXX ASM)
 
 message(STATUS "Bespoke: Build Type: ${CMAKE_BUILD_TYPE}")
 
@@ -52,6 +52,10 @@ add_subdirectory(Source/freeverb)
 add_subdirectory(Source/json)
 add_subdirectory(Source/nanovg)
 add_subdirectory(Source/vinylcontrol)
+
+# Generate build time info for the cpp
+configure_file(${CMAKE_SOURCE_DIR}/Source/VersionInfo.cpp.in
+        ${CMAKE_BINARY_DIR}/geninclude/VersionInfo.cpp)
 
 set(BESPOKE_SOURCE_LIST
         Source/glew/Bespoke_glew.c
@@ -380,6 +384,8 @@ set(BESPOKE_SOURCE_LIST
         Source/UserData.cpp
         Source/VSTPlayhead.cpp
         Source/VSTWindow.cpp
+
+        ${CMAKE_BINARY_DIR}/geninclude/VersionInfo.cpp
         )
 
 juce_add_gui_app(BespokeSynth
@@ -395,6 +401,7 @@ juce_add_gui_app(BespokeSynth
 juce_generate_juce_header(BespokeSynth)
 target_sources(BespokeSynth PRIVATE ${BESPOKE_SOURCE_LIST})
 target_include_directories(BespokeSynth PRIVATE
+        Source
         Source/glew/include
         Source/push2
         Source/push2/libusb
@@ -511,6 +518,10 @@ else ()
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/resource)
+
+    # Finally provide install rules if folks want to install into CMAKE_INSTALL_PREFIX
+    install(TARGETS BespokeSynth DESTINATION bin)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/resource DESTINATION share/BespokeSynth)
 
 endif ()
 

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -10,6 +10,7 @@
 #include <JuceHeader.h>
 using namespace juce::gl;
 
+#include "VersionInfo.h"
 
 #include "nanovg/nanovg.h"
 #define NANOVG_GLES2_IMPLEMENTATION
@@ -44,6 +45,10 @@ public:
 #endif
    {
       ofLog() << "bespoke synth " << JUCEApplication::getInstance()->getApplicationVersion();
+
+#if BESPOKE_LINUX
+      ofLog() << "cmake install prefix '" << Bespoke::CMAKE_INSTALL_PREFIX << "'";
+#endif
       
       openGLContext.setOpenGLVersionRequired(juce::OpenGLContext::openGL3_2);
       openGLContext.setContinuousRepainting(false);

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -37,6 +37,7 @@
 
 #include <JuceHeader.h>
 using namespace juce::gl;
+#include <VersionInfo.h>
 
 //#include <chrono>
 #include <time.h>
@@ -126,14 +127,17 @@ string ofToResourcePath(string path, bool makeAbsolute)
 
 #elif JUCE_LINUX
       string localDataDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
-      string developmentDataDir = File::getCurrentWorkingDirectory().getChildFile("../../resource").getFullPathName().toStdString();   //OSX dir in dev environment
+      string cmakeDataDir = File(Bespoke::CMAKE_INSTALL_PREFIX).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString();
       string installedDataDir = File::getSpecialLocation(File::globalApplicationsDirectory).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString(); // /usr/share/BespokeSynth/resource
       if (juce::File(localDataDir).exists())
          sResourceDir = localDataDir;
-      else if (juce::File(developmentDataDir).exists())
-         sResourceDir = developmentDataDir;
+      else if (getenv("BESPOKE_DATA_DIR") && juce::File(getenv("BESPOKE_DATA_DIR")).exists())
+          sResourceDir = getenv("BESPOKE_DATA_DIR");
+      else if (juce::File(cmakeDataDir).exists())
+         sResourceDir = cmakeDataDir;
       else if (juce::File(installedDataDir).exists())
          sResourceDir = installedDataDir;
+      ofLog() << "Resources directory is '" << sResourceDir << "'";
    
 #elif BESPOKE_MAC
       auto bundle = CFBundleGetMainBundle();

--- a/Source/VersionInfo.cpp.in
+++ b/Source/VersionInfo.cpp.in
@@ -1,0 +1,8 @@
+#include "VersionInfo.h"
+
+// This file will get replaced with the CMAKE variables as below at build time
+namespace Bespoke
+{
+    const char* VERSION = "@CMAKE_PROJECT_VERSION@";
+    const char* CMAKE_INSTALL_PREFIX = "@CMAKE_INSTALL_PREFIX@";
+}

--- a/Source/VersionInfo.h
+++ b/Source/VersionInfo.h
@@ -1,0 +1,7 @@
+#include <string>
+
+namespace Bespoke
+{
+    extern const char* VERSION; // This will be the same string as Juce::Application::getApplicationVersion()
+    extern const char* CMAKE_INSTALL_PREFIX;
+}


### PR DESCRIPTION
This commit accomplishes three things

1. Sets up a rudimentary Cmake-to-CPP constant communication by having
   a VersionInfo file (but don't do the full surge thing of git versions
   and the like yet)
2. With that done, modify the linux resource location waterfall to be
   a. working directory / resoruce
   b. $ENV{BESPOKE_DATA_DIR}
   c. ${CMAKE_INSTALL_PREFIX}/resource
   d. /usr/share/BespokeSynth/resource
3. With that done, create a cmake install rule so a succesfull build
   and install on linux is now

```
cmake -Bignore/lin -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/what/ever/you/want
cmake --build ignore/lin --config Release
sudo cmake --install ignore/lin
```

and after that then `/what/ever/you/want/bin/BespokeSynth` will be installed and
load resources from `/what/ever/you/want/share/BespokeSynth/resources`

Tested on ubuntu 20.