### PR TITLE
Use a timeout instead of a margin for hover hysteresis

### DIFF
--- a/Source/IUIControl.cpp
+++ b/Source/IUIControl.cpp
@@ -86,6 +86,8 @@ void IUIControl::CheckHover(int x, int y)
    if (TheSynth->GetFrameCount() != sLastHoveredUIControlFrame && TestHover(x, y) && (gHoveredUIControl == nullptr || !gHoveredUIControl->IsMouseDown()))
    {
       gHoveredUIControl = this;
+      gHoveredUIControlIsHighlighted = true;
+      gHoveredUIControlFramesUntilExpiration = 0;
       sLastHoveredUIControl = this;
       sLastUIHoverWasSetViaTab = false;
       sLastHoveredUIControlFrame = TheSynth->GetFrameCount();
@@ -97,7 +99,7 @@ void IUIControl::DrawHover(float x, float y, float w, float h)
    if (Push2Control::sDrawingPush2Display)
       return;
    
-   if (gHoveredUIControl == this && IKeyboardFocusListener::GetActiveKeyboardFocus() == nullptr && TheSynth->GetGroupSelectedModules().empty())
+   if (gHoveredUIControl == this && gHoveredUIControlIsHighlighted && IKeyboardFocusListener::GetActiveKeyboardFocus() == nullptr && TheSynth->GetGroupSelectedModules().empty())
    {
       ofPushStyle();
       ofNoFill();

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -376,6 +376,12 @@ void ModularSynth::Poll()
       mScheduledEnvelopeEditorSpawnDisplay = nullptr;
    }
 
+   if (gHoveredUIControlFramesUntilExpiration > 0) {
+      gHoveredUIControlFramesUntilExpiration--;
+      if (gHoveredUIControlFramesUntilExpiration == 0)
+         gHoveredUIControl = nullptr;
+   }
+
    {
       static MouseCursor sCurrentCursor = MouseCursor::NormalCursor;
       MouseCursor desiredCursor;
@@ -1144,8 +1150,11 @@ void ModularSynth::MouseMoved(int intX, int intY )
          gHoveredUIControl->GetPosition(uiX, uiY);
          float w, h;
          gHoveredUIControl->GetDimensions(w, h);
-         if (x < uiX - 10 || y < uiY - 10 || x > uiX + w + 10 || y > uiY + h + 10)
-            gHoveredUIControl = nullptr;
+         if (x < uiX || y < uiY || x > uiX + w || y > uiY + h) {
+            gHoveredUIControlIsHighlighted = false;
+            if (gHoveredUIControlFramesUntilExpiration == 0)
+               gHoveredUIControlFramesUntilExpiration = 4;
+         }
       }
    }
    

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -67,6 +67,8 @@ float gWorkBuffer[kWorkBufferSize];
 ChannelBuffer gWorkChannelBuffer(kWorkBufferSize);
 IDrawableModule* gHoveredModule = nullptr;
 IUIControl* gHoveredUIControl = nullptr;
+bool gHoveredUIControlIsHighlighted = false;
+int gHoveredUIControlFramesUntilExpiration = 0;
 IUIControl* gHotBindUIControl[10];
 float gControlTactileFeedback = 0;
 float gDrawScale = 1;

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -109,6 +109,8 @@ extern float gWorkBuffer[kWorkBufferSize];  //scratch buffer for doing work in
 extern ChannelBuffer gWorkChannelBuffer;
 extern IDrawableModule* gHoveredModule;
 extern IUIControl* gHoveredUIControl;
+extern bool gHoveredUIControlIsHighlighted;
+extern int gHoveredUIControlFramesUntilExpiration;
 extern IUIControl* gHotBindUIControl[10];
 extern float gControlTactileFeedback;
 extern float gDrawScale;


### PR DESCRIPTION
There are two parts to this patch:

1. When a control (particularly a button) is highlighted, it creates the expectation that clicking will interact with that control.  Leaving the highlight active within a 10 pixel boundary does make things less visually jittery, but it defeats this fundamental UI expectation.  So this patch disables the highlight immediately when the mouse leaves the control's bounding box.

2. The visual highlight isn't the only effect of the hover state.  There's also a tooltip and some descriptive text that appears in the top left.  These effects don't need to be as precise as the visual highlight, and in fact, making them overly precise leads to distracting flashing in and out as you move your mouse over a dense arrangement of controls.  To avoid this flashing, keep the hover state active for a few frames after the mouse leaves the control.  Using a timeout rather than a margin avoids the confusing situation where you're hovering the mouse a few pixels outside of the control, and it's not highlighted, but the tooltip is staying around anyway.

Fixes issue #151.