### PR TITLE
Fix segfault when writing data to file

### DIFF
--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -170,12 +170,13 @@ bool Sample::Write(const char* path /*=nullptr*/)
 bool Sample::WriteDataToFile(const char *path, float **data, int numSamples, int channels)
 {
    ScopedPointer<WavAudioFormat> wavFormat = new WavAudioFormat();
-   File outputFile(ofToDataPath(path).c_str());
+   string dataPath = ofToDataPath(string(path));
+   File outputFile(dataPath.c_str());
    outputFile.create();
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);
    bool b1 {false};
-   ScopedPointer<AudioFormatWriter> writer = wavFormat->createWriterFor(outputTo.get(), gSampleRate, channels, 16, b1, 0);
+   ScopedPointer<AudioFormatWriter> writer = wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0);
    writer->writeFromFloatArrays(data, channels, numSamples);
    
    return true;

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -170,8 +170,7 @@ bool Sample::Write(const char* path /*=nullptr*/)
 bool Sample::WriteDataToFile(const char *path, float **data, int numSamples, int channels)
 {
    ScopedPointer<WavAudioFormat> wavFormat = new WavAudioFormat();
-   string dataPath = ofToDataPath(string(path));
-   File outputFile(dataPath.c_str());
+   File outputFile(ofToDataPath(path).c_str());
    outputFile.create();
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);


### PR DESCRIPTION
There are 2 fixes here:

1. a `char*` (`path`) was being passed into a function expecting a `std::string` (unsure why this wasn't a compiler error, who knows)
2. The raw pointer inside `outputTo` was being passed into `wavFormat->createWriterFor`. However, this actually takes ownership of the pointer & frees it at the end of the scope, leading to a double free when `outputTo` tries to free itself. I believe `.release()` stops the `unique_ptr` freeing itself, I'm no C++ guru though :p

