### PR TITLE
154 Enhancement: highlight a module when a cable will connect to it

### DIFF
--- a/Source/PatchCable.h
+++ b/Source/PatchCable.h
@@ -87,6 +87,7 @@ private:
    void SetTarget(IClickable* target);
    PatchCablePos GetPatchCablePos();
    ofVec2f FindClosestSide(int x, int y, int w, int h, ofVec2f start, ofVec2f startDirection, ofVec2f& endDirection);
+   IClickable* GetDropTarget();
    
    PatchCableSource* mOwner;
    IClickable* mTarget;


### PR DESCRIPTION
when a patch cable is held, and it's hovered over a valid target (module or control), show a highlight on that target to make it clear that a connection will happen when you release the mouse