### PR TITLE
Add selection features to TextEntry + Small CodeEntry fix

### DIFF
--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -849,7 +849,9 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       }
       else
       {
-         if (mCaretPosition > 0)
+         if (!(GetKeyModifiers() & kModifier_Shift) && mCaretPosition != mCaretPosition2) 
+            MoveCaret(MIN(mCaretPosition, mCaretPosition2));
+         else if (mCaretPosition > 0)
             MoveCaret(mCaretPosition - 1);
       }
    }
@@ -865,7 +867,9 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       }
       else
       {
-         if (mCaretPosition < mString.length())
+         if (!(GetKeyModifiers() & kModifier_Shift) && mCaretPosition != mCaretPosition2) 
+            MoveCaret(MAX(mCaretPosition, mCaretPosition2));
+         else if (mCaretPosition < mString.length())
             MoveCaret(mCaretPosition + 1);
       }
    }

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -323,6 +323,7 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
          for (int i=mCaretPosition-1; i<len; ++i)
             mString[i] = mString[i + 1];
          --mCaretPosition;
+         --mCaretPosition2;
       }
    }
    else if (key == KeyPress::deleteKey)
@@ -447,6 +448,8 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
    }
    else if (key < CHAR_MAX && juce::CharacterFunctions::isPrintable((char)key))
    {
+      if (mCaretPosition != mCaretPosition2)
+          RemoveSelectedText();
       AddCharacter((char)key);
    }
 }
@@ -461,7 +464,9 @@ void TextEntry::AddCharacter(char c)
          for (int i=len; i>mCaretPosition; --i)
             mString[i] = mString[i-1];
          mString[mCaretPosition] = c;
+         mString[len + 1] = '\0';
          ++mCaretPosition;
+         ++mCaretPosition2;
       }
    }
 }

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -76,7 +76,7 @@ public:
    void Delete() override;
    
    void MakeActiveTextEntry(bool setCaretToEnd);
-   
+   void RemoveSelectedText();
    void SetNextTextEntry(TextEntry* entry);
    void UpdateDisplayString();
    void SetInErrorMode(bool error) { mInErrorMode = error; }
@@ -108,7 +108,7 @@ private:
    bool AllowCharacter(char c);
    void AcceptEntry(bool pressedEnter) override;
    void CancelEntry() override;
-   
+   void MoveCaret(int pos, bool allowSelection = true);
    void OnClicked(int x, int y, bool right) override;
    bool MouseMoved(float x, float y) override;
    
@@ -124,6 +124,7 @@ private:
    float mFloatMin;
    float mFloatMax;
    int mCaretPosition;
+   int mCaretPosition2;
    float mCaretBlinkTimer;
    bool mCaretBlink;
    TextEntryType mType;


### PR DESCRIPTION
Mostly a copy of CodeEntry selection related code to TextEntry, including main shortcuts support. 
This PR also fixes the caret position when it is moved out of selection (it should be at the beginning or end of the selection depending on which key was pressed). 

Solves #246 .

This is my first PR here and it's been a long time since I haven't worked on a C++ project, so tell me if anything is wrong/missing in my submission and I will fix it. 