### PR TITLE
Replace usages of deprecated juce::ScopedPointer with std::unique_ptr

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <JuceHeader.h>
+#include <memory>
 
 Component* createMainContentComponent();
 
@@ -28,14 +29,13 @@ public:
    {
       // This method is where you should put your application's initialisation code..
       
-      mainWindow = new MainWindow ("bespoke synth");
+      mainWindow = std::make_unique<MainWindow>("bespoke synth");
    }
    
    void shutdown() override
    {
       // Add your application's shutdown code here..
-      
-      mainWindow = nullptr; // (deletes our window)
+      mainWindow.reset();
    }
    
    //==============================================================================
@@ -93,7 +93,7 @@ public:
    };
    
 private:
-   ScopedPointer<MainWindow> mainWindow;
+   std::unique_ptr<MainWindow> mainWindow;
 };
 
 //==============================================================================

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -28,6 +28,7 @@
 #include "FileStream.h"
 #include "ModularSynth.h"
 #include "ChannelBuffer.h"
+#include <memory>
 
 Sample::Sample()
 : mData(0)
@@ -169,15 +170,16 @@ bool Sample::Write(const char* path /*=nullptr*/)
 //static
 bool Sample::WriteDataToFile(const char *path, float **data, int numSamples, int channels)
 {
-   ScopedPointer<WavAudioFormat> wavFormat = new WavAudioFormat();
+   auto wavFormat = std::make_unique<WavAudioFormat>();
    File outputFile(ofToDataPath(path).c_str());
    outputFile.create();
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);
-   bool b1 {false};
-   ScopedPointer<AudioFormatWriter> writer = wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0);
+   bool b1{false};
+   auto writer = std::unique_ptr<AudioFormatWriter>(
+       wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0));
    writer->writeFromFloatArrays(data, channels, numSamples);
-   
+
    return true;
 }
 

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -205,8 +205,7 @@ void VSTPlugin::Exit()
    IDrawableModule::Exit();
    if (mWindow)
    {
-      VSTWindow* window = mWindow.release();
-      delete window;
+      mWindow.reset();
    }
 }
 
@@ -797,7 +796,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
       if (mPlugin != nullptr)
       {
          if (mWindow == nullptr)
-            mWindow = VSTWindow::CreateWindow(this, VSTWindow::Normal);
+            mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateWindow(this, VSTWindow::Normal));
          mWindow->toFront (true);
       }
       

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -120,7 +120,7 @@ private:
    bool mPluginReady;
    std::unique_ptr<AudioProcessor> mPlugin;
    string mPluginName;
-   juce::ScopedPointer<VSTWindow> mWindow;
+   std::unique_ptr<VSTWindow> mWindow;
    juce::MidiBuffer mMidiBuffer;
    juce::MidiBuffer mFutureMidiBuffer;
    juce::CriticalSection mMidiInputLock;


### PR DESCRIPTION
As discussed in #245, all usages of the deprecated `juce::ScopedPointer` have been replaced with `std::unique_ptr`. Thanks! :)