### PR TITLE
Expanded Linux Install Rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,8 +570,13 @@ else ()
             COMMAND ${CMAKE_COMMAND} -E  copy_directory resource ${OUTDIR}/resource)
 
     # Finally provide install rules if folks want to install into CMAKE_INSTALL_PREFIX
+    configure_file(${CMAKE_SOURCE_DIR}/scripts/installer_linux/BespokeSynth.desktop.in
+            ${CMAKE_BINARY_DIR}/BespokeSynth.desktop)
+
     install(TARGETS BespokeSynth DESTINATION bin)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/resource DESTINATION share/BespokeSynth)
+    install(FILES ${CMAKE_BINARY_DIR}/BespokeSynth.desktop DESTINATION share/applications)
+    install(FILES ${CMAKE_SOURCE_DIR}/bespoke_icon.png DESTINATION share/icons/hicolor/512x512/apps)
 
 endif ()
 

--- a/scripts/installer_linux/BespokeSynth.desktop.in
+++ b/scripts/installer_linux/BespokeSynth.desktop.in
@@ -2,7 +2,7 @@
 Name=BespokeSynth
 GenericName=Software modular synth
 Comment=Software modular synth with controllers support, scripting and VST
-Exec=/usr/bin/BespokeSynth
+Exec=@CMAKE_INSTALL_PREFIX@/bin/BespokeSynth
 Icon=bespoke_icon
 Categories=AudioVideo;Audio;Music;Midi
 Terminal=false


### PR DESCRIPTION
Linux install rules which (1) configure the .desktop file with
CMAKE_INSTALL_PREFIX and (2) install the icon