### PR TITLE
Input Bus Disablement also

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -335,6 +335,9 @@ void VSTPlugin::LoadVST(juce::PluginDescription desc)
       for (int busIndex = 1; busIndex < layouts.outputBuses.size(); ++busIndex)
           layouts.outputBuses.getReference(busIndex) = AudioChannelSet::disabled();
 
+      for (int busIndex = 1; busIndex < layouts.inputBuses.size(); ++busIndex)
+          layouts.inputBuses.getReference(busIndex) = AudioChannelSet::disabled();
+
       mPlugin->setBusesLayout(layouts);
 
       mPlugin->prepareToPlay(gSampleRate, gBufferSize);


### PR DESCRIPTION
The VST3 Input Bus > 1 also needs disabling. This impacts
some multi-in FX, most notably from my testing the Surge FX
Bank, meaning that it thinks it has a sidechain and it passes
that through as a dry signal improperly.

So disable the aux inputs until we can properly route to them,
just like i did with the outputs.

Also addresses #277