### PR TITLE
Drop JuceHeader.h, include JUCE modules directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ project(BespokeSynth VERSION 1.0.1 LANGUAGES C CXX ASM)
 
 message(STATUS "Bespoke: Build Type: ${CMAKE_BUILD_TYPE}")
 
+# Global compile options
+add_compile_options(
+    # Build with Multiple Processes on Visual Studio
+    $<$<CXX_COMPILER_ID:MSVC>:/MP>
+    # Set source and executable charsets to UTF-8. Required for building on CJK Windows.
+    $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
+    )
+
 if(BESPOKE_PYTHON_ROOT)
     set(Python_ROOT "${BESPOKE_PYTHON_ROOT}")
     message( STATUS "Bespoke: Overriding Python_ROOT to ${Python_ROOT}")
@@ -404,7 +412,6 @@ juce_add_gui_app(BespokeSynth
         DOCUMENT_BROWSER_ENABLED        TRUE
         )
 
-juce_generate_juce_header(BespokeSynth)
 target_sources(BespokeSynth PRIVATE ${BESPOKE_SOURCE_LIST})
 target_include_directories(BespokeSynth PRIVATE
         Source

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -297,7 +297,7 @@ void BeatBloks::FilesDropped(vector<string> files, int x, int y)
    string cachedFilename = tokens[tokens.size()-1].c_str();
    tokens = ofSplitString(cachedFilename, ".");
    cachedFilename = tokens[0]+".cached";
-   bool hasCached = File(ofToDataPath(cachedFilename)).existsAsFile();
+   bool hasCached = juce::File(ofToDataPath(cachedFilename)).existsAsFile();
    
    ofLog() << cachedFilename << " exists: " << (hasCached ? "true" : "false");
    

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -603,8 +603,9 @@ void Canvas::SetRowColor(int row, ofColor color)
       mRowColors[row] = color;
 }
 
-MouseCursor Canvas::GetMouseCursorType()
+juce::MouseCursor Canvas::GetMouseCursorType()
 {
+   using juce::MouseCursor;
    if (GetKeyModifiers() & kModifier_Shift)
       return MouseCursor::CopyingCursor;
    if (GetKeyModifiers() & kModifier_Alt)

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -30,6 +30,8 @@
 #include "IUIControl.h"
 #include "CanvasElement.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 #define MAX_CANVAS_MASK_ELEMENTS 128
 
 class Canvas;
@@ -116,7 +118,7 @@ public:
    DragMode GetDragMode() const { return mDragMode; }
    bool IsRowVisible(int row) const;
    void SetRowColor(int row, ofColor color);
-   MouseCursor GetMouseCursorType();
+   juce::MouseCursor GetMouseCursorType();
    ofVec2f RescaleForZoom(float x, float y) const;
    
    //IUIControl

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -786,7 +786,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
             UpdateString(mString.substr(0, mCaretPosition));
       }
    }
-   else if (key == KeyPress::deleteKey)
+   else if (key == juce::KeyPress::deleteKey)
    {
       if (mCaretPosition != mCaretPosition2)
       {
@@ -978,11 +978,11 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       mCaretPosition = 0;
       mCaretPosition2 = (int)mString.size();
    }
-   else if (key == KeyPress::endKey)
+   else if (key == juce::KeyPress::endKey)
    {
       MoveCaretToEnd();
    }
-   else if (key == KeyPress::homeKey)
+   else if (key == juce::KeyPress::homeKey)
    {
       MoveCaretToStart();
    }

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -34,6 +34,8 @@
 #include "UIControlMacros.h"
 #include "SamplePlayer.h"
 
+using namespace juce;
+
 DrumPlayer::DrumPlayer()
 : mSpeed(1)
 , mSpeedRandomization(0)

--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -28,7 +28,7 @@
 #include "SynthGlobals.h"
 
 FileStreamOut::FileStreamOut(const char* file)
-: mStream(File(file))
+: mStream(juce::File(file))
 {
    mStream.setPosition(0);
    mStream.truncate();
@@ -40,7 +40,7 @@ FileStreamOut::~FileStreamOut()
 }
 
 FileStreamIn::FileStreamIn(const char* file)
-: mStream(File(file))
+: mStream(juce::File(file))
 {
 }
 

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -26,8 +26,9 @@
 #ifndef __Bespoke__FileStream__
 #define __Bespoke__FileStream__
 
-#include <JuceHeader.h>
 #include "OpenFrameworksPort.h"
+
+#include "juce_core/juce_core.h"
 
 class FileStreamOut
 {
@@ -44,7 +45,7 @@ public:
    void Write(const float* buffer, int size);
    void WriteGeneric(const void* buffer, int size);
 private:
-   FileOutputStream mStream;
+   juce::FileOutputStream mStream;
 };
 
 class FileStreamIn
@@ -66,7 +67,7 @@ public:
    
    bool Eof();
 private:
-   FileInputStream mStream;
+   juce::FileInputStream mStream;
 };
 
 #endif /* defined(__Bespoke__FileStream__) */

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -403,7 +403,7 @@ void FubbleModule::MouseReleased()
       if (mQuantizeLength)
       {
          float quantizeResolution = TheTransport->GetMeasureFraction(mQuantizeInterval);
-         int quantizeIntervalSteps = roundToInt(mLength/quantizeResolution);
+         int quantizeIntervalSteps = juce::roundToInt(mLength/quantizeResolution);
          if (quantizeIntervalSteps <= 0)
             quantizeIntervalSteps = 1;
          float quantizedLength = quantizeResolution * quantizeIntervalSteps;

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -30,6 +30,9 @@
 #include "TitleBar.h"
 #include "EffectChain.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+#include "juce_opengl/juce_opengl.h"
+
 bool HelpDisplay::sShowTooltips = false;
 bool HelpDisplay::sTooltipsLoaded = false;
 list<HelpDisplay::ModuleTooltipInfo> HelpDisplay::sTooltips;
@@ -67,7 +70,7 @@ HelpDisplay::~HelpDisplay()
 
 void HelpDisplay::LoadHelp()
 {
-   File file(ofToResourcePath("help.txt").c_str());
+   juce::File file(ofToResourcePath("help.txt").c_str());
    if (file.existsAsFile())
    {
       string help = file.loadFileAsString().toStdString();
@@ -84,7 +87,7 @@ void HelpDisplay::DrawModule()
    ofRect(0,0,mWidth,mHeight);
    ofPopStyle();
 
-   DrawTextLeftJustify(JUCEApplication::getInstance()->getApplicationVersion().toStdString() + " (" + string(__DATE__) + " " + string(__TIME__) + ")", mWidth-5, 12);
+   DrawTextLeftJustify(juce::JUCEApplication::getInstance()->getApplicationVersion().toStdString() + " (" + string(__DATE__) + " " + string(__TIME__) + ")", mWidth-5, 12);
    
    mShowTooltipsCheckbox->Draw();
    mDumpModuleInfoButton->SetShowing(GetKeyModifiers() == kModifier_Shift);
@@ -184,7 +187,7 @@ void HelpDisplay::LoadTooltips()
    ModuleTooltipInfo moduleInfo;
    UIControlTooltipInfo controlInfo;
 
-   File tooltipsFile(tooltipsPath);
+   juce::File tooltipsFile(tooltipsPath);
    if (tooltipsFile.existsAsFile())
    {
       juce::StringArray lines;
@@ -267,9 +270,9 @@ namespace
       for (int i = 1; i <= n; i++) {
          for (int j = 1; j <= m; j++) {
             // Two cases if we see a '*'
-            // a) We ignore ‘*’ character and move
+            // a) We ignore â€˜*â€™ character and move
             //    to next  character in the pattern,
-            //     i.e., ‘*’ indicates an empty sequence.
+            //     i.e., â€˜*â€™ indicates an empty sequence.
             // b) '*' character matches with ith
             //     character in input
             if (pattern[j - 1] == '*')
@@ -366,15 +369,15 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
 {
    if (button == mTutorialVideoLinkButton)
    {
-      URL("https://youtu.be/SYBc8X2IxqM").launchInDefaultBrowser();
+      juce::URL("https://youtu.be/SYBc8X2IxqM").launchInDefaultBrowser();
    }
    if (button == mDocsLinkButton)
    {
-      URL("http://bespokesynth.com/docs").launchInDefaultBrowser();
+      juce::URL("http://bespokesynth.com/docs").launchInDefaultBrowser();
    }
    if (button == mDiscordLinkButton)
    {
-      URL("https://discord.gg/YdTMkvvpZZ").launchInDefaultBrowser();
+      juce::URL("https://discord.gg/YdTMkvvpZZ").launchInDefaultBrowser();
    }
    if (button == mDumpModuleInfoButton)
    {
@@ -459,7 +462,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
          }
       }
 
-      File moduleDump(ofToDataPath("module_dump.txt"));
+      juce::File moduleDump(ofToDataPath("module_dump.txt"));
       moduleDump.replaceWithText(output);
    }
    if (button == mDoModuleScreenshotsButton)
@@ -580,7 +583,7 @@ void HelpDisplay::RenderScreenshot(int x, int y, int width, int height, string f
    juce::gl::glReadPixels(x, ofGetHeight()*scale-y-height, width, height, juce::gl::GL_RGB, juce::gl::GL_UNSIGNED_BYTE, pixels);
    juce::gl::glPixelStorei(juce::gl::GL_PACK_ALIGNMENT, oldAlignment);
 
-   Image image(Image::RGB, width, height, true);
+   juce::Image image(juce::Image::RGB, width, height, true);
    for (int x = 0; x < width; ++x)
    {
       for (int y = 0; y < height; ++y)
@@ -595,8 +598,8 @@ void HelpDisplay::RenderScreenshot(int x, int y, int width, int height, string f
       juce::File pngFile(ofToDataPath("screenshots/"+filename));
       if (pngFile.existsAsFile())
          pngFile.deleteFile();
-      FileOutputStream stream(pngFile);
-      PNGImageFormat pngWriter;
+      juce::FileOutputStream stream(pngFile);
+      juce::PNGImageFormat pngWriter;
       pngWriter.writeImageToStream(image, stream);
    }
 

--- a/Source/INoteReceiver.h
+++ b/Source/INoteReceiver.h
@@ -29,6 +29,10 @@
 #include "OpenFrameworksPort.h"
 #include "ModulationChain.h"
 
+namespace juce {
+   class MidiMessage;
+}
+
 class INoteReceiver
 {
 public:
@@ -36,7 +40,7 @@ public:
    virtual void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) = 0;
    virtual void SendPressure(int pitch, int pressure) {}
    virtual void SendCC(int control, int value, int voiceIdx = -1) = 0;
-   virtual void SendMidi(const MidiMessage& message) { }
+   virtual void SendMidi(const juce::MidiMessage& message) { }
 };
 
 struct NoteInputElement

--- a/Source/INoteSource.cpp
+++ b/Source/INoteSource.cpp
@@ -79,7 +79,7 @@ void NoteOutput::SendCC(int control, int value, int voiceIdx)
       noteReceiver->SendCC(control, value, voiceIdx);
 }
 
-void NoteOutput::SendMidi(const MidiMessage& message)
+void NoteOutput::SendMidi(const juce::MidiMessage& message)
 {
    for (auto noteReceiver : mNoteSource->GetPatchCableSource()->GetNoteReceivers())
       noteReceiver->SendMidi(message);

--- a/Source/INoteSource.h
+++ b/Source/INoteSource.h
@@ -47,7 +47,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendPressure(int pitch, int pressure) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
-   void SendMidi(const MidiMessage& message) override;
+   void SendMidi(const juce::MidiMessage& message) override;
    
    void PlayNoteInternal(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
 

--- a/Source/KompleteKontrol.cpp
+++ b/Source/KompleteKontrol.cpp
@@ -95,8 +95,8 @@ void KompleteKontrol::Poll()
          {
             mTextBoxes[i].slider = true;
             mTextBoxes[i].amount = uicontrol->GetMidiValue();
-            mTextBoxes[i].line1 = String(uicontrol->Name()).toUpperCase().toStdString();
-            mTextBoxes[i].line2 = String(uicontrol->GetDisplayValue(uicontrol->GetValue())).toUpperCase().toStdString();
+            mTextBoxes[i].line1 = juce::String(uicontrol->Name()).toUpperCase().toStdString();
+            mTextBoxes[i].line2 = juce::String(uicontrol->GetDisplayValue(uicontrol->GetValue())).toUpperCase().toStdString();
             if (mTextBoxes[i].line2.length() > 0 && mTextBoxes[i].line2[0] == '.')
                mTextBoxes[i].line2 = " "+mTextBoxes[i].line2; //can't have a period as the first character, so add a space
          }

--- a/Source/LocationZoomer.cpp
+++ b/Source/LocationZoomer.cpp
@@ -67,7 +67,7 @@ void LocationZoomer::Update()
 
 void LocationZoomer::OnKeyPressed(char key)
 {
-   if (key < CHAR_MAX && CharacterFunctions::isDigit((char)key) && key != '0') //0 is reserved
+   if (key < CHAR_MAX && juce::CharacterFunctions::isDigit((char)key) && key != '0') //0 is reserved
    {
       if (GetKeyModifiers() == kModifier_Control)
          WriteCurrentLocation(key);

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -8,8 +8,12 @@
  ==============================================================================
  */
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 #include <memory>
+
+#include "VersionInfo.h"
+
+using namespace juce;
 
 Component* createMainContentComponent();
 
@@ -20,8 +24,8 @@ public:
    //==============================================================================
    BespokeApplication() {}
    
-   const String getApplicationName() override       { return ProjectInfo::projectName; }
-   const String getApplicationVersion() override    { return ProjectInfo::versionString; }
+   const String getApplicationName() override       { return Bespoke::APP_NAME; }
+   const String getApplicationVersion() override    { return Bespoke::VERSION; }
    bool moreThanOneInstanceAllowed() override       { return true; }
    
    //==============================================================================

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -7,8 +7,11 @@
 //#include <GL/glew.h>
 #endif
 
-#include <JuceHeader.h>
+#include "juce_audio_devices/juce_audio_devices.h"
+#include "juce_audio_formats/juce_audio_formats.h"
+#include "juce_opengl/juce_opengl.h"
 using namespace juce::gl;
+using namespace juce;
 
 #include "VersionInfo.h"
 

--- a/Source/MidiCapturer.cpp
+++ b/Source/MidiCapturer.cpp
@@ -35,7 +35,7 @@ MidiCapturerDummyController::MidiCapturerDummyController(MidiDeviceListener* lis
    dynamic_cast<MidiCapturer*>(TheSynth->FindModule("midicapturer"))->AddDummyController(this);
 }
 
-void MidiCapturerDummyController::SendMidi(const MidiMessage& message)
+void MidiCapturerDummyController::SendMidi(const juce::MidiMessage& message)
 {
    MidiDevice::SendMidiMessage(mListener, "midicapturer", message);
 }
@@ -101,10 +101,10 @@ void MidiCapturer::AddDummyController(MidiCapturerDummyController* controller)
    mDummyControllers.push_back(controller);
 }
 
-void MidiCapturer::SendMidi(const MidiMessage& message)
+void MidiCapturer::SendMidi(const juce::MidiMessage& message)
 {
    //ofLog() << message.getDescription();
-   MidiMessage copy = message;
+   auto copy = message;
    copy.setTimeStamp(TheTransport->GetMeasureTime(gTime));
    mMessages[mRingBufferPos] = copy;
    mRingBufferPos = (mRingBufferPos + 1) % kRingBufferLength;

--- a/Source/MidiCapturer.h
+++ b/Source/MidiCapturer.h
@@ -42,7 +42,7 @@ public:
    
    void SendValue(int page, int control, float value, bool forceNoteOn = false, int channel = -1) override {}
    
-   void SendMidi(const MidiMessage& message);
+   void SendMidi(const juce::MidiMessage& message);
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
@@ -68,7 +68,7 @@ public:
    
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
-   void SendMidi(const MidiMessage& message) override;
+   void SendMidi(const juce::MidiMessage& message) override;
    
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
@@ -81,7 +81,7 @@ private:
    
    static const int kRingBufferLength = 1000;
    int mRingBufferPos;
-   MidiMessage mMessages[kRingBufferLength];
+   juce::MidiMessage mMessages[kRingBufferLength];
    list<MidiCapturerDummyController*> mDummyControllers;
    int mPlayhead;
 };

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -39,6 +39,8 @@
 #include "ScriptModule.h"
 #include "Push2Control.h"
 
+using namespace juce;
+
 bool UIControlConnection::sDrawCables = true;
 
 namespace

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -310,7 +310,7 @@ public:
    void OnMidiPressure(MidiPressure& pressure) override;
    void OnMidiProgramChange(MidiProgramChange& program) override;
    void OnMidiPitchBend(MidiPitchBend& pitchBend) override;
-   void OnMidi(const MidiMessage& message) override;
+   void OnMidi(const juce::MidiMessage& message) override;
    
    void OnTransportAdvanced(float amount) override;
 

--- a/Source/MidiDevice.cpp
+++ b/Source/MidiDevice.cpp
@@ -29,6 +29,8 @@
 
 #include <string.h>
 
+using namespace juce;
+
 MidiDevice::MidiDevice(MidiDeviceListener* listener)
    : mListener(listener)
    , mMidiOut(nullptr)
@@ -39,7 +41,7 @@ MidiDevice::MidiDevice(MidiDeviceListener* listener)
 
 MidiDevice::~MidiDevice()
 {
-   AudioDeviceManager& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
    deviceManager.removeMidiInputCallback(mDeviceNameIn, this);
    if (mMidiOut.get())
       mMidiOut->stopBackgroundThread();
@@ -51,11 +53,11 @@ bool MidiDevice::ConnectInput(const char* name)
    
    mDeviceNameIn = name;
    
-   AudioDeviceManager& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
    deviceManager.setMidiInputEnabled(mDeviceNameIn, true);
    deviceManager.addMidiInputCallback(mDeviceNameIn, this);
    
-   mIsInputEnabled = TheSynth->GetGlobalManagers()->mDeviceManager.isMidiInputEnabled(mDeviceNameIn);
+   mIsInputEnabled = deviceManager.isMidiInputEnabled(mDeviceNameIn);
    
    TheSynth->AddMidiDevice(this);   //TODO(Ryan) need better place for this, but constructor is too early
    
@@ -103,7 +105,7 @@ void MidiDevice::ConnectOutput(int index, int channel /*= 1*/)
 
 void MidiDevice::DisconnectInput()
 {
-   AudioDeviceManager& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
    deviceManager.setMidiInputEnabled(mDeviceNameIn, false);
    deviceManager.removeMidiInputCallback(mDeviceNameIn, this);
 }

--- a/Source/MidiDevice.h
+++ b/Source/MidiDevice.h
@@ -29,6 +29,8 @@
 #include "OpenFrameworksPort.h"
 #include "ModularSynth.h"
 
+#include "juce_audio_devices/juce_audio_devices.h"
+
 struct MidiNote
 {
    const char* mDeviceName;
@@ -78,10 +80,10 @@ public:
    virtual void OnMidiProgramChange(MidiProgramChange& program) {}
    virtual void OnMidiPitchBend(MidiPitchBend& pitchBend) {}
    virtual void OnMidiPressure(MidiPressure& pressure) {}
-   virtual void OnMidi(const MidiMessage& message) {}
+   virtual void OnMidi(const juce::MidiMessage& message) {}
 };
 
-class MidiDevice : public MidiInputCallback
+class MidiDevice : public juce::MidiInputCallback
 {
 public:
    MidiDevice(MidiDeviceListener* listener);
@@ -107,15 +109,15 @@ public:
    void SendPitchBend(int bend, int channel = -1);
    void SendData(unsigned char a, unsigned char b, unsigned char c);
    
-   static void SendMidiMessage(MidiDeviceListener* listener, const char* deviceName, const MidiMessage& message);
+   static void SendMidiMessage(MidiDeviceListener* listener, const char* deviceName, const juce::MidiMessage& message);
    
 private:
-   void handleIncomingMidiMessage(MidiInput* source, const MidiMessage& message) override;
+   void handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message) override;
    
    juce::String mDeviceNameIn;
    juce::String mDeviceNameOut;
    
-   unique_ptr<MidiOutput> mMidiOut;
+   unique_ptr<juce::MidiOutput> mMidiOut;
    MidiDeviceListener* mListener;
    int mOutputChannel;
    bool mIsInputEnabled;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -23,7 +23,6 @@
 #include "FileStream.h"
 #include "PatchCable.h"
 #include "ADSRDisplay.h"
-#include <JuceHeader.h>
 #include "QuickSpawnMenu.h"
 #include "AudioToCV.h"
 #include "ScriptModule.h"
@@ -54,6 +53,8 @@ float ModularSynth::sBackgroundLissajousB = 0.418f;
 #if BESPOKE_WINDOWS
 LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo);
 #endif
+
+using namespace juce;
 
 void AtExit()
 {

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -1,8 +1,6 @@
 #ifndef _MODULAR_SYNTH
 #define _MODULAR_SYNTH
 
-#include <JuceHeader.h>
-
 #undef LoadString //undo some junk from a windows define
 
 #include "SynthGlobals.h"
@@ -19,6 +17,11 @@
 #ifdef BESPOKE_LINUX
 #include <climits>
 #endif
+
+namespace juce {
+   class Component;
+   class OpenGLContext;
+}
 
 class IAudioSource;
 class IAudioReceiver;
@@ -177,7 +180,7 @@ public:
    void LockRender(bool lock) { if (lock) { mRenderLock.enter(); } else { mRenderLock.exit(); } }
    void UpdateFrameRate(float fps) { mFrameRate = fps; }
    float GetFrameRate() const { return mFrameRate; }
-   CriticalSection* GetRenderLock() { return &mRenderLock; }
+   juce::CriticalSection* GetRenderLock() { return &mRenderLock; }
    NamedMutex* GetAudioMutex() { return &mAudioThreadMutex; }
    
    IDrawableModule* CreateModule(const ofxJSONElement& moduleInfo);
@@ -211,8 +214,8 @@ public:
    ofxJSONElement GetUserPrefs() { return mUserPrefs; }
    UserPrefsEditor* GetUserPrefsEditor() { return mUserPrefsEditor; }
 
-   const String& GetTextFromClipboard() const;
-   void CopyTextToClipboard(const String& text);
+   const juce::String& GetTextFromClipboard() const;
+   void CopyTextToClipboard(const juce::String& text);
    
    void SetFatalError(string error);
 
@@ -336,7 +339,7 @@ private:
    juce::Component* mMainComponent;
    juce::OpenGLContext* mOpenGLContext;
    
-   CriticalSection mRenderLock;
+   juce::CriticalSection mRenderLock;
    float mFrameRate;
    long mFrameCount;
    
@@ -361,7 +364,7 @@ private:
    vector<float*> mInputBuffers;
    vector<float*> mOutputBuffers;
 
-   String mClipboard;
+   juce::String mClipboard;
 };
 
 extern ModularSynth* TheSynth;

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -657,7 +657,7 @@ void ModuleContainer::LoadState(FileStreamIn& in)
          
          //read through the rest of the module until we find the spacer, so we can continue loading the next module
          int separatorProgress = 0;
-         uint64 safetyCheck = 0;
+         juce::uint64 safetyCheck = 0;
          while (!in.Eof() && safetyCheck < 1000000)
          {
             char val;

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -577,6 +577,7 @@ bool ModuleFactory::IsExperimental(string typeName)
 //static
 void ModuleFactory::GetPrefabs(vector<string>& prefabs)
 {
+   using namespace juce;
    File dir(ofToDataPath("prefabs"));
    Array<File> files;
    dir.findChildFiles(files, File::findFiles, false);

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -73,7 +73,7 @@ void Monome::ListMonomes()
    
    mJustRequestedDeviceList = true;
    
-   OSCMessage listMsg("/serialosc/list");
+   juce::OSCMessage listMsg("/serialosc/list");
    listMsg.addString("localhost");
    listMsg.addInt32(mMonomeReceivePort);
    bool written = mToSerialOsc.send(listMsg);
@@ -123,7 +123,7 @@ void Monome::Poll()
       
       if (mLights[index].mLastUpdatedTime > mLights[index].mLastSentTime)
       {
-         OSCMessage lightMsg("/"+mPrefix+"/grid/led/level/set");
+         juce::OSCMessage lightMsg("/"+mPrefix+"/grid/led/level/set");
          lightMsg.addInt32(index % mMaxColumns);
          lightMsg.addInt32(index / mMaxColumns);
          lightMsg.addInt32(mLights[index].mValue*16);
@@ -197,22 +197,22 @@ void Monome::ConnectToDevice(string deviceDesc)
    mToMonome.connect(HOST, device->port);
    mHasMonome = true;
    
-   OSCMessage setPortMsg("/sys/port");
+   juce::OSCMessage setPortMsg("/sys/port");
    setPortMsg.addInt32(mMonomeReceivePort);
    bool written = mToMonome.send(setPortMsg);
    assert(written);
    
-   OSCMessage setHostMsg("/sys/host");
+   juce::OSCMessage setHostMsg("/sys/host");
    setHostMsg.addString(HOST);
    written = mToMonome.send(setHostMsg);
    assert(written);
    
-   OSCMessage setPrefixMsg("/sys/prefix");
+   juce::OSCMessage setPrefixMsg("/sys/prefix");
    setPrefixMsg.addString(mPrefix);
    written = mToMonome.send(setPrefixMsg);
    assert(written);
    
-   OSCMessage sysInfoMsg("/sys/info");
+   juce::OSCMessage sysInfoMsg("/sys/info");
    written = mToMonome.send(sysInfoMsg);
    assert(written);
    
@@ -229,9 +229,9 @@ bool Monome::Reconnect()
    return mHasMonome;
 }
 
-void Monome::oscMessageReceived(const OSCMessage& msg)
+void Monome::oscMessageReceived(const juce::OSCMessage& msg)
 {
-   String label = msg.getAddressPattern().toString();
+   juce::String label = msg.getAddressPattern().toString();
    
    if (label == "/serialosc/device")
    {

--- a/Source/Monome.h
+++ b/Source/Monome.h
@@ -26,11 +26,12 @@
 #ifndef __modularSynth__Monome__
 #define __modularSynth__Monome__
 
-#include <JuceHeader.h>
 #include "OpenFrameworksPort.h"
 #include "MidiDevice.h"
 #include "INonstandardController.h"
 #include "Oscillator.h"
+
+#include "juce_osc/juce_osc.h"
 
 #define HOST "127.0.0.1"
 #define SERIAL_OSC_PORT 12002
@@ -40,8 +41,8 @@
 class DropdownList;
 
 class Monome : public INonstandardController,
-               private OSCReceiver,
-               private OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>
+               private juce::OSCReceiver,
+               private juce::OSCReceiver::Listener<juce::OSCReceiver::MessageLoopCallback>
 {
 public:
    Monome(MidiDeviceListener* listener);
@@ -57,7 +58,7 @@ public:
    void ConnectToDevice(string deviceDesc);
    void UpdateDeviceList(DropdownList* list);
    
-   void oscMessageReceived(const OSCMessage& msg) override;
+   void oscMessageReceived(const juce::OSCMessage& msg) override;
    
    void SendValue(int page, int control, float value, bool forceNoteOn = false, int channel = -1)override;
    
@@ -73,14 +74,14 @@ private:
    
    static int sNextMonomeReceivePort;
    
-   OSCSender mToSerialOsc;
-   OSCSender mToMonome;
+   juce::OSCSender mToSerialOsc;
+   juce::OSCSender mToMonome;
    int mMonomeReceivePort;
    bool mIsOscSetUp;
    bool mHasMonome;
    int mMaxColumns;
    int mGridRotation;
-   String mPrefix;
+   juce::String mPrefix;
    bool mJustRequestedDeviceList;
    string mPendingDeviceDesc;
    

--- a/Source/OSCOutput.cpp
+++ b/Source/OSCOutput.cpp
@@ -106,7 +106,7 @@ void OSCOutput::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
 {
    if (mNoteOutLabel.size() > 0)
    {
-      OSCMessage msg(("/bespoke/"+mNoteOutLabel).c_str());
+      juce::OSCMessage msg(("/bespoke/"+mNoteOutLabel).c_str());
       float pitchOut = pitch;
       if (modulation.pitchBend != nullptr)
          pitchOut += modulation.pitchBend->GetValue(0);
@@ -118,21 +118,21 @@ void OSCOutput::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
 
 void OSCOutput::SendFloat(string address, float val)
 {
-   OSCMessage msg(address.c_str());
+   juce::OSCMessage msg(address.c_str());
    msg.addFloat32(val);
    mOscOut.send(msg);
 }
 
 void OSCOutput::SendInt(string address, int val)
 {
-   OSCMessage msg(address.c_str());
+   juce::OSCMessage msg(address.c_str());
    msg.addInt32(val);
    mOscOut.send(msg);
 }
 
 void OSCOutput::SendString(string address, string val)
 {
-   OSCMessage msg(address.c_str());
+   juce::OSCMessage msg(address.c_str());
    msg.addString(val);
    mOscOut.send(msg);
 }
@@ -149,7 +149,7 @@ void OSCOutput::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    address[0] = 0;
    strcat(address, "/bespoke/");
    strcat(address, slider->Name());
-   OSCMessage msg(address);
+   juce::OSCMessage msg(address);
    msg.addFloat32(slider->GetValue());
    mOscOut.send(msg);
 }

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -34,6 +34,8 @@
 #include "Slider.h"
 #include "INoteReceiver.h"
 
+#include "juce_osc/juce_osc.h"
+
 #define OSC_OUTPUT_MAX_PARAMS 50
 
 class OSCOutput : public IDrawableModule, public ITextEntryListener, public IFloatSliderListener, public INoteReceiver
@@ -82,7 +84,7 @@ private:
    string mNoteOutLabel;
    TextEntry* mNoteOutLabelEntry;
    
-   OSCSender mOscOut;
+   juce::OSCSender mOscOut;
 
    float mWidth;
    float mHeight;

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -35,8 +35,9 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-#include <JuceHeader.h>
+#include "juce_opengl/juce_opengl.h"
 using namespace juce::gl;
+using namespace juce;
 #include <VersionInfo.h>
 
 //#include <chrono>

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <JuceHeader.h>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
@@ -8,6 +7,9 @@
 #include <map>
 #include <vector>
 #include <list>
+#include <cmath>
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 using namespace std;
 
@@ -153,7 +155,7 @@ public:
    {
       mCritSec.exit();
    }
-   CriticalSection mCritSec;
+   juce::CriticalSection mCritSec;
 };
 
 #define CLAMP(v,a,b) (v<a ? a : (v>b ? b : v))
@@ -162,14 +164,14 @@ public:
 #define MAX(a,b) (a>b?a:b)
 #define MIN(a,b) (a<b?a:b)
 
-#define OF_KEY_RETURN KeyPress::returnKey
-#define OF_KEY_TAB KeyPress::tabKey
-#define OF_KEY_BACKSPACE KeyPress::backspaceKey
-#define OF_KEY_LEFT KeyPress::leftKey
-#define OF_KEY_RIGHT KeyPress::rightKey
-#define OF_KEY_ESC KeyPress::escapeKey
-#define OF_KEY_UP KeyPress::upKey
-#define OF_KEY_DOWN KeyPress::downKey
+#define OF_KEY_RETURN juce::KeyPress::returnKey
+#define OF_KEY_TAB juce::KeyPress::tabKey
+#define OF_KEY_BACKSPACE juce::KeyPress::backspaceKey
+#define OF_KEY_LEFT juce::KeyPress::leftKey
+#define OF_KEY_RIGHT juce::KeyPress::rightKey
+#define OF_KEY_ESC juce::KeyPress::escapeKey
+#define OF_KEY_UP juce::KeyPress::upKey
+#define OF_KEY_DOWN juce::KeyPress::downKey
 
 template <class T>
 inline std::string ofToString(const T& value)
@@ -310,7 +312,7 @@ float ofLerp(float start, float stop, float amt);
 float ofDistSquared(float x1, float y1, float x2, float y2);
 vector<string> ofSplitString(string str, string splitter, bool ignoreEmpty = false, bool trim = false);
 bool ofIsStringInString(const string& haystack, const string& needle);
-String GetFileNameWithoutExtension(String fullPath);
+juce::String GetFileNameWithoutExtension(juce::String fullPath);
 void ofScale(float x, float y, float z);
 void ofExit();
 void ofToggleFullscreen();

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -96,7 +96,7 @@ void OscController::SendValue(int page, int control, float value, bool forceNote
    {
       if (control == mOscMap[i].mControl)// && mOscMap[i].mLastChangedTime + 50 < gTime)
       {
-         OSCMessage msg(mOscMap[i].mAddress.c_str());
+         juce::OSCMessage msg(mOscMap[i].mAddress.c_str());
 
          if (mOscMap[i].mIsFloat)
          {
@@ -115,7 +115,7 @@ void OscController::SendValue(int page, int control, float value, bool forceNote
    }
 }
 
-void OscController::oscMessageReceived(const OSCMessage& msg)
+void OscController::oscMessageReceived(const juce::OSCMessage& msg)
 {
    string address = msg.getAddressPattern().toString().toStdString();
 

--- a/Source/OscController.h
+++ b/Source/OscController.h
@@ -31,6 +31,8 @@
 #include "INonstandardController.h"
 #include "ofxJSONElement.h"
 
+#include "juce_osc/juce_osc.h"
+
 struct OscMap
 {
    int mControl;
@@ -42,15 +44,15 @@ struct OscMap
 };
 
 class OscController : public INonstandardController,
-                      private OSCReceiver,
-                      private OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>
+                      private juce::OSCReceiver,
+                      private juce::OSCReceiver::Listener<juce::OSCReceiver::MessageLoopCallback>
 {
 public:
    OscController(MidiDeviceListener* listener, string outAddress, int outPort, int inPort);
    ~OscController();
    
    void Connect();
-   void oscMessageReceived(const OSCMessage& msg) override;
+   void oscMessageReceived(const juce::OSCMessage& msg) override;
    void SendValue(int page, int control, float value, bool forceNoteOn = false, int channel = -1) override;
    int AddControl(string address, bool isFloat);
    
@@ -71,7 +73,7 @@ private:
    string mOutAddress;
    int mOutPort;
    int mInPort;
-   OSCSender mOscOut;
+   juce::OSCSender mOscOut;
    bool mConnected;
    bool mOutputConnected;
    

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -29,6 +29,8 @@
 #include "ModularSynth.h"
 #include "PatchCableSource.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 //static
 bool Prefab::sLoadingPrefab = false;
 
@@ -201,6 +203,7 @@ void Prefab::GetModuleDimensions(float& width, float& height)
 
 void Prefab::ButtonClicked(ClickButton* button)
 {
+   using namespace juce;
    if (button == mSaveButton)
    {
       FileChooser chooser("Save prefab as...", File(ofToDataPath("prefabs/prefab.pfb")), "*.pfb", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
@@ -265,7 +268,7 @@ void Prefab::LoadPrefab(string loadPath)
    sLoadingPrefab = true;
 
    ScopedMutex mutex(TheSynth->GetAudioMutex(), "LoadPrefab()");
-   ScopedLock renderLock(*TheSynth->GetRenderLock());
+   juce::ScopedLock renderLock(*TheSynth->GetRenderLock());
    
    mModuleContainer.Clear();
    

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -30,7 +30,7 @@
 // #include <GL/glew.h>
 #endif
 
-#include <JuceHeader.h>
+#include "juce_opengl/juce_opengl.h"
 using namespace juce::gl;
 
 #include "Push2Control.h"

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -30,6 +30,8 @@
 #include "ChannelBuffer.h"
 #include <memory>
 
+#include "juce_audio_formats/juce_audio_formats.h"
+
 Sample::Sample()
 : mData(0)
 , mNumSamples(0)
@@ -57,7 +59,7 @@ bool Sample::Read(const char* path, bool mono, ReadType readType)
    vector<string> tokens = ofSplitString(mReadPath, "/");
    mName = tokens[tokens.size()-1].c_str();
    
-   File file(ofToDataPath(mReadPath));
+   juce::File file(ofToDataPath(mReadPath));
    delete mReader;
    mReader = TheSynth->GetGlobalManagers()->mAudioFormatManager.createReaderFor(file);
    
@@ -74,7 +76,7 @@ bool Sample::Read(const char* path, bool mono, ReadType readType)
       mOffset = mNumSamples;
       mSampleRateRatio = float(mReader->sampleRate) / gSampleRate;
       
-      mReadBuffer = make_unique<AudioSampleBuffer>();
+      mReadBuffer = make_unique<juce::AudioSampleBuffer>();
       mReadBuffer->setSize(mReader->numChannels, mNumSamples);
       
       if (readType == ReadType::Sync)
@@ -170,13 +172,13 @@ bool Sample::Write(const char* path /*=nullptr*/)
 //static
 bool Sample::WriteDataToFile(const char *path, float **data, int numSamples, int channels)
 {
-   auto wavFormat = std::make_unique<WavAudioFormat>();
-   File outputFile(ofToDataPath(path).c_str());
+   auto wavFormat = std::make_unique<juce::WavAudioFormat>();
+   juce::File outputFile(ofToDataPath(path).c_str());
    outputFile.create();
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);
    bool b1{false};
-   auto writer = std::unique_ptr<AudioFormatWriter>(
+   auto writer = std::unique_ptr<juce::AudioFormatWriter>(
        wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0));
    writer->writeFromFloatArrays(data, channels, numSamples);
 

--- a/Source/Sample.h
+++ b/Source/Sample.h
@@ -32,6 +32,12 @@
 class FileStreamOut;
 class FileStreamIn;
 
+namespace juce {
+   class AudioFormatReader;
+   template <typename T> class AudioBuffer;
+   using AudioSampleBuffer = AudioBuffer<float>;
+}
+
 class Sample : public juce::Timer
 {
 public:
@@ -100,8 +106,8 @@ private:
    int mNumBars;
    float mVolume;
 
-   AudioFormatReader* mReader;
-   unique_ptr<AudioSampleBuffer> mReadBuffer;
+   juce::AudioFormatReader* mReader;
+   unique_ptr<juce::AudioSampleBuffer> mReadBuffer;
    int mSamplesLeftToRead;
 };
 

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -30,6 +30,10 @@
 #include "ModularSynth.h"
 #include "UIControlMacros.h"
 
+#include "juce_audio_formats/juce_audio_formats.h"
+
+using namespace juce;
+
 SampleBrowser::SampleBrowser()
 {
    mCurrentDirectory = ofToDataPath("samples");

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -56,12 +56,12 @@ private:
    bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override { width=300; height=38+(int)mButtons.size()*17; }
    
-   void SetDirectory(String dirPath);
+   void SetDirectory(juce::String dirPath);
    int GetNumPages() const;
    void ShowPage(int page);
    
-   String mCurrentDirectory;
-   StringArray mDirectoryListing;
+   juce::String mCurrentDirectory;
+   juce::StringArray mDirectoryListing;
    std::array<ClickButton*, 30> mButtons;
    ClickButton* mBackButton;
    ClickButton* mForwardButton;

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -31,6 +31,8 @@
 #include "UIControlMacros.h"
 #include "Sample.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 SampleCapturer::SampleCapturer()
    : IAudioProcessor(gBufferSize)
    , mCurrentSampleIndex(0)
@@ -195,6 +197,7 @@ void SampleCapturer::DrawModule()
 
 void SampleCapturer::ButtonClicked(ClickButton* button)
 {
+   using namespace juce;
    if (button == mPlayButton)
    {
       mSamples[mCurrentSampleIndex].mPlaybackPos = 0;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -36,6 +36,11 @@
 #include "Scale.h"
 #include "UIControlMacros.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+#include "juce_audio_formats/juce_audio_formats.h"
+
+using namespace juce;
+
 namespace
 {
    const int kRecordingChunkSize = 48000 * 5;

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -40,9 +40,11 @@
 #include "RadioButton.h"
 #include "GateEffect.h"
 
+#include "juce_osc/juce_osc.h"
+
 class Sample;
 
-class SamplePlayer : public IAudioProcessor, public IDrawableModule, public INoteReceiver, public IFloatSliderListener, public IIntSliderListener, public IDropdownListener, public IButtonListener, public IRadioButtonListener, public ITextEntryListener, private OSCReceiver, private OSCReceiver::Listener<OSCReceiver::RealtimeCallback>
+class SamplePlayer : public IAudioProcessor, public IDrawableModule, public INoteReceiver, public IFloatSliderListener, public IIntSliderListener, public IDropdownListener, public IButtonListener, public IRadioButtonListener, public ITextEntryListener, private juce::OSCReceiver, private juce::OSCReceiver::Listener<juce::OSCReceiver::RealtimeCallback>
 {
 public:
    SamplePlayer();
@@ -72,8 +74,8 @@ public:
    ChannelBuffer* GetCueSampleData(int cueIndex);
    float GetLengthInSeconds() const;
    
-   void oscMessageReceived(const OSCMessage& msg) override;
-   void oscBundleReceived(const OSCBundle& bundle) override;
+   void oscMessageReceived(const juce::OSCMessage& msg) override;
+   void oscBundleReceived(const juce::OSCBundle& bundle) override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
@@ -110,7 +112,7 @@ private:
    float GetZoomEndSeconds() const;
    void UpdateActiveCuePoint();
    void PlayCuePoint(double time, int index, int velocity, float speedMult, float startOffsetSeconds);
-   void RunProcess(const StringArray& args);
+   void RunProcess(const juce::StringArray& args);
    void AutoSlice(int slices);
    void StopRecording();
    
@@ -210,7 +212,7 @@ private:
       string youtubeId;
    };
    RunningProcessType mRunningProcessType;
-   ChildProcess* mRunningProcess;
+   juce::ChildProcess* mRunningProcess;
    std::function<void()> mOnRunningProcessComplete;
    vector<YoutubeSearchResult> mYoutubeSearchResults;
    std::array<ClickButton*, kMaxYoutubeSearchResults> mSearchResultButtons;

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -49,6 +49,7 @@
 #include "leathers/pop"
 
 namespace py = pybind11;
+using namespace juce;
 
 //static
 std::vector<ScriptModule*> ScriptModule::sScriptModules;

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -38,9 +38,11 @@
 #include "ModulationChain.h"
 #include "MidiController.h"
 
+#include "juce_osc/juce_osc.h"
+
 class ScriptModule : public IDrawableModule, public IButtonListener, public NoteEffectBase, public IPulseReceiver, public ICodeEntryListener, public IFloatSliderListener, public IDropdownListener,
-                     private OSCReceiver,
-                     private OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>
+                     private juce::OSCReceiver,
+                     private juce::OSCReceiver::Listener<juce::OSCReceiver::MessageLoopCallback>
 {
 public:
    ScriptModule();
@@ -89,7 +91,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
    //OSCReceiver
-   void oscMessageReceived(const OSCMessage& msg) override;
+   void oscMessageReceived(const juce::OSCMessage& msg) override;
    
    bool HasDebugDraw() const override { return true; }
    

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -31,6 +31,9 @@
 #include "Profiler.h"
 #include "ModulationChain.h"
 
+#include "juce_audio_formats/juce_audio_formats.h"
+#include "juce_gui_basics/juce_gui_basics.h"
+
 const float mBufferX = 5;
 const float mBufferY = 100;
 const float mBufferW = 800;
@@ -304,6 +307,7 @@ void SeaOfGrain::UpdateDisplaySamples()
 
 void SeaOfGrain::LoadFile()
 {
+   using namespace juce;
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
                        TheSynth->GetGlobalManagers()->mAudioFormatManager.getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
    if (chooser.browseForFileToOpen())

--- a/Source/SpaceMouseControl.cpp
+++ b/Source/SpaceMouseControl.cpp
@@ -37,10 +37,10 @@ SpaceMouseMessageWindow::SpaceMouseMessageWindow(ModularSynth* theSynth)
 {
    sInstance = this;
 
-   String className("JUCE_");
-   className << String::toHexString(Time::getHighResolutionTicks());
+   juce::String className("JUCE_");
+   className << juce::String::toHexString(juce::Time::getHighResolutionTicks());
 
-   HMODULE moduleHandle = (HMODULE)Process::getCurrentModuleInstanceHandle();
+   HMODULE moduleHandle = (HMODULE)juce::Process::getCurrentModuleInstanceHandle();
 
    WNDCLASSEX wc = { 0 };
    wc.cbSize = sizeof(wc);
@@ -291,6 +291,11 @@ void SpaceMouseMessageWindow::Poll()
          break;
       }
    }
+}
+
+LPCTSTR SpaceMouseMessageWindow::getClassNameFromAtom() const noexcept
+{
+   return (LPCTSTR)(juce::pointer_sized_uint)atom;
 }
 
 #endif

--- a/Source/SpaceMouseControl.h
+++ b/Source/SpaceMouseControl.h
@@ -73,6 +73,6 @@ private:
    bool mIsPanningOrZooming;
    bool mIsTwisting;
 
-   LPCTSTR getClassNameFromAtom() noexcept { return (LPCTSTR)(pointer_sized_uint)atom; }
+   LPCTSTR getClassNameFromAtom() const noexcept;
 };
 #endif

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -68,7 +68,7 @@ StepSequencer::StepSequencer()
 {
    mFlusher.SetInterval(mStepInterval);
    
-   mMetaStepMasks = new uint32[META_STEP_MAX * NUM_STEPSEQ_ROWS];
+   mMetaStepMasks = new juce::uint32[META_STEP_MAX * NUM_STEPSEQ_ROWS];
    for (int i=0; i<META_STEP_MAX * NUM_STEPSEQ_ROWS; ++i)
       mMetaStepMasks[i] = 0xff;
 }
@@ -278,7 +278,7 @@ void StepSequencer::UpdateMetaLights()
       return;
    
    bool hasHeldButtons = mHeldButtons.size() > 0;
-   uint32 metaStepMask = 0;
+   juce::uint32 metaStepMask = 0;
    if (hasHeldButtons)
       metaStepMask = mMetaStepMasks[GetMetaStepMaskIndex(mHeldButtons.begin()->mCol, mHeldButtons.begin()->mRow)];
    
@@ -530,7 +530,7 @@ void StepSequencer::DrawModule()
    {
       for (int row = 0; row < mGrid->GetRows(); ++row)
       {
-         uint32 mask = mMetaStepMasks[GetMetaStepMaskIndex(col, row)];
+         auto mask = mMetaStepMasks[GetMetaStepMaskIndex(col, row)];
          ofVec2f pos = mGrid->GetCellPosition(col, row) + mGrid->GetPosition(true);
          float cellWidth = (float)mGrid->GetWidth() / mGrid->GetCols();
          float cellHeight = (float)mGrid->GetHeight() / mGrid->GetRows();

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -242,7 +242,7 @@ private:
    ClickButton* mShiftLeftButton;
    ClickButton* mShiftRightButton;
    std::list<HeldButton> mHeldButtons;
-   uint32* mMetaStepMasks;
+   juce::uint32* mMetaStepMasks;
    bool mIsSetUp;
    NoteInputMode mNoteInputMode;
    bool mHasExternalPulseSource;

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -39,9 +39,13 @@
 #include "IPulseReceiver.h"
 #include "exprtk/exprtk.hpp"
 
+#include "juce_audio_formats/juce_audio_formats.h"
+
 #ifdef JUCE_MAC
 #import <execinfo.h>
 #endif
+
+using namespace juce;
 
 int gBufferSize = -999; //values set in SetGlobalSampleRateAndBufferSize(), setting them to bad values here to highlight any bugs
 int gSampleRate = -999;

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -29,7 +29,6 @@
  #pragma clang diagnostic ignored "-Wreorder"
 #endif
 
-#include <JuceHeader.h>
 #include "OpenFrameworksPort.h"
 #include <map>
 #include <list>
@@ -117,10 +116,13 @@ extern float gCornerRoundness;
 extern std::random_device gRandomDevice;
 extern std::mt19937 gRandom;
 
+#include "juce_audio_devices/juce_audio_devices.h"
+#include "juce_audio_formats/juce_audio_formats.h"
+
 struct GlobalManagers
 {
-   AudioDeviceManager mDeviceManager;
-   AudioFormatManager mAudioFormatManager;
+   juce::AudioDeviceManager mDeviceManager;
+   juce::AudioFormatManager mAudioFormatManager;
 };
 
 enum OscillatorType

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -282,7 +282,7 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
          --mCaretPosition;
       }
    }
-   else if (key == KeyPress::deleteKey)
+   else if (key == juce::KeyPress::deleteKey)
    {
       int len = (int)strlen(mString);
       for (int i = mCaretPosition; i < len; ++i)
@@ -354,11 +354,11 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
       for (int i=0; i<clipboard.length(); ++i)
          AddCharacter(clipboard[i]);
    }
-   else if (key == KeyPress::homeKey)
+   else if (key == juce::KeyPress::homeKey)
    {
       mCaretPosition = 0;
    }
-   else if (key == KeyPress::endKey)
+   else if (key == juce::KeyPress::endKey)
    {
       mCaretPosition = (int)strlen(mString);
    }
@@ -448,9 +448,9 @@ bool TextEntry::AllowCharacter(char c)
    if (mType == kTextEntry_Text)
       return juce::CharacterFunctions::isPrintable(c);
    if (mType == kTextEntry_Int)
-      return CharacterFunctions::isDigit((char)c) || c == '-';
+      return juce::CharacterFunctions::isDigit((char)c) || c == '-';
    if (mType == kTextEntry_Float)
-      return CharacterFunctions::isDigit((char)c) || c == '.' || c == '-';
+      return juce::CharacterFunctions::isDigit((char)c) || c == '.' || c == '-';
    return false;
 }
 

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -23,7 +23,6 @@
 //
 //
 
-#include <JuceHeader.h>
 #include "TitleBar.h"
 #include "ModularSynth.h"
 #include "SynthGlobals.h"
@@ -35,6 +34,8 @@
 #include "Prefab.h"
 #include "UserPrefsEditor.h"
 #include "UIControlMacros.h"
+
+#include "juce_audio_devices/juce_audio_devices.h"
 
 TitleBar* TheTitleBar = nullptr;
 
@@ -264,16 +265,16 @@ void TitleBar::ListLayouts()
 {
    mLoadLayoutDropdown->Clear();
    
-   DirectoryIterator dir(File(ofToDataPath("layouts")), false);
+   juce::DirectoryIterator dir(juce::File(ofToDataPath("layouts")), false);
    int layoutIdx = 0;
    while (dir.next())
    {
-      File file = dir.getFile();
+      juce::File file = dir.getFile();
       if (file.getFileExtension() == ".json")
       {
          mLoadLayoutDropdown->AddLabel(file.getFileNameWithoutExtension().toRawUTF8(), layoutIdx);
          
-         if (file.getRelativePathFrom(File(ofToDataPath(""))).toStdString() == TheSynth->GetLoadedLayout())
+         if (file.getRelativePathFrom(juce::File(ofToDataPath(""))).toStdString() == TheSynth->GetLoadedLayout())
             mLoadLayoutIndex = layoutIdx;
          
          ++layoutIdx;
@@ -447,7 +448,7 @@ void TitleBar::DrawModuleUnclipped()
       TheTitleBar->GetDimensions(titleBarWidth, titleBarHeight);
       float x = 100;
       float y = 40 + titleBarHeight;
-      string filename = File(TheSynth->GetLastSavePath()).getFileName().toStdString();
+      string filename = juce::File(TheSynth->GetLastSavePath()).getFileName().toStdString();
       gFontBold.DrawString("saved "+filename, 50, x, y);
       ofPopStyle();
    }

--- a/Source/UserData.cpp
+++ b/Source/UserData.cpp
@@ -19,8 +19,8 @@ void UpdateUserData(string destDirPath)
    }
    else
    {
-      StringArray bundledVersionLines;
-      StringArray destVersionLines;
+      juce::StringArray bundledVersionLines;
+      juce::StringArray destVersionLines;
       bundledDataVersionFile.readLines(bundledVersionLines);
       destDataVersionFile.readLines(destVersionLines);
       if (bundledVersionLines.isEmpty())
@@ -43,14 +43,14 @@ void UpdateUserData(string destDirPath)
       ofLog() << "copying data from "+bundledDataDir.getFullPathName().toStdString()+" to "+destDirPath;
       destDataDir.createDirectory();
       
-      DirectoryIterator directories(bundledDataDir, true, "*", File::findDirectories);
+      juce::DirectoryIterator directories(bundledDataDir, true, "*", juce::File::findDirectories);
       while (directories.next())
       {
          juce::String destDirName = juce::String(destDirPath) + "/" + directories.getFile().getRelativePathFrom(bundledDataDir);
          juce::File(destDirName).createDirectory();
       }
 
-      DirectoryIterator entry(bundledDataDir, true);
+      juce::DirectoryIterator entry(bundledDataDir, true);
       while (entry.next())
       {
          juce::String sourceFileName = entry.getFile().getFullPathName();

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -30,6 +30,8 @@
 #include "SynthGlobals.h"
 #include "UIControlMacros.h"
 
+#include "juce_audio_devices/juce_audio_devices.h"
+
 UserPrefsEditor::UserPrefsEditor()
 {
 }
@@ -209,7 +211,7 @@ void UserPrefsEditor::Show()
 
 void UserPrefsEditor::UpdateDropdowns(vector<DropdownList*> toUpdate)
 {
-   AudioDeviceManager& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
 
    int i;
 
@@ -283,13 +285,13 @@ void UserPrefsEditor::UpdateDropdowns(vector<DropdownList*> toUpdate)
       }
    }
 
-   String outputDeviceName;
+   juce::String outputDeviceName;
    if (mAudioOutputDeviceIndex >= 0)
       outputDeviceName = selectedDeviceType->getDeviceNames()[mAudioOutputDeviceIndex];
    else if (mAudioOutputDeviceIndex == -1)
       outputDeviceName = selectedDeviceType->getDeviceNames()[selectedDeviceType->getDefaultDeviceIndex(false)];
 
-   String inputDeviceName;
+   juce::String inputDeviceName;
    if (selectedDeviceType->hasSeparateInputsAndOutputs())
    {
       if (mAudioInputDeviceIndex >= 0)
@@ -347,7 +349,7 @@ void UserPrefsEditor::DrawModule()
    DrawTextNormal("editor for userprefs.json file", 3, 15);
    DrawTextNormal("any changes will not take effect until bespoke is restarted", 3, 35);
 
-   AudioDeviceManager& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;    
+   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
    auto* selectedDeviceType = mDeviceTypeIndex != -1 ? deviceManager.getAvailableDeviceTypes()[mDeviceTypeIndex] : deviceManager.getCurrentDeviceTypeObject();
    mAudioInputDeviceDropdown->SetShowing(selectedDeviceType->hasSeparateInputsAndOutputs());
 
@@ -505,11 +507,11 @@ void UserPrefsEditor::ButtonClicked(ClickButton* button)
       string output = userPrefs.getRawString(true);
       CleanUpSave(output);
 
-      File file(TheSynth->GetUserPrefsPath(false));
+      juce::File file(TheSynth->GetUserPrefsPath(false));
       file.create();
       file.replaceWithText(output);
 
-      JUCEApplicationBase::quit();
+      juce::JUCEApplicationBase::quit();
    }
    if (button == mCancelButton)
       SetShowing(false);

--- a/Source/VSTPlayhead.h
+++ b/Source/VSTPlayhead.h
@@ -26,7 +26,7 @@
 #ifndef __Bespoke__VSTPlayhead__
 #define __Bespoke__VSTPlayhead__
 
-#include <JuceHeader.h>
+#include "juce_audio_basics/juce_audio_basics.h"
 
 class VSTPlayhead : public juce::AudioPlayHead
 {

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -42,6 +42,8 @@ namespace
 //static
 bool VSTPlugin::sIsRescanningVsts = false;
 
+using namespace juce;
+
 namespace VSTLookup
 {
    static juce::AudioPluginFormatManager sFormatManager;
@@ -245,7 +247,7 @@ void VSTPlugin::SetVST(string vstName)
       ofxJSONElement root;
       root.open(ofToDataPath("vst/used_vsts.json"));
       
-      Time time = Time::getCurrentTime();
+      auto time = juce::Time::getCurrentTime();
       root["vsts"][path] = (double)time.currentTimeMillis();
 
       root.save(ofToDataPath("vst/used_vsts.json"), true);

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -26,7 +26,6 @@
 #ifndef __Bespoke__VSTPlugin__
 #define __Bespoke__VSTPlugin__
 
-#include <JuceHeader.h>
 #include "IAudioProcessor.h"
 #include "PolyphonyMgr.h"
 #include "INoteReceiver.h"
@@ -37,9 +36,10 @@
 #include "EnvOscillator.h"
 #include "Ramp.h"
 #include "ClickButton.h"
-#include <JuceHeader.h>
 #include "VSTPlayhead.h"
 #include "VSTWindow.h"
+
+#include "juce_audio_processors/juce_audio_processors.h"
 
 class ofxJSONElement;
 //class NSWindowOverlay;
@@ -118,7 +118,7 @@ private:
    int mOverlayHeight;
    
    bool mPluginReady;
-   std::unique_ptr<AudioProcessor> mPlugin;
+   std::unique_ptr<juce::AudioProcessor> mPlugin;
    string mPluginName;
    std::unique_ptr<VSTWindow> mWindow;
    juce::MidiBuffer mMidiBuffer;
@@ -131,7 +131,7 @@ private:
    {
       float mValue;
       FloatSlider* mSlider;
-      AudioProcessorParameter* mParameter;
+      juce::AudioProcessorParameter* mParameter;
       bool mShowing;
       bool mInSelectorList;
    };

--- a/Source/VSTWindow.cpp
+++ b/Source/VSTWindow.cpp
@@ -27,6 +27,8 @@
 #include "VSTPlugin.h"
 #include "ModularSynth.h"
 
+#include "juce_gui_extra/juce_gui_extra.h"
+
 VSTWindow::VSTWindow (VSTPlugin* vst,
                       Component* const pluginEditor,
                       WindowFormatType t)
@@ -42,7 +44,7 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
    
    setContentOwned (pluginEditor, true);
    
-   auto mainMon = Desktop::getInstance().getDisplays().findDisplayForRect(TheSynth->GetMainComponent()->getScreenBounds()).userArea;
+   auto mainMon = juce::Desktop::getInstance().getDisplays().findDisplayForRect(TheSynth->GetMainComponent()->getScreenBounds()).userArea;
 
    setTopLeftPosition(mainMon.getX() + mainMon.getWidth() / 4,
                       mainMon.getY() + mainMon.getHeight() / 4);

--- a/Source/VSTWindow.h
+++ b/Source/VSTWindow.h
@@ -26,9 +26,14 @@
 #ifndef __Bespoke__VSTWindow__
 #define __Bespoke__VSTWindow__
 
-#include <JuceHeader.h>
+#include "juce_audio_processors/juce_audio_processors.h"
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class VSTPlugin;
+
+namespace juce {
+   class NSViewComponent;
+}
 
 //==============================================================================
 class VSTWindow  : public juce::DocumentWindow

--- a/Source/VersionInfo.cpp.in
+++ b/Source/VersionInfo.cpp.in
@@ -3,6 +3,7 @@
 // This file will get replaced with the CMAKE variables as below at build time
 namespace Bespoke
 {
+    const char* APP_NAME = "@CMAKE_PROJECT_NAME@";
     const char* VERSION = "@CMAKE_PROJECT_VERSION@";
     const char* PYTHON_VERSION ="@Python_VERSION@";
     const char* CMAKE_INSTALL_PREFIX = "@CMAKE_INSTALL_PREFIX@";

--- a/Source/VersionInfo.h
+++ b/Source/VersionInfo.h
@@ -2,6 +2,7 @@
 
 namespace Bespoke
 {
+    extern const char* APP_NAME; // The application name. Taken from the top-level CMake project name.
     extern const char* VERSION; // This will be the same string as Juce::Application::getApplicationVersion()
     extern const char* PYTHON_VERSION; // The python version we compiled with
     extern const char* CMAKE_INSTALL_PREFIX;

--- a/Source/ofxJSONElement.cpp
+++ b/Source/ofxJSONElement.cpp
@@ -8,7 +8,6 @@
  */
 
 #include "ofxJSONElement.h"
-#include <JuceHeader.h>
 #include "SynthGlobals.h"
 
 using namespace Json;
@@ -43,11 +42,11 @@ bool ofxJSONElement::parse(string jsonString)
 //--------------------------------------------------------------
 bool ofxJSONElement::open(string filename)
 {
-   File file(filename);
+   juce::File file(filename);
    
    if (file.exists())
    {
-      String str = file.loadFileAsString();
+      juce::String str = file.loadFileAsString();
       
       Reader reader;
       if(!reader.parse( str.toStdString(), *this ))
@@ -68,7 +67,7 @@ bool ofxJSONElement::open(string filename)
 bool ofxJSONElement::save(string filename, bool pretty)
 {
    filename = ofToDataPath(filename, true);
-   File file(filename);
+   juce::File file(filename);
    file.create();
    if (!file.exists()) {
       ofLog() << "Unable to create "+filename;

--- a/Source/push2/push2/JuceToPush2DisplayBridge.h
+++ b/Source/push2/push2/JuceToPush2DisplayBridge.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "Push2-Display.h"
-#include <JuceHeader.h>
 
 namespace ableton
 {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         linux-x64:
           imageName: 'ubuntu-20.04'
           isLinux: True
-          cmakeArguments: "-DCMAKE_BUILD_TYPE=Debug"
+          cmakeArguments: "-GNinja -DCMAKE_BUILD_TYPE=Debug"
           cmakeConfig: "Debug"
 
     pool:
@@ -65,30 +65,27 @@ jobs:
               libxkbcommon-dev \
               libxkbcommon-x11-dev \
               ninja-build \
-              xcb
-
-            # These are the JUCE deps
-            sudo apt-get install -y libgtk-3-dev
-            sudo apt-get install -y libwebkit2gtk-4.0
-            sudo apt-get install -y libwebkit2gtk-4.0-dev
-            sudo apt-get install -y libcurl4-openssl-dev
-            sudo apt-get install -y alsa
-            sudo apt-get install -y alsa-tools
-            sudo apt-get install -y libasound2-dev
-            sudo apt-get install -y libjack-dev
-            sudo apt-get install -y libfreetype6-dev
-            sudo apt-get install -y libxinerama-dev
-            sudo apt-get install -y libxcb-xinerama0
-            sudo apt-get install -y libxinerama1
-            sudo apt-get install -y x11proto-xinerama-dev
-            sudo apt-get install -y libxrandr-dev
-            sudo apt-get install -y libgl1-mesa-dev
-            sudo apt-get install -y libxcursor-dev
-            sudo apt-get install -y libxcursor1
-            sudo apt-get install -y libxcb-cursor-dev
-            sudo apt-get install -y libxcb-cursor0
-            sudo apt-get install -y libusb-1.0.0-dev 
-            sudo apt-get install -y --fix-missing
+              xcb \
+              libgtk-3-dev \
+              libwebkit2gtk-4.0 \
+              libwebkit2gtk-4.0-dev \
+              libcurl4-openssl-dev \
+              alsa \
+              alsa-tools \
+              libasound2-dev \
+              libjack-dev \
+              libfreetype6-dev \
+              libxinerama-dev \
+              libxcb-xinerama0 \
+              libxinerama1 \
+              x11proto-xinerama-dev \
+              libxrandr-dev \
+              libgl1-mesa-dev \
+              libxcursor-dev \
+              libxcursor1 \
+              libxcb-cursor-dev \
+              libxcb-cursor0 \
+              libusb-1.0.0-dev
 
         condition: variables.isLinux
         displayName: linux - run apt-get
@@ -100,5 +97,5 @@ jobs:
 
       - bash: |
           set -e
-          cmake --build build --config $(cmakeConfig) --parallel 8
+          cmake --build build --config $(cmakeConfig)
         displayName: all - build with cmake


### PR DESCRIPTION
This is a first step to reduce build time and namespace pollution. It's quite mechanical:

- Remove `#include <JuceHeader.h>`
- `#include` the JUCE module header(s) only
- Add `juce::` / `using` as needed (`JuceHeader.h` was configured to do a global `using namespace juce`).

Speedup is rather modest, ~10% on Linux. If and when this gets merged, I have a second commit ready that makes the most notorious headers JUCE-free, reducing build time by 40%-50% vs. current `main`. Those changes move code around and change interfaces, so I separated them out for easier review.