### PR TITLE
Add ignore file for clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,9 @@ _pkginfo.txt
 # but keep track of directories ending in .cache
 !*.[Cc]ache/
 
+# clangd cache files
+.cache/
+
 # Others
 ClientBin/
 ~$*


### PR DESCRIPTION
Ignores directory `.cache/` created by clangd at the root.