### PR TITLE
De-JUCE some widely included headers for faster builds

### DIFF
--- a/Source/Arpeggiator.cpp
+++ b/Source/Arpeggiator.cpp
@@ -44,7 +44,7 @@ Arpeggiator::Arpeggiator()
 {
    TheScale->AddListener(this);
    
-   bzero(mArpString, MAX_TEXTENTRY_LENGTH);
+   std::memset(mArpString, 0, MAX_TEXTENTRY_LENGTH);
 }
 
 void Arpeggiator::Init()

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -30,6 +30,11 @@
 #include "ModularSynth.h"
 #include "Profiler.h"
 
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 const float mBufferX = 5;
 const float mBufferY = 80;
 const float mBufferW = 900;
@@ -316,8 +321,7 @@ void BeatBloks::FilesDropped(vector<string> files, int x, int y)
    }
    
    char c;
-   char line[512];
-   bzero(line,512);
+   char line[512]{};
    int linepos = 0;
    do
    {
@@ -330,7 +334,7 @@ void BeatBloks::FilesDropped(vector<string> files, int x, int y)
          ReadEchonestLine(line);
          
          linepos = 0;
-         bzero(line,512);
+         std::memset(line, 0, sizeof(line));
       }
       else
       {

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -39,8 +39,8 @@ Chorder::Chorder()
 , mChordIndex(0)
 , mInversion(0)
 {
-   bzero(mHeldCount, TOTAL_NUM_NOTES*sizeof(int));
-   bzero(mInputNotes, TOTAL_NUM_NOTES*sizeof(bool));
+   std::memset(mHeldCount, 0, TOTAL_NUM_NOTES*sizeof(int));
+   std::memset(mInputNotes, 0, TOTAL_NUM_NOTES*sizeof(bool));
 }
 
 void Chorder::CreateUIControls()
@@ -151,8 +151,8 @@ void Chorder::CheckboxUpdated(Checkbox *checkbox)
    if (checkbox == mEnabledCheckbox)
    {
       mNoteOutput.Flush(gTime + gBufferSizeMs);
-      bzero(mHeldCount,TOTAL_NUM_NOTES*sizeof(int));
-      bzero(mInputNotes, TOTAL_NUM_NOTES*sizeof(bool));
+      std::memset(mHeldCount, 0, TOTAL_NUM_NOTES*sizeof(int));
+      std::memset(mInputNotes, 0, TOTAL_NUM_NOTES*sizeof(bool));
    }
    
    if (checkbox == mDiatonicCheckbox)

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -44,6 +44,8 @@
    #include "pybind11/stl.h"
 #include "leathers/pop"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 namespace py = pybind11;
 
 //static

--- a/Source/DelayEffect.cpp
+++ b/Source/DelayEffect.cpp
@@ -123,7 +123,7 @@ void DelayEffect::ProcessAudio(double time, ChannelBuffer* buffer)
             mDelayBuffer.Write(buffer->GetChannel(ch)[i], ch);
 
          float delayInput = delayedSample * mFeedback * (mInvert ? -1 : 1);
-         FIX_DENORMAL(delayInput);
+         JUCE_UNDENORMALISE(delayInput);
          if (delayInput == delayInput) //filter NaNs
             buffer->GetChannel(ch)[i] += delayInput;
 

--- a/Source/FFT.cpp
+++ b/Source/FFT.cpp
@@ -24,6 +24,7 @@
 //
 
 #include "FFT.h"
+#include <cstring>
 
 // Constructor for FFT routine
 FFT::FFT(int nfft)
@@ -514,3 +515,11 @@ void mayer_realifft(int n, REAL *real)
    }
    mayer_fht(real,n);
 }
+
+void FFTData::Clear()
+{
+   std::memset(mRealValues, 0, mFreqDomainSize * sizeof(float));
+   std::memset(mImaginaryValues, 0, mFreqDomainSize * sizeof(float));
+   std::memset(mTimeDomain, 0, mWindowSize * sizeof(float));
+}
+

--- a/Source/FFT.h
+++ b/Source/FFT.h
@@ -62,12 +62,7 @@ struct FFTData
       delete[] mTimeDomain;
    }
 
-   void Clear()
-   {
-      bzero(mRealValues, mFreqDomainSize * sizeof(float));
-      bzero(mImaginaryValues, mFreqDomainSize * sizeof(float));
-      bzero(mTimeDomain, mWindowSize * sizeof(float));
-   }
+   void Clear();
 
    int mWindowSize;
    int mFreqDomainSize;

--- a/Source/FFTtoAdditive.cpp
+++ b/Source/FFTtoAdditive.cpp
@@ -218,7 +218,7 @@ void FFTtoAdditive::DrawViz()
       }
    }
 
-   bzero(mPeakHistory[mHistoryPtr], sizeof(float) * VIZ_WIDTH);
+   std::memset(mPeakHistory[mHistoryPtr], 0, sizeof(float) * VIZ_WIDTH);
    for (int i=1; i<=numPartials; ++i)
    {
       float height = mFFTData.mRealValues[i-1];

--- a/Source/GridController.cpp
+++ b/Source/GridController.cpp
@@ -106,9 +106,9 @@ GridControllerMidi::GridControllerMidi()
 , mCols(8)
 , mOwner(nullptr)
 {
-   bzero(mControls, sizeof(int)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
-   bzero(mInput, sizeof(float)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
-   bzero(mLights, sizeof(int)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
+   std::memset(mControls, 0, sizeof(int)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
+   std::memset(mInput, 0, sizeof(float)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
+   std::memset(mLights, 0, sizeof(int)*MAX_GRIDCONTROLLER_ROWS*MAX_GRIDCONTROLLER_COLS);
 }
 
 void GridControllerMidi::OnControllerPageSelected()

--- a/Source/INoteSource.h
+++ b/Source/INoteSource.h
@@ -38,7 +38,7 @@ class INoteSource;
 class NoteOutput : public INoteReceiver
 {
 public:
-   NoteOutput(INoteSource* source) : mNoteSource(source), mStackDepth(0) { bzero(mNotes, 128*sizeof(bool)); bzero(mNoteOnTimes, 128*sizeof(double)); }
+   NoteOutput(INoteSource* source) : mNoteSource(source), mStackDepth(0) { std::memset(mNotes, 0, 128*sizeof(bool)); std::memset(mNoteOnTimes, 0, 128*sizeof(double)); }
    
    void Flush(double time);
    void FlushTarget(double time, INoteReceiver* target);

--- a/Source/KarplusStrongVoice.cpp
+++ b/Source/KarplusStrongVoice.cpp
@@ -134,17 +134,17 @@ bool KarplusStrongVoice::Process(double time, ChannelBuffer* out, int oversampli
             float nextSample = posNext >= mBuffer.Size() ? 0 : mBuffer.GetSample(posNext, 0);
             float a = samplesAgo - pos;
             feedbackSample = (1 - a)*sample + a * nextSample; //interpolate
-            FIX_DENORMAL(feedbackSample);
+            JUCE_UNDENORMALISE(feedbackSample);
          }
       }
       mFilteredSample = ofLerp(feedbackSample, mFilteredSample, filterLerp);
-      FIX_DENORMAL(mFilteredSample);
+      JUCE_UNDENORMALISE(mFilteredSample);
       //sample += mFeedbackRamp.Value(time) * mFilterSample;
       float feedback = mFilteredSample * sqrtf(mVoiceParams->mFeedback + GetPressure(pos) * .02f) * mMuteRamp.Value(time);
       if (mVoiceParams->mInvert)
          feedback *= -1;
       sample += feedback;
-      FIX_DENORMAL(sample);
+      JUCE_UNDENORMALISE(sample);
 
       mBuffer.Write(sample, 0);
       

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -233,7 +233,7 @@ public:
 
       SetGlobalSampleRateAndBufferSize(sampleRate, bufferSize);
       
-      mSynth.Setup(&mGlobalManagers, this, &openGLContext);
+      mSynth.Setup(&mGlobalManagers.mDeviceManager, &mGlobalManagers.mAudioFormatManager, this, &openGLContext);
 
       if (!mGlobalManagers.mDeviceManager.getCurrentDeviceTypeObject()->hasSeparateInputsAndOutputs())
          inputDevice = outputDevice;    //asio must have identical input and output
@@ -526,8 +526,12 @@ private:
       return ret;
    }
 
-   GlobalManagers mGlobalManagers;
-   
+   struct
+   {
+      juce::AudioDeviceManager mDeviceManager;
+      juce::AudioFormatManager mAudioFormatManager;
+   } mGlobalManagers;
+
    ModularSynth mSynth;
    
    NVGcontext* mVG;

--- a/Source/MidiDevice.cpp
+++ b/Source/MidiDevice.cpp
@@ -41,7 +41,7 @@ MidiDevice::MidiDevice(MidiDeviceListener* listener)
 
 MidiDevice::~MidiDevice()
 {
-   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetAudioDeviceManager();
    deviceManager.removeMidiInputCallback(mDeviceNameIn, this);
    if (mMidiOut.get())
       mMidiOut->stopBackgroundThread();
@@ -53,7 +53,7 @@ bool MidiDevice::ConnectInput(const char* name)
    
    mDeviceNameIn = name;
    
-   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetAudioDeviceManager();
    deviceManager.setMidiInputEnabled(mDeviceNameIn, true);
    deviceManager.addMidiInputCallback(mDeviceNameIn, this);
    
@@ -105,7 +105,7 @@ void MidiDevice::ConnectOutput(int index, int channel /*= 1*/)
 
 void MidiDevice::DisconnectInput()
 {
-   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetAudioDeviceManager();
    deviceManager.setMidiInputEnabled(mDeviceNameIn, false);
    deviceManager.removeMidiInputCallback(mDeviceNameIn, this);
 }
@@ -142,7 +142,7 @@ bool MidiDevice::IsInputConnected(bool immediate)
    for (auto& device : sConnectedInputDevices)
    {
       if (device.name == mDeviceNameIn)
-         return TheSynth->GetGlobalManagers()->mDeviceManager.isMidiInputDeviceEnabled(device.identifier);
+         return TheSynth->GetAudioDeviceManager().isMidiInputDeviceEnabled(device.identifier);
    }
    return false;
 }

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -232,9 +232,10 @@ bool ModularSynth::IsReady()
    return gTime > 100;
 }
 
-void ModularSynth::Setup(GlobalManagers* globalManagers, juce::Component* mainComponent, juce::OpenGLContext* openGLContext)
+void ModularSynth::Setup(juce::AudioDeviceManager* globalAudioDeviceManager, juce::AudioFormatManager* globalAudioFormatManager, juce::Component* mainComponent, juce::OpenGLContext* openGLContext)
 {
-   mGlobalManagers = globalManagers;
+   mGlobalAudioDeviceManager = globalAudioDeviceManager;
+   mGlobalAudioFormatManager = globalAudioFormatManager;
    mMainComponent = mainComponent;
    mOpenGLContext = openGLContext;
    int recordBufferLengthMinutes = 30;
@@ -857,7 +858,6 @@ void ModularSynth::Exit()
    mAudioThreadMutex.Lock("exiting");
    mAudioPaused = true;
    mAudioThreadMutex.Unlock();
-   mSoundStream.stop();
    mModuleContainer.Exit();
    DeleteAllModules();
    ofExit();
@@ -937,7 +937,7 @@ void ModularSynth::KeyPressed(int key, bool isRepeat)
       }
       else
       {
-         bzero(mConsoleText, MAX_TEXTENTRY_LENGTH);
+         std::memset(mConsoleText, 0, MAX_TEXTENTRY_LENGTH);
          mConsoleEntry->MakeActiveTextEntry(true);
       }
    }

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -19,6 +19,8 @@
 #endif
 
 namespace juce {
+   class AudioDeviceManager;
+   class AudioFormatManager;
    class Component;
    class OpenGLContext;
 }
@@ -59,7 +61,7 @@ public:
    ModularSynth();
    virtual ~ModularSynth();
    
-   void Setup(GlobalManagers* globalManagers, juce::Component* mainComponent, juce::OpenGLContext* openGLContext);
+   void Setup(juce::AudioDeviceManager* globalAudioDeviceManager, juce::AudioFormatManager* globalAudioFormatManager, juce::Component* mainComponent, juce::OpenGLContext* openGLContext);
    void LoadResources(void* nanoVG, void* fontBoundsNanoVG);
    void InitIOBuffers(int inputChannelCount, int outputChannelCount);
    void Poll();
@@ -163,7 +165,8 @@ public:
    bool HasNotMovedMouseSinceClick() { return mClickStartX < INT_MAX; }
    IDrawableModule* GetMoveModule() { return mMoveModule; }
    ModuleFactory* GetModuleFactory() { return &mModuleFactory; }
-   GlobalManagers* GetGlobalManagers() { return mGlobalManagers; }
+   juce::AudioDeviceManager &GetAudioDeviceManager() { return *mGlobalAudioDeviceManager; }
+   juce::AudioFormatManager &GetAudioFormatManager() { return *mGlobalAudioFormatManager; }
    juce::Component* GetMainComponent() { return mMainComponent; }
    juce::OpenGLContext* GetOpenGLContext() { return mOpenGLContext; }
    IDrawableModule* GetLastClickedModule() const;
@@ -239,7 +242,6 @@ private:
 
    void ReadClipboardTextFromSystem();
    
-   ofSoundStream mSoundStream;
    int mIOBufferSize;
    
    vector<IAudioSource*> mSources;
@@ -335,7 +337,8 @@ private:
    ofVec2f mMousePos;
    string mNextDrawTooltip;
    
-   GlobalManagers* mGlobalManagers;
+   juce::AudioDeviceManager* mGlobalAudioDeviceManager;
+   juce::AudioFormatManager* mGlobalAudioFormatManager;
    juce::Component* mMainComponent;
    juce::OpenGLContext* mOpenGLContext;
    

--- a/Source/ModuleSaveData.h
+++ b/Source/ModuleSaveData.h
@@ -87,7 +87,7 @@ public:
    
    struct SaveVal
    {
-      SaveVal(string prop) : mProperty(prop), mMin(0), mMax(10), mIsTextField(false), mFillDropdownFn(nullptr) { bzero(mString,MAX_TEXTENTRY_LENGTH); }
+      explicit SaveVal(string prop) : mProperty(std::move(prop)), mString(), mMin(0), mMax(10), mIsTextField(false), mFillDropdownFn(nullptr) {}
       
       string mProperty;
       Type mType;

--- a/Source/NoteDisplayer.cpp
+++ b/Source/NoteDisplayer.cpp
@@ -28,7 +28,7 @@
 
 NoteDisplayer::NoteDisplayer()
 {
-   bzero(mVelocities, 127 * sizeof(int));
+   std::memset(mVelocities, 0, 127 * sizeof(int));
 }
 
 void NoteDisplayer::DrawModule()

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -538,19 +538,6 @@ bool ofIsStringInString(const string& haystack, const string& needle)
    return ( strstr(haystack.c_str(), needle.c_str() ) != nullptr );
 }
 
-String GetFileNameWithoutExtension(String fullPath)
-{
-   auto lastSlash = fullPath.lastIndexOfChar('/') + 1;
-   if (lastSlash == 0)
-      lastSlash = fullPath.lastIndexOfChar('\\') + 1;
-   auto lastDot   = fullPath.lastIndexOfChar ('.');
-
-   if (lastDot > lastSlash)
-     return fullPath.substring (lastSlash, lastDot);
-
-   return fullPath.substring (lastSlash);
-}
-
 void ofScale(float x, float y, float z)
 {
    nvgScale(gNanoVG, x, y);

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -8,8 +8,7 @@
 #include <vector>
 #include <list>
 #include <cmath>
-
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <mutex>
 
 using namespace std;
 
@@ -144,19 +143,7 @@ struct ofRectangle
    float height;
 };
 
-class ofMutex
-{
-public:
-   void lock()
-   {
-      mCritSec.enter();
-   }
-   void unlock()
-   {
-      mCritSec.exit();
-   }
-   juce::CriticalSection mCritSec;
-};
+using ofMutex = std::recursive_mutex;
 
 #define CLAMP(v,a,b) (v<a ? a : (v>b ? b : v))
 
@@ -189,51 +176,6 @@ inline std::string ofToString(const T& value, int precision)
    return out.str();
 }
 
-namespace Poco
-{
-   namespace FastMutex
-   {
-      class ScopedLock
-      {
-      public:
-         ScopedLock(ofMutex& mutex)
-         : mMutex(&mutex)
-         {
-            mMutex->lock();
-         }
-         ~ScopedLock()
-         {
-            mMutex->unlock();
-         }
-      private:
-         ofMutex* mMutex;
-      };
-   }
-}
-
-
-
-struct ofDragInfo
-{
-   vector<string> files;
-};
-
-struct ofMessage
-{
-   
-};
-
-
-
-class ofSoundStream
-{
-public:
-   void setup(void*, int outChannels, int inChannels, int sampleRate, int bufferSize, int numBuffers) {}
-   int getTickCount() { return 0; }
-   int GetLastStarvationTick() { return 0; }
-   void stop() {}
-};
-
 #define PI 3.14159265358979323846
 #define TWO_PI 6.28318530717958647693
 
@@ -255,17 +197,6 @@ private:
    bool mLoaded;
    string mFontPath;
 };
-
-struct ofFileDialogResult
-{
-   bool bSuccess;
-   string filePath;
-};
-
-struct ofEventArgs
-{
-};
-
 
 typedef ofVec2f ofPoint;
 
@@ -312,7 +243,6 @@ float ofLerp(float start, float stop, float amt);
 float ofDistSquared(float x1, float y1, float x2, float y2);
 vector<string> ofSplitString(string str, string splitter, bool ignoreEmpty = false, bool trim = false);
 bool ofIsStringInString(const string& haystack, const string& needle);
-juce::String GetFileNameWithoutExtension(juce::String fullPath);
 void ofScale(float x, float y, float z);
 void ofExit();
 void ofToggleFullscreen();

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -33,6 +33,8 @@
 #include "AudioSend.h"
 #include "MacroSlider.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 namespace
 {
    const int kPatchCableSourceRadius = 5;

--- a/Source/Profiler.h
+++ b/Source/Profiler.h
@@ -50,15 +50,14 @@ private:
    
    struct Cost
    {
-      Cost() : mFrameCost(0), mHistoryIdx(0) { bzero(mHistory, sizeof(long)); }
       void EndFrame();
       unsigned long long MaxCost() const;
       
       string mName;
-      uint32_t mHash;
-      unsigned long long mFrameCost;
-      unsigned long long mHistory[PROFILER_HISTORY_LENGTH];
-      int mHistoryIdx;
+      uint32_t mHash{0};
+      unsigned long long mFrameCost{0};
+      unsigned long long mHistory[PROFILER_HISTORY_LENGTH]{};
+      int mHistoryIdx{0};
    };
    
    unsigned long long mTimerStart;

--- a/Source/Razor.cpp
+++ b/Source/Razor.cpp
@@ -74,9 +74,9 @@ Razor::Razor()
 , mModWheel(nullptr)
 , mPressure(nullptr)
 {
-   bzero(mAmp, sizeof(float) * NUM_PARTIALS);
-   bzero(mPeakHistory, sizeof(float) * (VIZ_WIDTH+1) * RAZOR_HISTORY);
-   bzero(mPhases, sizeof(float) * NUM_PARTIALS);
+   std::memset(mAmp, 0, sizeof(float) * NUM_PARTIALS);
+   std::memset(mPeakHistory, 0, sizeof(float) * (VIZ_WIDTH+1) * RAZOR_HISTORY);
+   std::memset(mPhases, 0, sizeof(float) * NUM_PARTIALS);
    
    for (int i=0; i<NUM_PARTIALS; ++i)
       mDetune[i] = 1;
@@ -273,7 +273,7 @@ void Razor::DrawViz()
       }
    }
 
-   bzero(mPeakHistory[mHistoryPtr], sizeof(float) * VIZ_WIDTH);
+   std::memset(mPeakHistory[mHistoryPtr], 0, sizeof(float) * VIZ_WIDTH);
    for (int i=1; i<=mUseNumPartials && i<=oscNyquistLimitIdx; ++i)
    {
       float height = mAdsr[i-1].Value(gTime)*mAmp[i-1];
@@ -342,7 +342,7 @@ void Razor::CalcAmp()
    float baseFreq = TheScale->PitchToFreq(mPitch);
    int oscNyquistLimitIdx = int(gNyquistLimit/baseFreq);
 
-   bzero(mAmp, sizeof(float)*NUM_PARTIALS);
+   std::memset(mAmp, 0, sizeof(float)*NUM_PARTIALS);
    for (int i=1; i<=mUseNumPartials && i<=oscNyquistLimitIdx; ++i)
    {
       if ((mHarmonicSelector == 0 && IsPrime(i)) ||
@@ -399,7 +399,7 @@ void Razor::IntSliderUpdated(IntSlider* slider, int oldVal)
 {
    if (slider == mNumPartialsSlider)
    {
-      bzero(mPhases, sizeof(float) * NUM_PARTIALS);
+      std::memset(mPhases, 0, sizeof(float) * NUM_PARTIALS);
    }
 }
 

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -61,7 +61,7 @@ bool Sample::Read(const char* path, bool mono, ReadType readType)
    
    juce::File file(ofToDataPath(mReadPath));
    delete mReader;
-   mReader = TheSynth->GetGlobalManagers()->mAudioFormatManager.createReaderFor(file);
+   mReader = TheSynth->GetAudioFormatManager().createReaderFor(file);
    
    if (mReader != nullptr)
    {

--- a/Source/Sample.h
+++ b/Source/Sample.h
@@ -29,6 +29,8 @@
 #include "OpenFrameworksPort.h"
 #include "ChannelBuffer.h"
 
+#include "juce_events/juce_events.h"
+
 class FileStreamOut;
 class FileStreamIn;
 

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -149,7 +149,7 @@ void SampleBrowser::SetDirectory(String dirPath)
    
    if (dirPath != "")
    {
-      String matcher = TheSynth->GetGlobalManagers()->mAudioFormatManager.getWildcardForAllFormats();
+      String matcher = TheSynth->GetAudioFormatManager().getWildcardForAllFormats();
 
       StringArray wildcards;
       wildcards.addTokens(matcher, ";,", "\"'");

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -807,7 +807,7 @@ void SamplePlayer::OnYoutubeSearchComplete(string searchTerm, double searchTime)
 void SamplePlayer::LoadFile()
 {
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetGlobalManagers()->mAudioFormatManager.getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -30,6 +30,8 @@
 #include "Tunings.h"
 #include "libMTSClient.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 Scale* TheScale = nullptr;
 
 Scale::Scale()

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -309,7 +309,7 @@ void SeaOfGrain::LoadFile()
 {
    using namespace juce;
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetGlobalManagers()->mAudioFormatManager.getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -40,6 +40,7 @@
 #include "exprtk/exprtk.hpp"
 
 #include "juce_audio_formats/juce_audio_formats.h"
+#include "juce_gui_basics/juce_gui_basics.h"
 
 #ifdef JUCE_MAC
 #import <execinfo.h>
@@ -91,7 +92,7 @@ void SynthInit()
    for (int i=0; i<10; ++i)
       gHotBindUIControl[i] = nullptr;
    
-   TheSynth->GetGlobalManagers()->mAudioFormatManager.registerBasicFormats();
+   TheSynth->GetAudioFormatManager().registerBasicFormats();
    
    assert(kNumVoices <= 16);  //assumption that we don't have more voices than midi channels
 }

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <list>
 #include <vector>
+#include <algorithm>
 #include <array>
 #include <math.h>
 #include <cctype>
@@ -61,11 +62,6 @@ void* operator new[](std::size_t size, const char *file, int line) throw(std::ba
 #define FTWO_PI   6.28318530717958647693f
 
 #define USE_VECTOR_OPS
-
-#if JUCE_WINDOWS
-#define popen _popen
-#define pclose _pclose
-#endif
 
 //bool labeling technique that I stole from Ableton
 #define K(x) true
@@ -115,15 +111,6 @@ extern bool gShowDevModules;
 extern float gCornerRoundness;
 extern std::random_device gRandomDevice;
 extern std::mt19937 gRandom;
-
-#include "juce_audio_devices/juce_audio_devices.h"
-#include "juce_audio_formats/juce_audio_formats.h"
-
-struct GlobalManagers
-{
-   juce::AudioDeviceManager mDeviceManager;
-   juce::AudioFormatManager mAudioFormatManager;
-};
 
 enum OscillatorType
 {
@@ -268,15 +255,6 @@ struct Vec2i
    int x;
    int y;
 };
-
-#ifdef JUCE_WINDOWS
-inline void bzero(void* mem, size_t size)
-{
-   memset(mem, 0, size);
-}
-#endif
-
-#define FIX_DENORMAL(p) JUCE_UNDENORMALISE(p)
 
 class ofLog
 {

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -30,6 +30,8 @@
 #include "IDrawableModule.h"
 #include "FileStream.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 IKeyboardFocusListener* IKeyboardFocusListener::sCurrentKeyboardFocus = nullptr;
 IKeyboardFocusListener* IKeyboardFocusListener::sKeyboardFocusBeforeClick = nullptr;
 
@@ -493,6 +495,12 @@ void TextEntry::UpdateDisplayString()
       StringCopy(mString, ofToString(*mVarInt).c_str(), MAX_TEXTENTRY_LENGTH);
    if (mVarFloat)
       StringCopy(mString, ofToString(*mVarFloat).c_str(), MAX_TEXTENTRY_LENGTH);
+}
+
+void TextEntry::ClearInput()
+{
+   std::memset(mString, 0, MAX_TEXTENTRY_LENGTH);
+   mCaretPosition = 0;
 }
 
 void TextEntry::SetValue(float value)

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -85,7 +85,7 @@ public:
    void DrawLabel(bool draw) { mDrawLabel = draw; }
    void SetRequireEnter(bool require) { mRequireEnterToAccept = require; }
    void SetFlexibleWidth(bool flex) { mFlexibleWidth = flex; }
-   void ClearInput() { bzero(mString, MAX_TEXTENTRY_LENGTH); mCaretPosition = 0; }
+   void ClearInput();
    const char* GetText() const { return mString; }
    
    void GetDimensions(float& width, float& height) override;

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -407,7 +407,7 @@ void TitleBar::DrawModule()
    mSpawnLists.mPrefabs.Draw();
    mModuleType = type;
    
-   float usage = TheSynth->GetGlobalManagers()->mDeviceManager.getCpuUsage();
+   float usage = TheSynth->GetAudioDeviceManager().getCpuUsage();
    string stats;
    stats += "fps:" + ofToString(ofGetFrameRate(),0);
    stats += "  audio cpu:" + ofToString(usage * 100,1);

--- a/Source/UIGrid.cpp
+++ b/Source/UIGrid.cpp
@@ -52,7 +52,7 @@ UIGrid::UIGrid(int x, int y, int w, int h, int cols, int rows, IClickable* paren
    SetGrid(cols,rows);
    Clear();
    SetParent(parent);
-   bzero(mDrawOffset, MAX_GRID_SIZE*sizeof(float));
+   std::memset(mDrawOffset, 0, MAX_GRID_SIZE*sizeof(float));
 }
 
 UIGrid::~UIGrid()
@@ -67,7 +67,7 @@ void UIGrid::Init(int x, int y, int w, int h, int cols, int rows, IClickable* pa
    SetGrid(cols,rows);
    Clear();
    SetParent(parent);
-   bzero(mDrawOffset, MAX_GRID_SIZE*sizeof(float));
+   std::memset(mDrawOffset, 0, MAX_GRID_SIZE*sizeof(float));
 }
 
 void UIGrid::Render()

--- a/Source/UserData.cpp
+++ b/Source/UserData.cpp
@@ -1,6 +1,8 @@
 #include "UserData.h"
 #include "OpenFrameworksPort.h"
 
+#include "juce_core/juce_core.h"
+
 void UpdateUserData(string destDirPath)
 {
    juce::File bundledDataDir(ofToResourcePath("userdata_original"));

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -31,6 +31,7 @@
 #include "UIControlMacros.h"
 
 #include "juce_audio_devices/juce_audio_devices.h"
+#include "juce_gui_basics/juce_gui_basics.h"
 
 UserPrefsEditor::UserPrefsEditor()
 {
@@ -211,7 +212,7 @@ void UserPrefsEditor::Show()
 
 void UserPrefsEditor::UpdateDropdowns(vector<DropdownList*> toUpdate)
 {
-   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetAudioDeviceManager();
 
    int i;
 
@@ -349,7 +350,7 @@ void UserPrefsEditor::DrawModule()
    DrawTextNormal("editor for userprefs.json file", 3, 15);
    DrawTextNormal("any changes will not take effect until bespoke is restarted", 3, 35);
 
-   auto& deviceManager = TheSynth->GetGlobalManagers()->mDeviceManager;
+   auto& deviceManager = TheSynth->GetAudioDeviceManager();
    auto* selectedDeviceType = mDeviceTypeIndex != -1 ? deviceManager.getAvailableDeviceTypes()[mDeviceTypeIndex] : deviceManager.getCurrentDeviceTypeObject();
    mAudioInputDeviceDropdown->SetShowing(selectedDeviceType->hasSeparateInputsAndOutputs());
 

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -37,6 +37,18 @@
 namespace
 {
    const int kGlobalModulationIdx = 16;
+   juce::String GetFileNameWithoutExtension(const juce::String &fullPath)
+   {
+       auto lastSlash = fullPath.lastIndexOfChar('/') + 1;
+       if (lastSlash == 0)
+           lastSlash = fullPath.lastIndexOfChar('\\') + 1;
+       auto lastDot   = fullPath.lastIndexOfChar ('.');
+
+       if (lastDot > lastSlash)
+           return fullPath.substring (lastSlash, lastDot);
+
+       return fullPath.substring (lastSlash);
+   }
 }
 
 //static

--- a/Source/ofxJSONElement.cpp
+++ b/Source/ofxJSONElement.cpp
@@ -10,6 +10,8 @@
 #include "ofxJSONElement.h"
 #include "SynthGlobals.h"
 
+#include "juce_core/juce_core.h"
+
 using namespace Json;
 
 


### PR DESCRIPTION
As promised, here's the more noticeable compile time wins. Resulting binary was smoke-tested on all 3 platforms.

I tried to preserve behavior as much as possible, even where it meant using less idiomatic C++. For instance, `bzero()` had to go and I replaced it with `std::memset()` instead of `std::fill()` because the latter performs worse in debug builds.