### PR TITLE
`FileStream`: Fix non-ASCII paths

### DIFF
--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -28,7 +28,7 @@
 
 #include "juce_core/juce_core.h"
 
-FileStreamOut::FileStreamOut(const char* file)
+FileStreamOut::FileStreamOut(const std::string& file)
 : mStream(std::make_unique<juce::FileOutputStream>(juce::File{file}))
 {
    mStream->setPosition(0);
@@ -40,7 +40,7 @@ FileStreamOut::~FileStreamOut()
    mStream->flush();
 }
 
-FileStreamIn::FileStreamIn(const char* file)
+FileStreamIn::FileStreamIn(const std::string& file)
 : mStream(std::make_unique<juce::FileInputStream>(juce::File{file}))
 {
 }

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -38,7 +38,8 @@ namespace juce {
 class FileStreamOut
 {
 public:
-   explicit FileStreamOut(const char* file);
+   explicit FileStreamOut(const std::string& file);
+   FileStreamOut(const char*) = delete; // Hint: UTF-8 encoded std::string required
    ~FileStreamOut();
    FileStreamOut& operator<<(const int& var);
    FileStreamOut& operator<<(const std::uint32_t &var);
@@ -56,7 +57,8 @@ private:
 class FileStreamIn
 {
 public:
-   explicit FileStreamIn(const char* file);
+   explicit FileStreamIn(const std::string& file);
+   FileStreamIn(const char*) = delete; // Hint: UTF-8 encoded std::string required
    ~FileStreamIn();
    FileStreamIn& operator>>(int& var);
    FileStreamIn& operator>>(std::uint32_t &var);

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2208,7 +2208,7 @@ void ModularSynth::LogEvent(string event, LogEventType type)
 IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
 {
    {
-      FileStreamOut out(ofToDataPath("tmp").c_str());
+      FileStreamOut out(ofToDataPath("tmp"));
       module->SaveState(out);
    }
    
@@ -2229,7 +2229,7 @@ IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
    newModule->SetName(module->Name()); //temporarily rename to the same as what we duplicated, so we can load state properly
    
    {
-      FileStreamIn in(ofToDataPath("tmp").c_str());
+      FileStreamIn in(ofToDataPath("tmp"));
       mIsLoadingModule = true;
       newModule->LoadState(in);
       mIsLoadingModule = false;
@@ -2314,7 +2314,7 @@ void ModularSynth::SaveState(string file, bool autosave)
 
    mAudioThreadMutex.Lock("SaveState()");
    
-   FileStreamOut out(file.c_str());
+   FileStreamOut out(file);
    
    out << GetLayout().getRawString(true);
    mModuleContainer.SaveState(out);
@@ -2342,7 +2342,7 @@ void ModularSynth::LoadState(string file)
    LockRender(false);
    mAudioThreadMutex.Unlock();
    
-   FileStreamIn in(ofToDataPath(file).c_str());
+   FileStreamIn in(ofToDataPath(file));
    
    string jsonString;
    in >> jsonString;

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -257,7 +257,7 @@ void Prefab::SavePrefab(string savePath)
    
    UpdatePrefabName(savePath);
    
-   FileStreamOut out(ofToDataPath(savePath).c_str());
+   FileStreamOut out(ofToDataPath(savePath));
    
    out << lines;
    mModuleContainer.SaveState(out);
@@ -272,7 +272,7 @@ void Prefab::LoadPrefab(string loadPath)
    
    mModuleContainer.Clear();
    
-   FileStreamIn in(ofToDataPath(loadPath).c_str());
+   FileStreamIn in(ofToDataPath(loadPath));
 
    assert(in.OpenedOk());
    


### PR DESCRIPTION
With such paths, loading would crash and saving would silently fail or create files with a garbage name.

`juce::File*Stream` ctors take a `juce::File`, whose ctor in turn takes a `juce::String`. When constructing a `juce::String` from `std::string`, input is assumed to be UTF-8. When constructing from `char*`, it's assumed to be 7-bit ASCII. The encoding can be specified via `juce::CharPointer_UTF8` & friends, but that's cumbersome and we don't want complete JUCE types at the `FileStream` interface.

So this simply deletes the `char*` ctor overloads and only accepts `std::string`s. These are UTF-8 at all current call sites because they come from `juce::File`s.