### PR TITLE
299 Two crashes on livestreaming, typically doing lots of stuff with multiple sequencers and connections all over everywhere

### DIFF
--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -58,13 +58,15 @@ struct ScalePitches
 {
    int mScaleRoot;
    string mScaleType;
-   vector<int> mScalePitches;
+   vector<int> mScalePitches[2]; //double-buffered to avoid thread safety issues when modifying
+   int mScalePitchesFlip{0};
    std::vector<Accidental> mAccidentals;
    
    void SetRoot(int root);
    void SetScaleType(string type);
    void SetAccidentals(const std::vector<Accidental>& accidentals);
    
+   const vector<int>& GetPitches() const { return mScalePitches[mScalePitchesFlip]; }
    int ScaleRoot() const { return mScaleRoot; }
    string GetType() const { return mScaleType; }
    void GetChordDegreeAndAccidentals(const Chord& chord, int& degree, std::vector<Accidental>& accidentals) const;
@@ -76,7 +78,7 @@ struct ScalePitches
    bool IsInScale(int pitch) const;
    int GetPitchFromTone(int n) const;
    int GetToneFromPitch(int pitch) const;
-   int NumPitchesInScale() const { return (int)mScalePitches.size(); }
+   int NumPitchesInScale() const { return (int)mScalePitches[mScalePitchesFlip].size(); }
 };
 
 class MTSClient;

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -91,12 +91,12 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
    });
    m.def("get_scale", []()
    {
-      return TheScale->GetScalePitches().mScalePitches;
+      return TheScale->GetScalePitches().GetPitches();
    });
    m.def("get_scale_range", [](int octave, int count)
    {
       int root = TheScale->ScaleRoot();
-      auto scalePitches = TheScale->GetScalePitches().mScalePitches;
+      auto scalePitches = TheScale->GetScalePitches().GetPitches();
       size_t numPitches = scalePitches.size();
       vector<int> ret(count);
       for (int i=0; i<count; ++i)


### PR DESCRIPTION
this solution was to double-buffer the list of pitches. I could reproduce the issue pretty quickly before this fix, and no longer can