### PR TITLE
Fix most deprecation warnings

### DIFF
--- a/Source/ControllingSong.cpp
+++ b/Source/ControllingSong.cpp
@@ -89,7 +89,7 @@ void ControllingSong::Init()
       mSongSelector->AddLabel(title.c_str(), i);
    }
    
-   random_shuffle(mShuffleList.begin(), mShuffleList.end());
+   std::shuffle(begin(mShuffleList), end(mShuffleList), std::mt19937(std::random_device()()));
 }
 
 void ControllingSong::Poll()
@@ -104,7 +104,7 @@ void ControllingSong::Poll()
          if (mShuffleIndex == mSongList["songs"].size())
          {
             mShuffleIndex = 0;
-            random_shuffle(mShuffleList.begin(), mShuffleList.end());
+            std::shuffle(begin(mShuffleList), end(mShuffleList), std::mt19937(std::random_device()()));
          }
       }
       else

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -68,8 +68,11 @@ public:
       int screenWidth, screenHeight;
       {
          const MessageManagerLock lock;
-         mPixelRatio = Desktop::getInstance().getDisplays().getMainDisplay().scale;
-         TheSynth->SetPixelRatio(mPixelRatio);
+         if (const auto* dpy = Desktop::getInstance().getDisplays().getPrimaryDisplay())
+         {
+            mPixelRatio = dpy->scale;
+            TheSynth->SetPixelRatio(mPixelRatio);
+         }
          auto bounds = Desktop::getInstance().getDisplays().getTotalBounds(true);
          screenWidth = bounds.getWidth();
          screenHeight = bounds.getHeight();
@@ -137,8 +140,11 @@ public:
 
       if (sRenderFrame % 30 == 0)
       {
-         mPixelRatio = Desktop::getInstance().getDisplays().findDisplayForRect(getScreenBounds()).scale; //adjust pixel ratio based on which screen has the majority of the window
-         TheSynth->SetPixelRatio(mPixelRatio);
+         if (const auto* dpy = Desktop::getInstance().getDisplays().getDisplayForRect(getScreenBounds()))
+         {
+            mPixelRatio = dpy->scale; //adjust pixel ratio based on which screen has the majority of the window
+            TheSynth->SetPixelRatio(mPixelRatio);
+         }
       }
       
       mScreenPosition = getScreenPosition();

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -920,17 +920,13 @@ void ScriptModule::RefreshStyleFiles()
 
 void ScriptModule::RefreshScriptFiles()
 {
-   DirectoryIterator dir(File(ofToDataPath("scripts")), false);
    mScriptFilePaths.clear();
    mLoadScriptSelector->Clear();
-   while(dir.next())
+   for (const auto& entry : RangedDirectoryIterator{File{ofToDataPath("scripts")}, false, "*.py"})
    {
-      File file = dir.getFile();
-      if (file.getFileExtension() ==  ".py")
-      {
-         mLoadScriptSelector->AddLabel(file.getFileName().toStdString(), (int)mScriptFilePaths.size());
-         mScriptFilePaths.push_back(file.getFullPathName().toStdString());
-      }
+      const auto& file = entry.getFile();
+      mLoadScriptSelector->AddLabel(file.getFileName().toStdString(), (int)mScriptFilePaths.size());
+      mScriptFilePaths.push_back(file.getFullPathName().toStdString());
    }
 }
 

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -265,20 +265,16 @@ void TitleBar::ListLayouts()
 {
    mLoadLayoutDropdown->Clear();
    
-   juce::DirectoryIterator dir(juce::File(ofToDataPath("layouts")), false);
    int layoutIdx = 0;
-   while (dir.next())
+   for (const auto& entry : juce::RangedDirectoryIterator{juce::File{ofToDataPath("layouts")}, false, "*.json"})
    {
-      juce::File file = dir.getFile();
-      if (file.getFileExtension() == ".json")
-      {
-         mLoadLayoutDropdown->AddLabel(file.getFileNameWithoutExtension().toRawUTF8(), layoutIdx);
-         
-         if (file.getRelativePathFrom(juce::File(ofToDataPath(""))).toStdString() == TheSynth->GetLoadedLayout())
-            mLoadLayoutIndex = layoutIdx;
-         
-         ++layoutIdx;
-      }
+      const auto& file = entry.getFile();
+      mLoadLayoutDropdown->AddLabel(file.getFileNameWithoutExtension().toRawUTF8(), layoutIdx);
+
+      if (file.getRelativePathFrom(juce::File{ofToDataPath("")}).toStdString() == TheSynth->GetLoadedLayout())
+         mLoadLayoutIndex = layoutIdx;
+
+      ++layoutIdx;
    }
    
    mSaveLayoutButton->PositionTo(mLoadLayoutDropdown, kAnchor_Right);

--- a/Source/UserData.cpp
+++ b/Source/UserData.cpp
@@ -45,15 +45,13 @@ void UpdateUserData(string destDirPath)
       ofLog() << "copying data from "+bundledDataDir.getFullPathName().toStdString()+" to "+destDirPath;
       destDataDir.createDirectory();
       
-      juce::DirectoryIterator directories(bundledDataDir, true, "*", juce::File::findDirectories);
-      while (directories.next())
+      for (const auto& entry : juce::RangedDirectoryIterator{bundledDataDir, true, "*", juce::File::findDirectories})
       {
-         juce::String destDirName = juce::String(destDirPath) + "/" + directories.getFile().getRelativePathFrom(bundledDataDir);
+         juce::String destDirName = juce::String(destDirPath) + "/" + entry.getFile().getRelativePathFrom(bundledDataDir);
          juce::File(destDirName).createDirectory();
       }
 
-      juce::DirectoryIterator entry(bundledDataDir, true);
-      while (entry.next())
+      for (const auto& entry : juce::RangedDirectoryIterator{bundledDataDir, true})
       {
          juce::String sourceFileName = entry.getFile().getFullPathName();
          juce::String destFileName = juce::String(destDirPath) + "/" + entry.getFile().getRelativePathFrom(bundledDataDir);

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -905,17 +905,13 @@ void VSTPlugin::RefreshPresetFiles()
       return;
    
    juce::File(ofToDataPath("vst/presets/"+ GetPluginId())).createDirectory();
-   DirectoryIterator dir(File(ofToDataPath("vst/presets/"+ GetPluginId())), false);
    mPresetFilePaths.clear();
    mPresetFileSelector->Clear();
-   while(dir.next())
+   for (const auto& entry : RangedDirectoryIterator{File{ofToDataPath("vst/presets/" + GetPluginId())}, false, "*.vstp"})
    {
-      File file = dir.getFile();
-      if (file.getFileExtension() ==  ".vstp")
-      {
-         mPresetFileSelector->AddLabel(file.getFileName().toStdString(), (int)mPresetFilePaths.size());
-         mPresetFilePaths.push_back(file.getFullPathName().toStdString());
-      }
+      const auto& file = entry.getFile();
+      mPresetFileSelector->AddLabel(file.getFileName().toStdString(), (int)mPresetFilePaths.size());
+      mPresetFilePaths.push_back(file.getFullPathName().toStdString());
    }
 }
 

--- a/Source/VSTWindow.cpp
+++ b/Source/VSTWindow.cpp
@@ -43,12 +43,14 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
    setSize (400, 300);
    
    setContentOwned (pluginEditor, true);
-   
-   auto mainMon = juce::Desktop::getInstance().getDisplays().findDisplayForRect(TheSynth->GetMainComponent()->getScreenBounds()).userArea;
 
-   setTopLeftPosition(mainMon.getX() + mainMon.getWidth() / 4,
-                      mainMon.getY() + mainMon.getHeight() / 4);
-   
+   if (const auto* dpy = juce::Desktop::getInstance().getDisplays().getDisplayForRect(TheSynth->GetMainComponent()->getScreenBounds()))
+   {
+      const auto& mainMon = dpy->userArea;
+      setTopLeftPosition(mainMon.getX() + mainMon.getWidth() / 4,
+                         mainMon.getY() + mainMon.getHeight() / 4);
+   }
+
    setVisible (true);
    
 #ifdef JUCE_MAC
@@ -74,7 +76,7 @@ VSTWindow* VSTWindow::CreateWindow(VSTPlugin* vst, WindowFormatType type)
    if (ui == nullptr)
    {
       if (type == Generic || type == Parameters)
-         ui = new juce::GenericAudioProcessorEditor (vst->GetAudioProcessor());
+         ui = new juce::GenericAudioProcessorEditor (*vst->GetAudioProcessor());
       else if (type == Programs)
          ui = new ProgramAudioProcessorEditor (vst->GetAudioProcessor());
    }

--- a/Source/push2/push2/Push2-Usb-Communicator.cpp
+++ b/Source/push2/push2/Push2-Usb-Communicator.cpp
@@ -57,7 +57,11 @@ namespace
       return NBase::Result("Failed to initialize usblib");
     }
 
+#if LIBUSB_API_VERSION >= 0x01000106
+    libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_ERROR);
+#else
     libusb_set_debug(NULL, LIBUSB_LOG_LEVEL_ERROR);
+#endif
 
     // Get a list of connected devices
     libusb_device** devices;

--- a/libs/leathers/leathers/range-loop-analysis
+++ b/libs/leathers/leathers/range-loop-analysis
@@ -22,12 +22,3 @@
 #  pragma clang diagnostic ignored "-Wrange-loop-analysis"
 # endif
 #endif
-
-#if (__GNUC__)
-# pragma GCC diagnostic ignored "-Wrange-loop-analysis"
-#endif
-
-//unsure what the MSVC code is for this
-//#if (_MSC_VER)
-//# pragma warning(disable: 4XXX)
-//#endif


### PR DESCRIPTION
These were starting to get annoying. The only remaining deprecation warning is in the `libusb` macOS implementation. It will be addressed in a separate PR that deals with `push2`.

---

- Migrate away from deprecated C++, JUCE and libusb API
- Remove `-Wrange-loop-analysis` pragma (GCC does not implement this warning, so it warns about the pragma itself)