### PR TITLE
Purge "using namespace std" from the code base

### DIFF
--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -55,10 +55,10 @@ ADSRDisplay::ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y,
    if (floatListener)
    {
       int sliderHeight = h/4;
-      mASlider = new FloatSlider(floatListener,(string(name)+"A").c_str(),x,y,w,sliderHeight,&(mAdsr->GetA()),1,1000);
-      mDSlider = new FloatSlider(floatListener,(string(name)+"D").c_str(),x,y+sliderHeight,w,sliderHeight,&(mAdsr->GetD()),0,1000);
-      mSSlider = new FloatSlider(floatListener,(string(name)+"S").c_str(),x,y+sliderHeight*2,w,sliderHeight,&(mAdsr->GetS()),0,1);
-      mRSlider = new FloatSlider(floatListener,(string(name)+"R").c_str(),x,y+sliderHeight*3,w,sliderHeight,&(mAdsr->GetR()),1,1000);
+      mASlider = new FloatSlider(floatListener,(std::string(name)+"A").c_str(),x,y,w,sliderHeight,&(mAdsr->GetA()),1,1000);
+      mDSlider = new FloatSlider(floatListener,(std::string(name)+"D").c_str(),x,y+sliderHeight,w,sliderHeight,&(mAdsr->GetD()),0,1000);
+      mSSlider = new FloatSlider(floatListener,(std::string(name)+"S").c_str(),x,y+sliderHeight*2,w,sliderHeight,&(mAdsr->GetS()),0,1);
+      mRSlider = new FloatSlider(floatListener,(std::string(name)+"R").c_str(),x,y+sliderHeight*3,w,sliderHeight,&(mAdsr->GetR()),1,1000);
       
       mASlider->SetMode(FloatSlider::kSquare);
       mDSlider->SetMode(FloatSlider::kSquare);

--- a/Source/Amplifier.h
+++ b/Source/Amplifier.h
@@ -39,7 +39,7 @@ public:
    virtual ~Amplifier();
    static IDrawableModule* Create() { return new Amplifier(); }
    
-   string GetTitleLabel() override { return "gain"; }
+   std::string GetTitleLabel() override { return "gain"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Arpeggiator.cpp
+++ b/Source/Arpeggiator.cpp
@@ -93,12 +93,12 @@ void Arpeggiator::DrawModule()
    mOctaveRepeatsSlider->Draw();
    
    ofSetColor(200,200,200,gModuleDrawAlpha);
-   string chord;
+   std::string chord;
    for (int i=0; i<mChord.size(); ++i)
       chord += GetArpNoteDisplay(mChord[i].pitch) + " ";
    DrawTextNormal(chord,5,16);
    ofSetColor(0,255,0,gModuleDrawAlpha);
-   string pad;
+   std::string pad;
    for (int i=0; i<mChord.size(); ++i)
    {
       if (i != mArpIndex)
@@ -121,7 +121,7 @@ void Arpeggiator::OnScaleChanged()
    mChordMutex.unlock();
 }
 
-string Arpeggiator::GetArpNoteDisplay(int pitch)
+std::string Arpeggiator::GetArpNoteDisplay(int pitch)
 {
    return NoteName(pitch, false, true);
 }

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -45,7 +45,7 @@ public:
    ~Arpeggiator();
    static IDrawableModule* Create() { return new Arpeggiator(); }
    
-   string GetTitleLabel() override { return "arpeggiator"; }
+   std::string GetTitleLabel() override { return "arpeggiator"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -86,7 +86,7 @@ private:
    bool Enabled() const override { return mEnabled; }
    void OnClicked(int x, int y, bool right) override;
    
-   string GetArpNoteDisplay(int pitch);
+   std::string GetArpNoteDisplay(int pitch);
    void UpdateInterval();
    
    struct ArpNote
@@ -97,7 +97,7 @@ private:
       int voiceIdx;
       ModulationParameters modulation;
    };
-   vector<ArpNote> mChord;
+   std::vector<ArpNote> mChord;
 
    float mWidth;
    float mHeight;

--- a/Source/AudioLevelToCV.cpp
+++ b/Source/AudioLevelToCV.cpp
@@ -148,7 +148,7 @@ void AudioLevelToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioLevelToCV();
    static IDrawableModule* Create() { return new AudioLevelToCV(); }
    
-   string GetTitleLabel() override { return "level to cv"; }
+   std::string GetTitleLabel() override { return "level to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -39,7 +39,7 @@ public:
    virtual ~AudioMeter();
    static IDrawableModule* Create() { return new AudioMeter(); }
    
-   string GetTitleLabel() override { return "audiometer"; }
+   std::string GetTitleLabel() override { return "audiometer"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/AudioRouter.cpp
+++ b/Source/AudioRouter.cpp
@@ -119,7 +119,7 @@ void AudioRouter::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
       if (cableSource == mDestinationCables[i])
       {
          IClickable* target = cableSource->GetTarget();
-         string name = target ? target->Name() : "                      ";
+         std::string name = target ? target->Name() : "                      ";
          mRouteSelector->SetLabel(name.c_str(), i);
       }
    }

--- a/Source/AudioRouter.h
+++ b/Source/AudioRouter.h
@@ -39,7 +39,7 @@ public:
    virtual ~AudioRouter();
    static IDrawableModule* Create() { return new AudioRouter(); }
    
-   string GetTitleLabel() override { return "audio router"; }
+   std::string GetTitleLabel() override { return "audio router"; }
    void CreateUIControls() override;
 
    void SetActiveIndex(int index) { mRouteIndex = index; }
@@ -66,10 +66,10 @@ private:
 
    int mRouteIndex;
    RadioButton* mRouteSelector;
-   vector<PatchCableSource*> mDestinationCables;
+   std::vector<PatchCableSource*> mDestinationCables;
    RollingBuffer mBlankVizBuffer;
    
-   array<Ramp,16> mSwitchAndRampIn;
+   std::array<Ramp,16> mSwitchAndRampIn;
    int mLastProcessedRouteIndex;
 };
 

--- a/Source/AudioSend.h
+++ b/Source/AudioSend.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioSend();
    static IDrawableModule* Create() { return new AudioSend(); }
    
-   string GetTitleLabel() override { return "send"; }
+   std::string GetTitleLabel() override { return "send"; }
    void CreateUIControls() override;
 
    void SetSend(float amount, bool crossfade) { mAmount = amount; mCrossfade = crossfade; }

--- a/Source/AudioToCV.cpp
+++ b/Source/AudioToCV.cpp
@@ -116,7 +116,7 @@ void AudioToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioToCV();
    static IDrawableModule* Create() { return new AudioToCV(); }
    
-   string GetTitleLabel() override { return "audio to cv"; }
+   std::string GetTitleLabel() override { return "audio to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/AudioToPulse.h
+++ b/Source/AudioToPulse.h
@@ -41,7 +41,7 @@ public:
    virtual ~AudioToPulse();
    static IDrawableModule* Create() { return new AudioToPulse(); }
 
-   string GetTitleLabel() override { return "audio to pulse"; }
+   std::string GetTitleLabel() override { return "audio to pulse"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Autotalent.cpp
+++ b/Source/Autotalent.cpp
@@ -933,7 +933,7 @@ void Autotalent::Process(double time)
    mLatency = (N-1);
 }
 
-string Autotalent::GetTitleLabel()
+std::string Autotalent::GetTitleLabel()
 {
    if (Minimized())
       return "autotalent";

--- a/Source/Autotalent.h
+++ b/Source/Autotalent.h
@@ -44,7 +44,7 @@ public:
    ~Autotalent();
    static IDrawableModule* Create() { return new Autotalent(); }
    
-   string GetTitleLabel() override;
+   std::string GetTitleLabel() override;
    void CreateUIControls() override;
 
    //IAudioReceiver

--- a/Source/BandVocoder.h
+++ b/Source/BandVocoder.h
@@ -45,7 +45,7 @@ public:
    virtual ~BandVocoder();
    static IDrawableModule* Create() { return new BandVocoder(); }
    
-   string GetTitleLabel() override { return "vocoder"; }
+   std::string GetTitleLabel() override { return "vocoder"; }
    void CreateUIControls() override;
    
    void SetCarrierBuffer(float* carrier, int bufferSize) override;

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -288,7 +288,7 @@ void BeatBloks::Process(double time)
    GetVizBuffer()->WriteChunk(out, bufferSize, 0);
 }
 
-void BeatBloks::FilesDropped(vector<string> files, int x, int y)
+void BeatBloks::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mLoading = true;
    
@@ -298,8 +298,8 @@ void BeatBloks::FilesDropped(vector<string> files, int x, int y)
    
    ResetRead();
    
-   vector<string> tokens = ofSplitString(files[0].c_str(), GetPathSeparator());
-   string cachedFilename = tokens[tokens.size()-1].c_str();
+   std::vector<std::string> tokens = ofSplitString(files[0].c_str(), GetPathSeparator());
+   std::string cachedFilename = tokens[tokens.size()-1].c_str();
    tokens = ofSplitString(cachedFilename, ".");
    cachedFilename = tokens[0]+".cached";
    bool hasCached = juce::File(ofToDataPath(cachedFilename)).existsAsFile();
@@ -381,7 +381,7 @@ void BeatBloks::ResetRead()
 
 void BeatBloks::ReadEchonestLine(const char* line)
 {
-   vector<string> tokens = ofSplitString(line," ");
+   std::vector<std::string> tokens = ofSplitString(line," ");
    if (tokens.size() == 1)
    {
       if (tokens[0] == "bars")
@@ -487,14 +487,14 @@ void BeatBloks::ButtonClicked(ClickButton *button)
    
    if (button == mGetLuckyButton)
    {
-      vector<string> fake;
+      std::vector<std::string> fake;
       fake.push_back(ofToDataPath("Daft Punk - Get Lucky.mp3",true));
       FilesDropped(fake, 0, 0);
       mOffset = -53275;
    }
    if (button == mLoseYourselfButton)
    {
-      vector<string> fake;
+      std::vector<std::string> fake;
       fake.push_back(ofToDataPath("Daft Punk - Lose Yourself To Dance.mp3",true));
       FilesDropped(fake, 0, 0);
    }
@@ -710,7 +710,7 @@ void BeatBloks::DrawModule()
       if (mBars.size() != 0)
       {
          ofSetColor(0,255,255,60);
-         vector<Blok>& drawBloks = mNothing;
+         std::vector<Blok>& drawBloks = mNothing;
          switch (mDrawBlokType)
          {
             case kBlok_Bar:

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -50,7 +50,7 @@ public:
    ~BeatBloks();
    static IDrawableModule* Create() { return new BeatBloks(); }
    
-   string GetTitleLabel() override { return "BEAT BLOKS by @awwbees"; }
+   std::string GetTitleLabel() override { return "BEAT BLOKS by @awwbees"; }
    void CreateUIControls() override;
    
    //INoteReceiver
@@ -62,7 +62,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void Poll() override;
    
    //IClickable
@@ -158,12 +158,12 @@ private:
    bool mWantWrite;
    ClickButton* mDoubleLengthButton;
    ClickButton* mHalveLengthButton;
-   vector<Blok> mBars;
-   vector<Blok> mBeats;
-   vector<Blok> mTatums;
-   vector<Blok> mSections;
-   vector<Blok> mSegments;
-   vector<Blok> mNothing;
+   std::vector<Blok> mBars;
+   std::vector<Blok> mBeats;
+   std::vector<Blok> mTatums;
+   std::vector<Blok> mSections;
+   std::vector<Blok> mSegments;
+   std::vector<Blok> mNothing;
    BlokType mDrawBlokType;
    DropdownList* mDrawBlokTypeDropdown;
    bool mLoading;
@@ -178,7 +178,7 @@ private:
    float mRemixPlayhead;
    bool mPlayRemix;
    Checkbox* mPlayRemixCheckbox;
-   list<Blok*> mRemixBloks;
+   std::list<Blok*> mRemixBloks;
    JumpBlender mRemixJumpBlender;
    Blok* mLastPlayedRemixBlok;
    float mLastLookupPlayhead;

--- a/Source/Beats.cpp
+++ b/Source/Beats.cpp
@@ -122,7 +122,7 @@ void Beats::DrawModule()
    }
 }
 
-void Beats::FilesDropped(vector<string> files, int x, int y)
+void Beats::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    for (auto file : files)
    {

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -86,7 +86,7 @@ private:
    Checkbox* mDoubleTimeCheckbox;
    int mNumBars;
    IntSlider* mNumBarsSlider;
-   vector<Sample*> mSamples;
+   std::vector<Sample*> mSamples;
    float mPan;
    FloatSlider* mPanSlider;
 };
@@ -98,7 +98,7 @@ public:
    virtual ~Beats();
    static IDrawableModule* Create() { return new Beats(); }
    
-   string GetTitleLabel() override { return "beats"; }
+   std::string GetTitleLabel() override { return "beats"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -108,7 +108,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    

--- a/Source/BiquadFilterEffect.h
+++ b/Source/BiquadFilterEffect.h
@@ -43,7 +43,7 @@ public:
    
    static IAudioEffect* Create() { return new BiquadFilterEffect(); }
    
-   string GetTitleLabel() override { return "biquad"; }
+   std::string GetTitleLabel() override { return "biquad"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -56,7 +56,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "biquad"; }
+   std::string GetType() override { return "biquad"; }
    
    bool MouseMoved(float x, float y) override;
 

--- a/Source/BitcrushEffect.h
+++ b/Source/BitcrushEffect.h
@@ -38,14 +38,14 @@ public:
    
    static IAudioEffect* Create() { return new BitcrushEffect(); }
    
-   string GetTitleLabel() override { return "bitcrush"; }
+   std::string GetTitleLabel() override { return "bitcrush"; }
    void CreateUIControls() override;
    
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "bitcrush"; }
+   std::string GetType() override { return "bitcrush"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void IntSliderUpdated(IntSlider* slider, int oldVal) override;

--- a/Source/ButterworthFilterEffect.h
+++ b/Source/ButterworthFilterEffect.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new ButterworthFilterEffect(); }
    
-   string GetTitleLabel() override { return "butterworth"; }
+   std::string GetTitleLabel() override { return "butterworth"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -52,7 +52,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "butterworth"; }
+   std::string GetType() override { return "butterworth"; }
    
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/CFMessaging/KontrolKommunicator.cpp
+++ b/Source/CFMessaging/KontrolKommunicator.cpp
@@ -59,21 +59,21 @@ void KontrolKommunicator::OutputRawData2(const uint8_t* data, size_t length)
 {
    for (int i=0; i<length; ++i)
    {
-      cout << ofToString(data[i]);
+      std::cout << ofToString(data[i]);
       if (i%4 == 3)
-         cout << " ";
+         std::cout << " ";
    }
-   cout << "\n";
+   std::cout << "\n";
    for (int i=0; i<length; ++i)
    {
-      cout << FormatString("%02x ", data[i]);
+      std::cout << FormatString("%02x ", data[i]);
       if (i%4 == 3)
-         cout << " ";
+         std::cout << " ";
    }
-   cout << "\n";
+   std::cout << "\n";
 }
 
-CFDataRef KontrolKommunicator::OnMessageReceived(string portname, SInt32 msgid, CFDataRef data)
+CFDataRef KontrolKommunicator::OnMessageReceived(std::string portname, SInt32 msgid, CFDataRef data)
 {
    vm_address_t vmData;
    vm_allocate(mach_task_self(),  &vmData, (vm_size_t)vm_page_size, TRUE);
@@ -120,7 +120,7 @@ CFDataRef KontrolKommunicator::OnMessageReceived(string portname, SInt32 msgid, 
    return reply;
 }
 
-CFDataRef KontrolKommunicator::ProcessIncomingMessage(string portName, char* data, size_t length)
+CFDataRef KontrolKommunicator::ProcessIncomingMessage(std::string portName, char* data, size_t length)
 {
    KDataArray input;
    input.resize(length);
@@ -203,7 +203,7 @@ uint16_t KontrolKommunicator::CharToSegments(char input)
 }
 
 //static
-KDataArray KontrolKommunicator::LettersToData(string input)
+KDataArray KontrolKommunicator::LettersToData(std::string input)
 {
    KDataArray data;
    data.resize(input.length()*2);
@@ -279,7 +279,7 @@ void KontrolKommunicator::Update()
    mMessageQueueMutex.unlock();
 }
 
-void KontrolKommunicator::SendMessage(string portName, KDataArray data)
+void KontrolKommunicator::SendMessage(std::string portName, KDataArray data)
 {
    if (mSendPorts.find(portName) == mSendPorts.end())
       CreateSender(portName.c_str());
@@ -322,7 +322,7 @@ void KontrolKommunicator::SendMessage(string portName, KDataArray data)
    }
 }
 
-void KontrolKommunicator::AddReply(string portName, string input, string reply)
+void KontrolKommunicator::AddReply(std::string portName, std::string input, std::string reply)
 {
    ReplyEntry entry;
    entry.mPort = portName;
@@ -331,7 +331,7 @@ void KontrolKommunicator::AddReply(string portName, string input, string reply)
    mReplies.push_back(entry);
 }
 
-void KontrolKommunicator::QueueMessage(string portName, KDataArray message)
+void KontrolKommunicator::QueueMessage(std::string portName, KDataArray message)
 {
    QueuedMessage entry;
    entry.mPort = portName;
@@ -341,10 +341,10 @@ void KontrolKommunicator::QueueMessage(string portName, KDataArray message)
    mMessageQueueMutex.unlock();
 }
 
-KDataArray KontrolKommunicator::RespondToMessage(string portName, KDataArray input)
+KDataArray KontrolKommunicator::RespondToMessage(std::string portName, KDataArray input)
 {
    uint32_t messageID = *((uint32_t*)input.data());
-   string type = TypeForMessageID(messageID);
+   std::string type = TypeForMessageID(messageID);
    
    //fake software responses
    if (portName == mNotificationPort)
@@ -391,7 +391,7 @@ int WordAlign(int input)
    return (input + 3) / 4 * 4;
 }
 
-void KontrolKommunicator::FollowUpToReply(string messageType, uint8_t* reply)
+void KontrolKommunicator::FollowUpToReply(std::string messageType, uint8_t* reply)
 {
    //fake software followups
    if (messageType == "NIGetServiceVersionMessage")
@@ -431,7 +431,7 @@ void KontrolKommunicator::FollowUpToReply(string messageType, uint8_t* reply)
    }
 }
 
-KDataArray KontrolKommunicator::CreateMessage(string type)
+KDataArray KontrolKommunicator::CreateMessage(std::string type)
 {
    uint32_t messageID = MessageIDForType(type);
    KDataArray ret(messageID);
@@ -483,23 +483,23 @@ KDataArray KontrolKommunicator::CreateMessage(string type)
    return ret;
 }
 
-void KontrolKommunicator::Output(string str)
+void KontrolKommunicator::Output(std::string str)
 {
    return;
    
-   cout << str;
+   std::cout << str;
 }
 
-string KontrolKommunicator::FormatString(string format, int number)
+std::string KontrolKommunicator::FormatString(std::string format, int number)
 {
    char buffer[100];
    sprintf(buffer, format.c_str(), number);
-   return (string)buffer;
+   return (std::string)buffer;
 }
 
-KDataArray KontrolKommunicator::StringToData(string input)
+KDataArray KontrolKommunicator::StringToData(std::string input)
 {
-   vector<string> tokens = ofSplitString(input, " ", true);
+   std::vector<std::string> tokens = ofSplitString(input, " ", true);
    size_t length = tokens.size();
    KDataArray data;
    data.resize(length);
@@ -580,7 +580,7 @@ void KontrolKommunicator::OutputRawData(const uint8_t* data, size_t length)
    Output("\n");
 }
 
-void KontrolKommunicator::SetDisplay(const uint16_t sliders[72], string display)
+void KontrolKommunicator::SetDisplay(const uint16_t sliders[72], std::string display)
 {
    KDataArray text(MessageIDForType("NIDisplayDrawMessage"));
    text += StringToData("00 00 00 00  00 00 00 00  03 00 48 00  b0 01 00 00");   //some sort of header

--- a/Source/CFMessaging/KontrolKommunicator.h
+++ b/Source/CFMessaging/KontrolKommunicator.h
@@ -32,8 +32,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include "../OpenFrameworksPort.h"
 
-using namespace std;
-
 class KDataArray
 {
 public:
@@ -41,7 +39,7 @@ public:
    KDataArray(uint8_t val) { mData.assign(&val, &val+1); }
    KDataArray(uint16_t val) { mData.assign(((uint8_t*)&val), ((uint8_t*)&val)+2); }
    KDataArray(uint32_t messageId) { mData.assign(((uint8_t*)&messageId), ((uint8_t*)&messageId)+4); }
-   KDataArray(string input) { mData.assign(input.c_str(), input.c_str()+input.length()+1); }
+   KDataArray(std::string input) { mData.assign(input.c_str(), input.c_str()+input.length()+1); }
    uint8_t* data() { return mData.data(); }
    void resize(size_t size) { mData.resize(size); }
    size_t size() const { return mData.size(); }
@@ -51,19 +49,19 @@ public:
    KDataArray operator+(const KDataArray& b) { mData.insert(mData.end(), b.mData.begin(), b.mData.end()); return *this; }
    void operator+=(const KDataArray& b) { mData.insert(mData.end(), b.mData.begin(), b.mData.end()); }
 private:
-   vector<uint8_t> mData;
+   std::vector<uint8_t> mData;
 };
 
 struct ReplyEntry
 {
-   string mPort;
+   std::string mPort;
    KDataArray mInput;
    KDataArray mReply;
 };
 
 struct QueuedMessage
 {
-   string mPort;
+   std::string mPort;
    KDataArray mMessage;
 };
 
@@ -84,28 +82,28 @@ public:
    void Init();
    void Exit();
    void CreateListener(const char* portName);
-   CFDataRef OnMessageReceived(string portName, SInt32 msgid, CFDataRef data) override;
-   void AddReply(string portName, string input, string reply);
-   void QueueMessage(string portName, KDataArray message);
+   CFDataRef OnMessageReceived(std::string portName, SInt32 msgid, CFDataRef data) override;
+   void AddReply(std::string portName, std::string input, std::string reply);
+   void QueueMessage(std::string portName, KDataArray message);
    void Update();
-   static KDataArray StringToData(string input);
-   static KDataArray LettersToData(string letters);
+   static KDataArray StringToData(std::string input);
+   static KDataArray LettersToData(std::string letters);
    static uint16_t CharToSegments(char input);
-   KDataArray CreateMessage(string type);
+   KDataArray CreateMessage(std::string type);
    
    bool IsReady() const { return mState == kState_Focused; }
    void SetListener(IKontrolListener* listener) { mListener = listener; }
-   void SetDisplay(const uint16_t sliders[72], string display);
+   void SetDisplay(const uint16_t sliders[72], std::string display);
    void SetKeyLights(ofColor keys[61]);
    
 private:
-   void SendMessage(string portName, KDataArray data);
+   void SendMessage(std::string portName, KDataArray data);
    void CreateSender(const char* portName);
-   CFDataRef ProcessIncomingMessage(string portName, char* data, size_t length);
-   static void Output(string str);
-   string FormatString(string format, int number);
-   KDataArray RespondToMessage(string portName, KDataArray input);
-   void FollowUpToReply(string messageType, uint8_t* reply);
+   CFDataRef ProcessIncomingMessage(std::string portName, char* data, size_t length);
+   static void Output(std::string str);
+   std::string FormatString(std::string format, int number);
+   KDataArray RespondToMessage(std::string portName, KDataArray input);
+   void FollowUpToReply(std::string messageType, uint8_t* reply);
    bool DataEquals(const KDataArray& a, const KDataArray& b);
    void OutputData(const KDataArray& a);
    void OutputRawData(const uint8_t* data, size_t length);
@@ -119,15 +117,15 @@ private:
       kState_Focused
    }mState;
    
-   string mSerialNumber;
-   string mRequestPort;
-   string mNotificationPort;
-   string mRequestSerialPort;
-   string mNotificationSerialPort;
-   vector<ReplyEntry> mReplies;
-   list<QueuedMessage> mMessageQueue;
-   map<string,ListenPort> mListenPorts;
-   map<string,SendPort> mSendPorts;
+   std::string mSerialNumber;
+   std::string mRequestPort;
+   std::string mNotificationPort;
+   std::string mRequestSerialPort;
+   std::string mNotificationSerialPort;
+   std::vector<ReplyEntry> mReplies;
+   std::list<QueuedMessage> mMessageQueue;
+   std::map<std::string,ListenPort> mListenPorts;
+   std::map<std::string,SendPort> mSendPorts;
    ofMutex mMessageQueueMutex;
    IKontrolListener* mListener;
 };

--- a/Source/CFMessaging/ListenPort.cpp
+++ b/Source/CFMessaging/ListenPort.cpp
@@ -47,7 +47,7 @@ void* SetupRunLoop(void* source)
 
 void ListenPort::CreateListener(const char* portName, ListenPortCallback* callback)
 {
-   cout << "Listening on port " << portName << endl;
+   std::cout << "Listening on port " << portName << std::endl;
    
    mPortName = portName;
    mCallback = callback;
@@ -86,7 +86,7 @@ void ListenPort::Close()
 }
 
 //static
-map<CFMessagePortRef, ListenPort*> ListenPortReceiver::mPortMap;
+std::map<CFMessagePortRef, ListenPort*> ListenPortReceiver::mPortMap;
 
 //static
 void ListenPortReceiver::RegisterPort(ListenPort* port, CFMessagePortRef portRef)

--- a/Source/CFMessaging/ListenPort.h
+++ b/Source/CFMessaging/ListenPort.h
@@ -30,13 +30,11 @@
 #include <string>
 #include <map>
 
-using namespace std;
-
 class ListenPortCallback
 {
 public:
    virtual ~ListenPortCallback() {}
-   virtual CFDataRef OnMessageReceived(string portName, SInt32 msgid, CFDataRef data) = 0;
+   virtual CFDataRef OnMessageReceived(std::string portName, SInt32 msgid, CFDataRef data) = 0;
 };
 
 class ListenPort
@@ -48,7 +46,7 @@ public:
    CFDataRef OnMessageReceived(SInt32 msgid, CFDataRef data);
    void Close();
 private:
-   string mPortName;
+   std::string mPortName;
    CFMessagePortRef mReceivePort;
    CFRunLoopSourceRef mLoopSource;
    ListenPortCallback* mCallback;
@@ -62,7 +60,7 @@ public:
 private:
    static ListenPort* LookupPort(CFMessagePortRef portRef);
    
-   static map<CFMessagePortRef, ListenPort*> mPortMap;
+   static std::map<CFMessagePortRef, ListenPort*> mPortMap;
 };
 
 #endif /* defined(__NI_SoftwareSide__ListenPort__) */

--- a/Source/CFMessaging/NIMessage.cpp
+++ b/Source/CFMessaging/NIMessage.cpp
@@ -55,7 +55,7 @@ MessageIdToString MessageIdToStringTable[NUM_NI_MESSAGE_IDS] = {
    { 0x03564e66, "NIOctaveChangedMessage" },
 };
 
-string TypeForMessageID(uint32_t messageId)
+std::string TypeForMessageID(uint32_t messageId)
 {
    for (int i=0; i<NUM_NI_MESSAGE_IDS; ++i)
    {
@@ -64,10 +64,10 @@ string TypeForMessageID(uint32_t messageId)
    }
    char messageIdStr[16];
    sprintf(messageIdStr, "0x%08x", messageId);
-   return string("Unknown message type ")+messageIdStr;
+   return std::string("Unknown message type ")+messageIdStr;
 }
 
-uint32_t MessageIDForType(string type)
+uint32_t MessageIDForType(std::string type)
 {
    for (int i=0; i<NUM_NI_MESSAGE_IDS; ++i)
    {

--- a/Source/CFMessaging/NIMessage.h
+++ b/Source/CFMessaging/NIMessage.h
@@ -28,19 +28,17 @@
 
 #include <iostream>
 
-using namespace std;
-
 typedef struct
 {
    uint32_t   messageId;
-   string className;
+   std::string className;
 } MessageIdToString;
 
 #define NUM_NI_MESSAGE_IDS 27
 
 extern MessageIdToString MessageIdToStringTable[NUM_NI_MESSAGE_IDS];
 
-string TypeForMessageID(uint32_t messageId);
-uint32_t MessageIDForType(string type);
+std::string TypeForMessageID(uint32_t messageId);
+uint32_t MessageIDForType(std::string type);
 
 #endif

--- a/Source/CFMessaging/SendPort.h
+++ b/Source/CFMessaging/SendPort.h
@@ -29,8 +29,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <string>
 
-using namespace std;
-
 class SendPort
 {
 public:
@@ -40,7 +38,7 @@ public:
    void SendData(uint32_t messageId, CFDataRef data, CFDataRef& replyData);
    void Close();
 private:
-   string mPortName;
+   std::string mPortName;
    CFMessagePortRef mSendPort;
 };
 

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -192,7 +192,7 @@ void Canvas::SelectElement(CanvasElement* element)
    }
 }
 
-void Canvas::SelectElements(vector<CanvasElement*> elements)
+void Canvas::SelectElements(std::vector<CanvasElement*> elements)
 {
    bool commandHeld = GetKeyModifiers() & kModifier_Command;
    if (mControls)
@@ -354,7 +354,7 @@ bool Canvas::MouseMoved(float x, float y)
             if (GetKeyModifiers() & kModifier_Shift && !mHasDuplicatedThisDrag && dragOffset.distanceSquared() > 9)
             {
                mHasDuplicatedThisDrag = true;
-               vector<CanvasElement*> newElements;
+               std::vector<CanvasElement*> newElements;
                for (auto element : mElements)
                {
                   if (element->GetHighlighted())
@@ -470,7 +470,7 @@ void Canvas::MouseReleased()
    
    if (mDragSelecting)
    {
-      vector<CanvasElement*> selectedElements;
+      std::vector<CanvasElement*> selectedElements;
       for (int i=(int)mElements.size()-1; i>=0; --i)
       {
          if (mElements[i]->GetRect(true, false).intersects(mDragSelectRect) ||
@@ -549,7 +549,7 @@ void Canvas::KeyPressed(int key, bool isRepeat)
          if (mControls)
             mControls->SetElement(nullptr);
          
-         vector<CanvasElement*> toRemove;
+         std::vector<CanvasElement*> toRemove;
          for (auto element : mElements)
          {
             if (element->GetHighlighted())
@@ -631,7 +631,7 @@ CanvasElement* Canvas::GetElementAt(float pos, int row)
    return nullptr;
 }
 
-void Canvas::FillElementsAt(float pos, vector<CanvasElement*>& elementsAt) const
+void Canvas::FillElementsAt(float pos, std::vector<CanvasElement*>& elementsAt) const
 {
    for (int i=0; i<mElements.size(); ++i)
    {
@@ -650,7 +650,7 @@ void Canvas::FillElementsAt(float pos, vector<CanvasElement*>& elementsAt) const
 
 void Canvas::EraseElementsAt(float pos)
 {
-   vector<CanvasElement*> toErase;
+   std::vector<CanvasElement*> toErase;
    for (int i = 0; i < mElements.size(); ++i)
    {
       if (mElements[i]->mRow == -1 || mElements[i]->mCol == -1)

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -96,11 +96,11 @@ public:
    void AddElement(CanvasElement* element);
    void RemoveElement(CanvasElement* element);
    void SelectElement(CanvasElement* element);
-   void SelectElements(vector<CanvasElement*> elements);
+   void SelectElements(std::vector<CanvasElement*> elements);
    void SetControls(CanvasControls* controls) { mControls = controls; }
    CanvasControls* GetControls() { return mControls; }
-   vector<CanvasElement*>& GetElements() { return mElements; }
-   void FillElementsAt(float pos, vector<CanvasElement*>& elements) const;
+   std::vector<CanvasElement*>& GetElements() { return mElements; }
+   void FillElementsAt(float pos, std::vector<CanvasElement*>& elements) const;
    void EraseElementsAt(float pos);
    CanvasElement* GetElementAt(float pos, int row);
    void SetCursorPos(float pos) { mCursorPos = pos; }
@@ -149,7 +149,7 @@ private:
    float mHeight;
    float mLength;
    ICanvasListener* mListener;
-   vector<CanvasElement*> mElements;
+   std::vector<CanvasElement*> mElements;
    CanvasControls* mControls;
    float mCursorPos;
    CreateCanvasElementFn mElementCreator;

--- a/Source/CanvasControls.cpp
+++ b/Source/CanvasControls.cpp
@@ -68,7 +68,7 @@ void CanvasControls::SetCanvas(Canvas* canvas)
    mCanvas = canvas;
    mWidth = mCanvas->GetWidth();
    mCanvas->SetControls(this);
-   StringCopy(NameMutable(), (string(mCanvas->Name())+"_controls").c_str(), MAX_TEXTENTRY_LENGTH);
+   StringCopy(NameMutable(), (std::string(mCanvas->Name())+"_controls").c_str(), MAX_TEXTENTRY_LENGTH);
 }
 
 void CanvasControls::SetElement(CanvasElement* element)
@@ -170,7 +170,7 @@ void CanvasControls::ButtonClicked(ClickButton* button)
    if (button == mRemoveElementButton)
    {
       mSelectedElement = nullptr;
-      vector<CanvasElement*> elementsToDelete;
+      std::vector<CanvasElement*> elementsToDelete;
       for (auto* element : mCanvas->GetElements())
       {
          if (element->GetHighlighted())

--- a/Source/CanvasControls.h
+++ b/Source/CanvasControls.h
@@ -42,7 +42,7 @@ public:
    ~CanvasControls();
    static IDrawableModule* Create() { return new CanvasControls(); }
    
-   string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() override { return ""; }
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
    bool CanMinimize() override { return false; }

--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -265,7 +265,7 @@ void CanvasElement::AddElementUIControl(IUIControl* control)
    control->SetShowing(false);
 }
 
-void CanvasElement::CheckboxUpdated(string label, bool value)
+void CanvasElement::CheckboxUpdated(std::string label, bool value)
 {
    for (auto* control : mUIControls)
    {
@@ -274,7 +274,7 @@ void CanvasElement::CheckboxUpdated(string label, bool value)
    }
 }
 
-void CanvasElement::FloatSliderUpdated(string label, float oldVal, float newVal)
+void CanvasElement::FloatSliderUpdated(std::string label, float oldVal, float newVal)
 {
    for (auto* control : mUIControls)
    {
@@ -283,7 +283,7 @@ void CanvasElement::FloatSliderUpdated(string label, float oldVal, float newVal)
    }
 }
 
-void CanvasElement::IntSliderUpdated(string label, int oldVal, float newVal)
+void CanvasElement::IntSliderUpdated(std::string label, int oldVal, float newVal)
 {
    for (auto* control : mUIControls)
    {
@@ -292,7 +292,7 @@ void CanvasElement::IntSliderUpdated(string label, int oldVal, float newVal)
    }
 }
 
-void CanvasElement::ButtonClicked(string label)
+void CanvasElement::ButtonClicked(std::string label)
 {
 }
 
@@ -488,12 +488,12 @@ void SampleCanvasElement::SetSample(Sample* sample)
    mSample = sample;
 }
 
-void SampleCanvasElement::CheckboxUpdated(string label, bool value)
+void SampleCanvasElement::CheckboxUpdated(std::string label, bool value)
 {
    CanvasElement::CheckboxUpdated(label, value);
 }
 
-void SampleCanvasElement::ButtonClicked(string label)
+void SampleCanvasElement::ButtonClicked(std::string label)
 {
    CanvasElement::ButtonClicked(label);
    if (label == "split")
@@ -669,7 +669,7 @@ void EventCanvasElement::DrawContents(bool clamp, bool wrapped, ofVec2f offset)
    ofFill();
    ofRect(GetRect(clamp, wrapped, offset), 0);
    
-   string text;
+   std::string text;
    if (mIsCheckbox)
    {
       text = mUIControl->Name();
@@ -757,7 +757,7 @@ void EventCanvasElement::LoadState(FileStreamIn& in)
    in >> mValue;
    if (rev < 1)
    {
-      string dummy;
+      std::string dummy;
       in >> dummy;
    }
 }

--- a/Source/CanvasElement.h
+++ b/Source/CanvasElement.h
@@ -55,16 +55,16 @@ public:
    void SetStart(float start, bool preserveLength);
    virtual float GetEnd() const;
    void SetEnd(float end);
-   vector<IUIControl*>& GetUIControls() { return mUIControls; }
+   std::vector<IUIControl*>& GetUIControls() { return mUIControls; }
    void MoveElementByDrag(ofVec2f dragOffset);
    
    virtual bool IsResizable() const { return true; }
    virtual CanvasElement* CreateDuplicate() const = 0;
    
-   virtual void CheckboxUpdated(string label, bool value);
-   virtual void FloatSliderUpdated(string label, float oldVal, float newVal);
-   virtual void IntSliderUpdated(string label, int oldVal, float newVal);
-   virtual void ButtonClicked(string label);
+   virtual void CheckboxUpdated(std::string label, bool value);
+   virtual void FloatSliderUpdated(std::string label, float oldVal, float newVal);
+   virtual void IntSliderUpdated(std::string label, int oldVal, float newVal);
+   virtual void ButtonClicked(std::string label);
    
    virtual void SaveState(FileStreamOut& out);
    virtual void LoadState(FileStreamIn& in);
@@ -85,7 +85,7 @@ protected:
    
    Canvas* mCanvas;
    bool mHighlighted;
-   vector<IUIControl*> mUIControls;
+   std::vector<IUIControl*> mUIControls;
 };
 
 class NoteCanvasElement : public CanvasElement
@@ -142,8 +142,8 @@ public:
    
    CanvasElement* CreateDuplicate() const override;
    
-   void CheckboxUpdated(string label, bool value) override;
-   void ButtonClicked(string label) override;
+   void CheckboxUpdated(std::string label, bool value) override;
+   void ButtonClicked(std::string label) override;
    
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;

--- a/Source/CanvasScrollbar.cpp
+++ b/Source/CanvasScrollbar.cpp
@@ -29,7 +29,7 @@
 #include "Canvas.h"
 #include "ModularSynth.h"
 
-CanvasScrollbar::CanvasScrollbar(Canvas* canvas, string name, Style style)
+CanvasScrollbar::CanvasScrollbar(Canvas* canvas, std::string name, Style style)
    : mClick(false)
    , mStyle(style)
    , mAutoHide(true)

--- a/Source/CanvasScrollbar.h
+++ b/Source/CanvasScrollbar.h
@@ -39,7 +39,7 @@ public:
       kVertical
    };
 
-   CanvasScrollbar(Canvas* canvas, string name, Style style);
+   CanvasScrollbar(Canvas* canvas, std::string name, Style style);
    ~CanvasScrollbar() {}
 
    void SetDimensions(float width, float height) { mWidth = width; mHeight = height; }

--- a/Source/CanvasTimeline.cpp
+++ b/Source/CanvasTimeline.cpp
@@ -29,7 +29,7 @@
 #include "Canvas.h"
 #include "ModularSynth.h"
 
-CanvasTimeline::CanvasTimeline(Canvas* canvas, string name)
+CanvasTimeline::CanvasTimeline(Canvas* canvas, std::string name)
    : mClick(false)
    , mHoverMode(HoverMode::kNone)
    , mCanvas(canvas)

--- a/Source/CanvasTimeline.h
+++ b/Source/CanvasTimeline.h
@@ -33,7 +33,7 @@ class Canvas;
 class CanvasTimeline : public IUIControl
 {
 public:
-   CanvasTimeline(Canvas* canvas, string name);
+   CanvasTimeline(Canvas* canvas, std::string name);
    ~CanvasTimeline() {}
 
    void SetDimensions(float width, float height) { mWidth = width; mHeight = height; }

--- a/Source/Capo.h
+++ b/Source/Capo.h
@@ -39,7 +39,7 @@ public:
    Capo();
    static IDrawableModule* Create() { return new Capo(); }
    
-   string GetTitleLabel() override { return "capo"; }
+   std::string GetTitleLabel() override { return "capo"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -192,7 +192,7 @@ void ChaosEngine::UpdateProgression(int beat)
    mNoteOutput.Flush(gTime);
    if (mPlayChord)
    {
-      vector<int> pitches = GetCurrentChordPitches();
+      std::vector<int> pitches = GetCurrentChordPitches();
       for (int i=0; i<pitches.size(); ++i)
       {
          PlayNoteOutput(gTime, pitches[i], 127, -1);
@@ -200,7 +200,7 @@ void ChaosEngine::UpdateProgression(int beat)
    }
 }
 
-vector<int> ChaosEngine::GetCurrentChordPitches()
+std::vector<int> ChaosEngine::GetCurrentChordPitches()
 {
    ProgressionChord chord(0);
    if (mChordProgressionIdx != -1)
@@ -208,12 +208,12 @@ vector<int> ChaosEngine::GetCurrentChordPitches()
    
    int degree = TheScale->GetScaleDegree();
    
-   vector<int> tones;
+   std::vector<int> tones;
    tones.push_back(0+degree);
    tones.push_back(2+degree);
    tones.push_back(4+degree);
    
-   vector<int> pitches;
+   std::vector<int> pitches;
    for (int i=0; i<tones.size(); ++i)
    {
       int tone = tones[i];
@@ -273,7 +273,7 @@ void ChaosEngine::DrawModule()
       int degree;
       std::vector<Accidental> accidentals;
       TheScale->GetChordDegreeAndAccidentals(mInputChords[i], degree, accidentals);
-      string accidentalList;
+      std::string accidentalList;
       for (int i=0; i<accidentals.size(); ++i)
          accidentalList += ofToString(accidentals[i].mPitch) + (accidentals[i].mDirection == 1? "#" : "b") + " ";
       DrawTextNormal(mInputChords[i].Name(true,true), 400, 75+i*15);
@@ -311,7 +311,7 @@ void ChaosEngine::DrawModule()
       displayChord.mInversion = mChordProgression[i].mInversion;
       gFont.DrawString(displayChord.Name(true,false,&scale),48, x, y);
       
-      string accidentalList;
+      std::string accidentalList;
       for (int j=0; j<mChordProgression[i].mAccidentals.size(); ++j)
          accidentalList += ofToString(mChordProgression[i].mAccidentals[j].mPitch) + (mChordProgression[i].mAccidentals[j].mDirection == 1? "#" : "b") + "\n";
       DrawTextNormal(accidentalList, x+180, y-18);
@@ -421,7 +421,7 @@ void ChaosEngine::DrawKeyboard(float x, float y)
    ofFill();
    ofSetColor(255,255,255);
    ofSetLineWidth(2);
-   vector<int> chord = GetCurrentChordPitches();
+   std::vector<int> chord = GetCurrentChordPitches();
    sort(chord.begin(),chord.end());
    ofVec2f lastNoteConnector;
    for (int j=0; j<chord.size(); ++j)
@@ -591,7 +591,7 @@ void ChaosEngine::ReadSongs()
       mSongs[i].mTimeSigTop = song["timesig"][0u].asInt();
       mSongs[i].mTimeSigBottom = song["timesig"][1u].asInt();
       
-      string scaleRootName = song["scaleroot"].asString();
+      std::string scaleRootName = song["scaleroot"].asString();
       int j;
       for (j=0; j<12; ++j)
       {

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -50,7 +50,7 @@ public:
    static IDrawableModule* Create() { return new ChaosEngine(); }
    static bool CanCreate() { return TheChaosEngine == nullptr; }
    
-   string GetTitleLabel() override { return "CHAOS ENGINE"; }
+   std::string GetTitleLabel() override { return "CHAOS ENGINE"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -89,18 +89,18 @@ private:
    
    struct SongSection
    {
-      string mName;
+      std::string mName;
       std::vector<ProgressionChord> mChords;
    };
    
    struct Song
    {
-      string mName;
+      std::string mName;
       float mTempo;
       int mTimeSigTop;
       int mTimeSigBottom;
       int mScaleRoot;
-      string mScaleType;
+      std::string mScaleType;
       std::vector<SongSection> mSections;
    };
    
@@ -111,7 +111,7 @@ private:
    void ReadSongs();
    void UpdateProgression(int beat);
    void GenerateRandomProgression();
-   vector<int> GetCurrentChordPitches();
+   std::vector<int> GetCurrentChordPitches();
    ofRectangle GetKeyboardKeyRect(int pitch, bool& isBlackKey);
    
    //IDrawableModule
@@ -154,7 +154,7 @@ private:
    DropdownList* mChordTypeList;
    IntSlider* mInversionSlider;
    
-   vector<Chord> mInputChords;
+   std::vector<Chord> mInputChords;
    ClickButton* mAddChordButton;
    ClickButton* mRemoveChordButton;
    ClickButton* mSetProgressionButton;

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -197,7 +197,7 @@ float Checkbox::GetValue() const
    return *mVar;
 }
 
-string Checkbox::GetDisplayValue(float val) const
+std::string Checkbox::GetDisplayValue(float val) const
 {
    return val>0 ? "on" : "off";
 }

--- a/Source/Checkbox.h
+++ b/Source/Checkbox.h
@@ -52,7 +52,7 @@ public:
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return 2; }
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    void Increment(float amount) override;
    void Poll() override;
    void SaveState(FileStreamOut& out) override;

--- a/Source/Chord.cpp
+++ b/Source/Chord.cpp
@@ -27,12 +27,12 @@
 #include "SynthGlobals.h"
 #include "Scale.h"
 
-Chord::Chord(string name)
+Chord::Chord(std::string name)
 {
    assert(name.length() >= 4);
    
-   string pitchName;
-   string typeName;
+   std::string pitchName;
+   std::string typeName;
    if (name[1] == 'b' || name[1] == '#')
    {
       pitchName = name.substr(0,2);
@@ -58,17 +58,17 @@ Chord::Chord(string name)
       mType = kChord_Unknown;
 }
 
-string Chord::Name(bool withDegree, bool withAccidentals, ScalePitches* scale)
+std::string Chord::Name(bool withDegree, bool withAccidentals, ScalePitches* scale)
 {
    if (scale == nullptr)
       scale = &TheScale->GetScalePitches();
    
    int degree;
-   vector<Accidental> accidentals;
+   std::vector<Accidental> accidentals;
    if (withDegree || withAccidentals)
       scale->GetChordDegreeAndAccidentals(*this, degree, accidentals);
    
-   string chordName = NoteName(mRootPitch);
+   std::string chordName = NoteName(mRootPitch);
    if (mType == kChord_Maj)
       chordName += "maj";
    else if (mType == kChord_Min)
@@ -88,7 +88,7 @@ string Chord::Name(bool withDegree, bool withAccidentals, ScalePitches* scale)
    
    if (withAccidentals)
    {
-      string accidentalList;
+      std::string accidentalList;
       for (int i=0; i<accidentals.size(); ++i)
          accidentalList += ofToString(accidentals[i].mPitch) + (accidentals[i].mDirection == 1? "#" : "b") + " ";
       chordName += accidentalList;

--- a/Source/Chord.h
+++ b/Source/Chord.h
@@ -43,14 +43,14 @@ enum ChordType
 struct Chord
 {
    Chord() {}
-   Chord(string name);
+   Chord(std::string name);
    Chord(int pitch, ChordType type, int inversion = 0) : mRootPitch(pitch), mType(type), mInversion(inversion) {}
    
    int mRootPitch;
    ChordType mType;
    int mInversion;
    
-   string Name(bool withDegree, bool withAccidentals, ScalePitches* scale = nullptr);
+   std::string Name(bool withDegree, bool withAccidentals, ScalePitches* scale = nullptr);
    void SetFromDegreeAndScale(int degree, const ScalePitches& scale, int inversion = 0);
 };
 

--- a/Source/ChordDatabase.cpp
+++ b/Source/ChordDatabase.cpp
@@ -54,13 +54,13 @@ ChordDatabase::ChordDatabase()
    mChordShapes.push_back(ChordShape("sus2", {0,2,7}));
 }
 
-string ChordDatabase::GetChordName(vector<int> pitches) const
+std::string ChordDatabase::GetChordName(std::vector<int> pitches) const
 {
    int numPitches = (int)pitches.size();
    if (numPitches < 3)
       return "None";
    
-   list<string> names;
+   std::list<std::string> names;
    
    sort(pitches.begin(), pitches.end());
    for (int inversion = 0; inversion<numPitches; ++inversion)
@@ -91,15 +91,15 @@ string ChordDatabase::GetChordName(vector<int> pitches) const
    if (names.size() == 0)
       return "Unknown";
    
-   string ret = "";
-   for (string name : names)
+   std::string ret = "";
+   for (std::string name : names)
       ret += name + "; ";
    return ret.substr(0, ret.length()-2);
 }
 
-vector<int> ChordDatabase::GetChord(string name, int inversion) const
+std::vector<int> ChordDatabase::GetChord(std::string name, int inversion) const
 {
-   vector<int> ret;
+   std::vector<int> ret;
    for (auto shape : mChordShapes)
    {
       if (shape.mName == name)
@@ -118,9 +118,9 @@ vector<int> ChordDatabase::GetChord(string name, int inversion) const
    return ret;
 }
 
-vector<string> ChordDatabase::GetChordNames() const
+std::vector<std::string> ChordDatabase::GetChordNames() const
 {
-   vector<string> ret;
+   std::vector<std::string> ret;
    
    for (auto shape : mChordShapes)
       ret.push_back(shape.mName);

--- a/Source/ChordDatabase.h
+++ b/Source/ChordDatabase.h
@@ -33,19 +33,19 @@ class ChordDatabase
 {
 public:
    ChordDatabase();
-   string GetChordName(vector<int> pitches) const;
-   vector<int> GetChord(string name, int inversion) const;
-   vector<string> GetChordNames() const;
+   std::string GetChordName(std::vector<int> pitches) const;
+   std::vector<int> GetChord(std::string name, int inversion) const;
+   std::vector<std::string> GetChordNames() const;
 private:
    struct ChordShape
    {
-      ChordShape(string name, vector<int> elements)
+      ChordShape(std::string name, std::vector<int> elements)
       {
          mName = name;
          mElements = elements;
       }
-      string mName;
-      vector<int> mElements;
+      std::string mName;
+      std::vector<int> mElements;
    };
-   vector<ChordShape> mChordShapes;
+   std::vector<ChordShape> mChordShapes;
 };

--- a/Source/ChordDisplayer.cpp
+++ b/Source/ChordDisplayer.cpp
@@ -38,7 +38,7 @@ void ChordDisplayer::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
    
-   list<int> notes = mNoteOutput.GetHeldNotesList();
+   std::list<int> notes = mNoteOutput.GetHeldNotesList();
    
    if (notes.size() > 2)
    {

--- a/Source/ChordDisplayer.h
+++ b/Source/ChordDisplayer.h
@@ -36,7 +36,7 @@ public:
    ChordDisplayer();
    static IDrawableModule* Create() { return new ChordDisplayer(); }
    
-   string GetTitleLabel() override { return "chord displayer"; }
+   std::string GetTitleLabel() override { return "chord displayer"; }
    
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/ChordHolder.h
+++ b/Source/ChordHolder.h
@@ -39,7 +39,7 @@ public:
    ChordHolder();
    static IDrawableModule* Create() { return new ChordHolder(); }
 
-   string GetTitleLabel() override { return "chord holder"; }
+   std::string GetTitleLabel() override { return "chord holder"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -169,7 +169,7 @@ void Chorder::DropdownUpdated(DropdownList* dropdown, int oldVal)
 {
    if (dropdown == mChordDropdown || dropdown == mInversionDropdown)
    {
-      vector<int> chord = TheScale->GetChordDatabase().GetChord(mChordDropdown->GetLabel(mChordIndex), mInversion);
+      std::vector<int> chord = TheScale->GetChordDatabase().GetChord(mChordDropdown->GetLabel(mChordIndex), mInversion);
       mChordGrid->Clear();
       for (int val : chord)
       {

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -41,7 +41,7 @@ public:
    Chorder();
    static IDrawableModule* Create() { return new Chorder(); }
    
-   string GetTitleLabel() override { return "chorder"; }
+   std::string GetTitleLabel() override { return "chorder"; }
    void CreateUIControls() override;
    
    void AddTone(int tone, float velocity=1);

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -77,7 +77,7 @@ public:
    ~CircleSequencer();
    static IDrawableModule* Create() { return new CircleSequencer(); }
    
-   string GetTitleLabel() override { return "circle sequencer"; }
+   std::string GetTitleLabel() override { return "circle sequencer"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -193,7 +193,7 @@ float ClickButton::GetMidiValue() const
    return 0;
 }
 
-string ClickButton::GetDisplayValue(float val) const
+std::string ClickButton::GetDisplayValue(float val) const
 {
    if (val > 0)
       return "click";

--- a/Source/ClickButton.h
+++ b/Source/ClickButton.h
@@ -67,7 +67,7 @@ public:
    void SetValue(float value) override;
    float GetValue() const override { return GetMidiValue(); }
    float GetMidiValue() const override;
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    int GetNumValues() override { return 2; }
    void GetDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    void SaveState(FileStreamOut& out) override {}

--- a/Source/ClipArranger.cpp
+++ b/Source/ClipArranger.cpp
@@ -197,7 +197,7 @@ bool ClipArranger::IsMousePosWithinClip(int x, int y)
    return x >= 0 && x < w && y >= 0 && y < h;
 }
 
-void ClipArranger::FilesDropped(vector<string> files, int x, int y)
+void ClipArranger::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample* sample = new Sample();
    sample->Read(files[0].c_str());

--- a/Source/ClipArranger.h
+++ b/Source/ClipArranger.h
@@ -50,7 +50,7 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
    
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
    void ButtonClicked(ClickButton* button) override;

--- a/Source/ClipLauncher.cpp
+++ b/Source/ClipLauncher.cpp
@@ -279,7 +279,7 @@ void ClipLauncher::SampleData::Init(ClipLauncher* launcher, int index)
       mPlayCheckbox->Delete();
    }
    
-   string indexStr = ofToString(index + 1);
+   std::string indexStr = ofToString(index + 1);
    
    mSample = new Sample();
    mSample->SetLooping(true);

--- a/Source/ClipLauncher.h
+++ b/Source/ClipLauncher.h
@@ -48,7 +48,7 @@ public:
    ~ClipLauncher();
    static IDrawableModule* Create() { return new ClipLauncher(); }
    
-   string GetTitleLabel() override { return "clip launcher"; }
+   std::string GetTitleLabel() override { return "clip launcher"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -112,7 +112,7 @@ private:
    float mVolume;
    FloatSlider* mVolumeSlider;
 
-   vector<SampleData> mSamples;
+   std::vector<SampleData> mSamples;
    JumpBlender mJumpBlender;
    ofMutex mSampleMutex;
 };

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -130,7 +130,7 @@ void CodeEntry::Poll()
             {
                try
                {
-                  string prefix = ScriptModule::GetBootstrapImportString() + "; import me\n";
+                  std::string prefix = ScriptModule::GetBootstrapImportString() + "; import me\n";
                   py::exec("jediScript = jedi.Script('''" + prefix + GetVisibleCode() + "''', project=jediProject)", py::globals());
                   //py::exec("jediScript = jedi.Script('''" + prefix + GetVisibleCode() + "''')", py::globals());
                   //py::exec("jediScript = jedi.Interpreter('''" + prefix + GetVisibleCode() + "''', [locals(), globals()])", py::globals());
@@ -153,7 +153,7 @@ void CodeEntry::Poll()
                            for (size_t j = 0; j < params.size(); ++j)
                               mAutocompleteSignatures[i].params[j] = juce::String(py::str(params[j].attr("description"))).replace("param ","").toStdString();
                            auto bracket_start = signature.attr("bracket_start").cast< std::tuple<int, int> >();
-                           mAutocompleteSignatures[i].caretPos = GetCaretPosition(get<1>(bracket_start), get<0>(bracket_start)-2);
+                           mAutocompleteSignatures[i].caretPos = GetCaretPosition(std::get<1>(bracket_start), std::get<0>(bracket_start)-2);
                            ++i;
                         }
                         else
@@ -188,8 +188,8 @@ void CodeEntry::Poll()
                            for (auto autocomplete : autocompletes)
                            {
                               //ofLog() << "    --" << autocomplete;
-                              string full = py::str(autocomplete.attr("name"));
-                              string rest = py::str(autocomplete.attr("complete"));
+                              std::string full = py::str(autocomplete.attr("name"));
+                              std::string rest = py::str(autocomplete.attr("complete"));
                               if (!((juce::String)full).startsWith("__") && i < mAutocompletes.size())
                               {
                                  mAutocompletes[i].valid = true;
@@ -206,9 +206,9 @@ void CodeEntry::Poll()
                         else //we're autocompleting a path, look for matching instantiated module names
                         {
                            int stringStart = mAutocompleteSignatures[0].caretPos + 2;
-                           string writtenSoFar = mString.substr(stringStart, mCaretPosition - stringStart);
+                           std::string writtenSoFar = mString.substr(stringStart, mCaretPosition - stringStart);
 
-                           vector<IDrawableModule*> modules;
+                           std::vector<IDrawableModule*> modules;
                            TheSynth->GetAllModules(modules);
 
                            for (auto module : modules)
@@ -216,8 +216,8 @@ void CodeEntry::Poll()
                               juce::String modulePath = module->Path();
                               if (modulePath.startsWith(writtenSoFar))
                               {
-                                 string full = modulePath.toStdString();
-                                 string rest = full;
+                                 std::string full = modulePath.toStdString();
+                                 std::string rest = full;
                                  ofStringReplace(rest, writtenSoFar, "", true);
                                  if (i < mAutocompletes.size())
                                  {
@@ -333,7 +333,7 @@ void CodeEntry::Render()
    
    ofSetColor(color, gModuleDrawAlpha);
    
-   string drawString = GetVisibleCode();
+   std::string drawString = GetVisibleCode();
 
    ofPushStyle();
    const float dim = .7f;
@@ -451,7 +451,7 @@ void CodeEntry::RenderOverlay()
          ofSetColor(200, 200, 200);
          gFontFixedWidth.DrawString(mAutocompletes[i].autocompleteFull, mFontSize, x, y);
          ofSetColor(255, 255, 255);
-         string prefix = "";
+         std::string prefix = "";
          for (size_t j = 0; j < charactersLeft; ++j)
             prefix += " ";
          gFontFixedWidth.DrawString(prefix + mAutocompletes[i].autocompleteRest, mFontSize, x, y);
@@ -462,12 +462,12 @@ void CodeEntry::RenderOverlay()
    {
       if (mAutocompleteSignatures[i].valid && mAutocompleteSignatures[i].params.size() > 0)
       {
-         string params = "(";
-         string highlightParamString = " ";
+         std::string params = "(";
+         std::string highlightParamString = " ";
          for (size_t j = 0; j < mAutocompleteSignatures[i].params.size(); ++j)
          {
-            string param = mAutocompleteSignatures[i].params[j];
-            string placeholder = "";
+            std::string param = mAutocompleteSignatures[i].params[j];
+            std::string placeholder = "";
             for (size_t k = 0; k < param.length(); ++k)
                placeholder += " ";
             if (j == mAutocompleteSignatures[i].entryIndex)
@@ -501,10 +501,10 @@ void CodeEntry::RenderOverlay()
    }
 }
 
-string CodeEntry::GetVisibleCode()
+std::string CodeEntry::GetVisibleCode()
 {
-   string visible;
-   vector<string> lines = GetLines(false);
+   std::string visible;
+   std::vector<std::string> lines = GetLines(false);
    if (lines.empty())
       return "";
    
@@ -538,9 +538,9 @@ string CodeEntry::GetVisibleCode()
    return visible;
 }
 
-void CodeEntry::DrawSyntaxHighlight(string input, ofColor color, std::vector<int> mapping, int filter1, int filter2)
+void CodeEntry::DrawSyntaxHighlight(std::string input, ofColor color, std::vector<int> mapping, int filter1, int filter2)
 {
-   string filtered = FilterText(input, mapping, filter1, filter2);
+   std::string filtered = FilterText(input, mapping, filter1, filter2);
    ofSetColor(color, gModuleDrawAlpha);
    
    float shake = (1 - ofClamp((gTime - mLastPublishTime) / 150, 0, 1)) * 3.0f;
@@ -550,7 +550,7 @@ void CodeEntry::DrawSyntaxHighlight(string input, ofColor color, std::vector<int
    gFontFixedWidth.DrawString(filtered, mFontSize, mX+2 - mScroll.x + offsetX, mY + mCharHeight - mScroll.y + offsetY);
 }
 
-string CodeEntry::FilterText(string input, std::vector<int> mapping, int filter1, int filter2)
+std::string CodeEntry::FilterText(std::string input, std::vector<int> mapping, int filter1, int filter2)
 {
    for (size_t i=0; i<input.size(); ++i)
    {
@@ -575,7 +575,7 @@ string CodeEntry::FilterText(string input, std::vector<int> mapping, int filter1
 //static
 void CodeEntry::OnPythonInit()
 {
-   const string syntaxHighlightCode = R"(def syntax_highlight_basic():
+   const std::string syntaxHighlightCode = R"(def syntax_highlight_basic():
    #this uses the built in lexer/tokenizer in python to identify part of code
    #will return a meaningful lookuptable for index colours per character
    import tokenize
@@ -793,7 +793,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       {
          ofVec2f coords = GetCaretCoords(mCaretPosition);
          int spacesNeeded = kTabSize - (int)coords.x % kTabSize;
-         string tab;
+         std::string tab;
          for (int i=0; i<spacesNeeded; ++i)
             tab += " ";
          AddString(tab);
@@ -910,7 +910,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
                   break;
             }
          }
-         string tab = "\n";
+         std::string tab = "\n";
          for (int i = 0; i < numSpaces; ++i)
             tab += ' ';
          AddString(tab);
@@ -936,7 +936,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
          if (mCaretPosition != mCaretPosition2)
             RemoveSelectedText();
          
-         string insert = pasteName->Path();
+         std::string insert = pasteName->Path();
          AddString(insert);
       }
    }
@@ -983,7 +983,7 @@ void CodeEntry::OnKeyPressed(int key, bool isRepeat)
       Publish();
       int lineStart = MIN(GetCaretCoords(mCaretPosition).y, GetCaretCoords(mCaretPosition2).y);
       int lineEnd = MAX(GetCaretCoords(mCaretPosition).y, GetCaretCoords(mCaretPosition2).y);
-      pair<int, int> ranLines = mListener->ExecuteBlock(lineStart, lineEnd);
+      std::pair<int, int> ranLines = mListener->ExecuteBlock(lineStart, lineEnd);
       mLastPublishedLineStart = ranLines.first;
       mLastPublishedLineEnd = ranLines.second;
    }
@@ -1043,7 +1043,7 @@ void CodeEntry::Redo()
    }
 }
 
-void CodeEntry::UpdateString(string newString)
+void CodeEntry::UpdateString(std::string newString)
 {
    mUndoBuffer[mUndoBufferPos].mCaretPos = mCaretPosition;
    
@@ -1064,7 +1064,7 @@ void CodeEntry::AddCharacter(char c)
 {
    if (AllowCharacter(c))
    {
-      string s;
+      std::string s;
       s += c;
       AddString(s);
 
@@ -1072,12 +1072,12 @@ void CodeEntry::AddCharacter(char c)
    }
 }
 
-void CodeEntry::AddString(string s)
+void CodeEntry::AddString(std::string s)
 {
    if (mCaretPosition != mCaretPosition2)
       RemoveSelectedText();
    
-   string toAdd;
+   std::string toAdd;
    for (int i=0; i<s.size(); ++i)
    {
       if (AllowCharacter(s[i]))
@@ -1111,7 +1111,7 @@ void CodeEntry::ShiftLines(bool backwards)
    ofVec2f coordsEnd = GetCaretCoords(caretEnd);
    
    auto lines = GetLines(false);
-   string newString = "";
+   std::string newString = "";
    for (size_t i=0; i<lines.size(); ++i)
    {
       if (i >= coordsStart.y && i <= coordsEnd.y)
@@ -1276,7 +1276,7 @@ ofVec2f CodeEntry::GetLinePos(int lineNum, bool end, bool published /*= true*/)
    
    if (end)
    {
-      string str = published ? mPublishedString : mString;
+      std::string str = published ? mPublishedString : mString;
       auto lines = ofSplitString(str, "\n");
       if (lineNum < (int)lines.size())
          x += lines[lineNum].length() * mCharWidth;

--- a/Source/CodeEntry.h
+++ b/Source/CodeEntry.h
@@ -36,7 +36,7 @@ class ICodeEntryListener
 public:
    virtual ~ICodeEntryListener() {}
    virtual void ExecuteCode() = 0;
-   virtual pair<int,int> ExecuteBlock(int lineStart, int lineEnd) = 0;  //return start/end lines that actually ran
+   virtual std::pair<int,int> ExecuteBlock(int lineStart, int lineEnd) = 0;  //return start/end lines that actually ran
    virtual void OnCodeUpdated() {}
 };
 
@@ -53,9 +53,9 @@ public:
    void Publish();
    
    void ClearInput() { mString = ""; mCaretPosition = 0; }
-   const string GetText(bool published) const { return published ? mPublishedString : mString; }
-   const vector<string> GetLines(bool published) const { return ofSplitString(published ? mPublishedString : mString, "\n"); }
-   void SetText(string text) { UpdateString(text); }
+   const std::string GetText(bool published) const { return published ? mPublishedString : mString; }
+   const std::vector<std::string> GetLines(bool published) const { return ofSplitString(published ? mPublishedString : mString, "\n"); }
+   void SetText(std::string text) { UpdateString(text); }
    void SetError(bool error, int errorLine = -1);
    void SetDoSyntaxHighlighting(bool highlight) { mDoSyntaxHighlighting = highlight; }
    static bool HasJediNotInstalledWarning() { return sWarnJediNotInstalled; }
@@ -85,7 +85,7 @@ protected:
    
 private:
    void AddCharacter(char c);
-   void AddString(string s);
+   void AddString(std::string s);
    bool AllowCharacter(char c);
    int GetCaretPosition(int col, int row);
    int GetColForX(float x);
@@ -99,11 +99,11 @@ private:
    void MoveCaretToNextToken(bool backwards);
    void Undo();
    void Redo();
-   void UpdateString(string newString);
-   void DrawSyntaxHighlight(string input, ofColor color, std::vector<int> mapping, int filter1, int filter2);
-   string FilterText(string input, std::vector<int> mapping, int filter1, int filter2);
+   void UpdateString(std::string newString);
+   void DrawSyntaxHighlight(std::string input, ofColor color, std::vector<int> mapping, int filter1, int filter2);
+   std::string FilterText(std::string input, std::vector<int> mapping, int filter1, int filter2);
    void OnCodeUpdated();
-   string GetVisibleCode();
+   std::string GetVisibleCode();
    bool IsAutocompleteShowing();
    void AcceptAutocompletion();
    
@@ -116,7 +116,7 @@ private:
    struct UndoBufferEntry
    {
       UndoBufferEntry() : mCaretPos(0) {}
-      string mString;
+      std::string mString;
       int mCaretPos;
    };
 
@@ -124,15 +124,15 @@ private:
    {
       bool valid;
       int entryIndex;
-      vector<string> params;
+      std::vector<std::string> params;
       int caretPos;
    };
 
    struct AutocompleteInfo
    {
       bool valid;
-      string autocompleteFull;
-      string autocompleteRest;
+      std::string autocompleteFull;
+      std::string autocompleteRest;
    };
    
    ICodeEntryListener* mListener;
@@ -140,8 +140,8 @@ private:
    float mHeight;
    float mCharWidth;
    float mCharHeight;
-   string mString;
-   string mPublishedString;
+   std::string mString;
+   std::string mPublishedString;
    std::array<UndoBufferEntry, 50> mUndoBuffer;
    int mUndoBufferPos;
    int mUndosLeft;

--- a/Source/ComboGridController.cpp
+++ b/Source/ComboGridController.cpp
@@ -40,9 +40,9 @@ void ComboGridController::CreateUIControls()
    IDrawableModule::CreateUIControls();
 }
 
-string ComboGridController::GetTitleLabel()
+std::string ComboGridController::GetTitleLabel()
 {
-   string title = "combo:";
+   std::string title = "combo:";
    for (int i=0; i<mGrids.size(); ++i)
    {
       title += dynamic_cast<IClickable*>(mGrids[i])->Name();
@@ -215,7 +215,7 @@ void ComboGridController::LoadLayout(const ofxJSONElement& moduleInfo)
 void ComboGridController::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
-   string grids = "";
+   std::string grids = "";
    for (int i=0; i<mGrids.size(); ++i)
    {
       IDrawableModule* grid = dynamic_cast<IDrawableModule*>(mGrids[i]);
@@ -231,8 +231,8 @@ void ComboGridController::SaveLayout(ofxJSONElement& moduleInfo)
 
 void ComboGridController::SetUpFromSaveData()
 {
-   string grids = mModuleSaveData.GetString("grids");
-   vector<string> gridVec = ofSplitString(grids, ",");
+   std::string grids = mModuleSaveData.GetString("grids");
+   std::vector<std::string> gridVec = ofSplitString(grids, ",");
    mGrids.clear();
    if (grids != "")
    {

--- a/Source/ComboGridController.h
+++ b/Source/ComboGridController.h
@@ -35,7 +35,7 @@ public:
    ~ComboGridController() {}
    static IDrawableModule* Create() { return new ComboGridController(); }
    
-   string GetTitleLabel() override;
+   std::string GetTitleLabel() override;
    void CreateUIControls() override;
    
    void Init() override;
@@ -75,7 +75,7 @@ private:
 
    unsigned int mRows;
    unsigned int mCols;
-   vector<IGridController*> mGrids;
+   std::vector<IGridController*> mGrids;
    Arrangements mArrangement;
    IGridControllerListener* mOwner;
 };

--- a/Source/CommentDisplay.h
+++ b/Source/CommentDisplay.h
@@ -38,7 +38,7 @@ public:
    virtual ~CommentDisplay();
    static IDrawableModule* Create() { return new CommentDisplay(); }
    
-   string GetTitleLabel() override { return "comment"; }
+   std::string GetTitleLabel() override { return "comment"; }
    void CreateUIControls() override;
    
    void TextEntryComplete(TextEntry* entry) override;

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -118,13 +118,13 @@ public:
    
    static IAudioEffect* Create() { return new Compressor(); }
    
-   string GetTitleLabel() override { return "compressor"; }
+   std::string GetTitleLabel() override { return "compressor"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   string GetType() override { return "compressor"; }
+   std::string GetType() override { return "compressor"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -27,7 +27,7 @@
 #include "ModularSynth.h"
 #include "PatchCableSource.h"
 
-list<ControlSequencer*> ControlSequencer::sControlSequencers;
+std::list<ControlSequencer*> ControlSequencer::sControlSequencers;
 
 ControlSequencer::ControlSequencer()
 : mGrid(nullptr)
@@ -168,7 +168,7 @@ void ControlSequencer::SetNumSteps(int numSteps, bool stretch)
    assert(oldNumSteps != 0);
    if (stretch)   //updated interval, stretch old pattern out to make identical pattern at higher res
    {              // abcd becomes aabbccdd
-      vector<float> pattern;
+      std::vector<float> pattern;
       pattern.resize(oldNumSteps);
       for (int i=0; i<oldNumSteps; ++i)
          pattern[i] = mGrid->GetVal(i,0);
@@ -295,7 +295,7 @@ void ControlSequencer::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void ControlSequencer::SetUpFromSaveData()
 {
-   string controlPath = mModuleSaveData.GetString("uicontrol");
+   std::string controlPath = mModuleSaveData.GetString("uicontrol");
    if (!controlPath.empty())
    {
       mUIControl = TheSynth->FindUIControl(controlPath);

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -43,7 +43,7 @@ public:
    ~ControlSequencer();
    static IDrawableModule* Create() { return new ControlSequencer(); }
    
-   string GetTitleLabel() override { return "control sequencer"; }
+   std::string GetTitleLabel() override { return "control sequencer"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -72,7 +72,7 @@ public:
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
    
-   static list<ControlSequencer*> sControlSequencers;
+   static std::list<ControlSequencer*> sControlSequencers;
    
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/ControlTactileFeedback.h
+++ b/Source/ControlTactileFeedback.h
@@ -39,7 +39,7 @@ public:
    ~ControlTactileFeedback();
    static IDrawableModule* Create() { return new ControlTactileFeedback(); }
    
-   string GetTitleLabel() override { return "tactile"; }
+   std::string GetTitleLabel() override { return "tactile"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/ControllingSong.cpp
+++ b/Source/ControllingSong.cpp
@@ -83,7 +83,7 @@ void ControllingSong::Init()
    for (int i=0; i<mSongList["songs"].size(); ++i)
    {
       mShuffleList.push_back(i);
-      string title = mSongList["songs"][i]["name"].asString();
+      std::string title = mSongList["songs"][i]["name"].asString();
       if (mSongList["songs"][i]["keyroot"].asString() == "X")
          title = "X " + title;
       mSongSelector->AddLabel(title.c_str(), i);
@@ -146,7 +146,7 @@ void ControllingSong::LoadSong(int index)
       }
    }
    
-   string keyroot = mSongList["songs"][index]["keyroot"].asString();
+   std::string keyroot = mSongList["songs"][index]["keyroot"].asString();
    if (keyroot != "X" && keyroot != "")
    {
       TheScale->SetRoot(PitchFromNoteName(keyroot));
@@ -314,7 +314,7 @@ void ControllingSong::LoadLayout(const ofxJSONElement& moduleInfo)
    const Json::Value& follows = moduleInfo["followsongs"];
    for (int i=0; i<follows.size(); ++i)
    {
-      string follow = follows[i].asString();
+      std::string follow = follows[i].asString();
       FollowingSong* followSong = dynamic_cast<FollowingSong*>(TheSynth->FindModule(follow));
       if (followSong)
          mFollowSongs.push_back(followSong);

--- a/Source/ControllingSong.h
+++ b/Source/ControllingSong.h
@@ -47,7 +47,7 @@ public:
    ~ControllingSong();
    static IDrawableModule* Create() { return new ControllingSong(); }
    
-   string GetTitleLabel() override { return "controlling song"; }
+   std::string GetTitleLabel() override { return "controlling song"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -102,8 +102,8 @@ private:
    DropdownList* mSongSelector;
    ClickButton* mNextSongButton;
    int mShuffleIndex;
-   vector<int> mShuffleList;
-   vector<FollowingSong*> mFollowSongs;
+   std::vector<int> mShuffleList;
+   std::vector<FollowingSong*> mFollowSongs;
 };
 
 #endif /* defined(__Bespoke__ControllingSong__) */

--- a/Source/Curve.h
+++ b/Source/Curve.h
@@ -68,7 +68,7 @@ protected:
 private:
    bool IsAtCapacity() { return mNumCurvePoints >= (int)mPoints.size(); }
    int FindIndexForTime(float time);
-   array<CurvePoint,5000> mPoints;
+   std::array<CurvePoint,5000> mPoints;
    int mNumCurvePoints;
    float mWidth;
    float mHeight;

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -250,7 +250,7 @@ void CurveLooper::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void CurveLooper::SetUpFromSaveData()
 {
-   string controlPath = mModuleSaveData.GetString("uicontrol");
+   std::string controlPath = mModuleSaveData.GetString("uicontrol");
    if (!controlPath.empty())
    {
       mUIControl = TheSynth->FindUIControl(controlPath);

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -43,7 +43,7 @@ public:
    ~CurveLooper();
    static IDrawableModule* Create() { return new CurveLooper(); }
    
-   string GetTitleLabel() override { return "curve looper"; }
+   std::string GetTitleLabel() override { return "curve looper"; }
    void CreateUIControls() override;
    
    IUIControl* GetUIControl() const { return mUIControl; }

--- a/Source/DCOffset.h
+++ b/Source/DCOffset.h
@@ -39,7 +39,7 @@ public:
    virtual ~DCOffset();
    static IDrawableModule* Create() { return new DCOffset(); }
    
-   string GetTitleLabel() override { return "dc offset"; }
+   std::string GetTitleLabel() override { return "dc offset"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/DCRemoverEffect.h
+++ b/Source/DCRemoverEffect.h
@@ -39,13 +39,13 @@ public:
    
    static IAudioEffect* Create() { return new DCRemoverEffect(); }
    
-   string GetTitleLabel() override { return "dc remover"; }
+   std::string GetTitleLabel() override { return "dc remover"; }
    
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "dcremover"; }
+   std::string GetType() override { return "dcremover"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    

--- a/Source/DebugAudioSource.h
+++ b/Source/DebugAudioSource.h
@@ -41,7 +41,7 @@ public:
    ~DebugAudioSource();
    static IDrawableModule* Create() { return new DebugAudioSource(); }
    
-   string GetTitleLabel() override { return "debug"; }
+   std::string GetTitleLabel() override { return "debug"; }
    
    //IAudioSource
    void Process(double time) override;

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -44,7 +44,7 @@ public:
    
    static IAudioEffect* Create() { return new DelayEffect(); }
    
-   string GetTitleLabel() override { return "delay"; }
+   std::string GetTitleLabel() override { return "delay"; }
    void CreateUIControls() override;
    bool Enabled() const override { return mEnabled; }
 
@@ -59,7 +59,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override;
    float GetEffectAmount() override;
-   string GetType() override { return "delay"; }
+   std::string GetType() override { return "delay"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/DistortionEffect.h
+++ b/Source/DistortionEffect.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new DistortionEffect(); }
    
-   string GetTitleLabel() override { return "distort"; }
+   std::string GetTitleLabel() override { return "distort"; }
    void CreateUIControls() override;
    
    void SetClip(float amount);
@@ -50,7 +50,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "distortion"; }
+   std::string GetType() override { return "distortion"; }
    
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -75,7 +75,7 @@ DropdownList::~DropdownList()
 {
 }
 
-void DropdownList::AddLabel(string label, int value)
+void DropdownList::AddLabel(std::string label, int value)
 {
    DropdownListElement element;
    element.mLabel = label;
@@ -122,7 +122,7 @@ void DropdownList::CalculateWidth()
    mModalList.SetDimensions(mModalWidth*mColumns, itemSpacing * MIN((int)mElements.size(), mMaxPerColumn));
 }
 
-string DropdownList::GetLabel(int val) const
+std::string DropdownList::GetLabel(int val) const
 {
    for (int i=0; i<mElements.size(); ++i)
    {
@@ -367,7 +367,7 @@ int DropdownList::FindItemIndex(float val) const
    return -1;
 }
 
-string DropdownList::GetDisplayValue(float val) const
+std::string DropdownList::GetDisplayValue(float val) const
 {
    int itemIndex = FindItemIndex(val);
    
@@ -428,7 +428,7 @@ void DropdownList::LoadState(FileStreamIn& in, bool shouldSetValue)
    }
    else
    {
-      string label;
+      std::string label;
       in >> label;
       if (shouldSetValue)
       {
@@ -449,7 +449,7 @@ void DropdownListModal::DrawModule()
    mOwner->DrawDropdown(mWidth, mHeight);
 }
 
-string DropdownListModal::GetHoveredLabel()
+std::string DropdownListModal::GetHoveredLabel()
 {
    int index = mOwner->GetItemIndex((int)mMouseX, (int)mMouseY);
    if (index >= 0 && index < mOwner->GetNumValues())

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -32,7 +32,7 @@
 
 struct DropdownListElement
 {
-   string mLabel;
+   std::string mLabel;
    int mValue;
 };
 
@@ -53,12 +53,12 @@ public:
    void DrawModule() override;
    void SetDimensions(int w, int h) { mWidth = w; mHeight = h; }
    bool HasTitleBar() const override { return false; }
-   string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() override { return ""; }
    void GetDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    bool ShouldClipContents() override { return false; }
    DropdownList* GetOwner() const { return mOwner; }
    bool MouseMoved(float x, float y) override;
-   string GetHoveredLabel();
+   std::string GetHoveredLabel();
    float GetMouseX() { return mMouseX; }
    float GetMouseY() { return mMouseY; }
 private:
@@ -76,9 +76,9 @@ class DropdownList : public IUIControl
 public:
    DropdownList(IDropdownListener* owner, const char* name, int x, int y, int* var, float width = -1);
    DropdownList(IDropdownListener* owner, const char* name, IUIControl* anchor, AnchorDirection anchorDirection, int* var, float width = -1);
-   void AddLabel(string label, int value);
+   void AddLabel(std::string label, int value);
    void RemoveLabel(int value);
-   string GetLabel(int val) const;
+   std::string GetLabel(int val) const;
    void Render() override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
@@ -88,7 +88,7 @@ public:
    void Clear();
    void SetVar(int* var) { mVar = var; }
    EnumMap GetEnumMap();
-   void SetUnknownItemString(string str) { mUnknownItemString = str; CalculateWidth(); }
+   void SetUnknownItemString(std::string str) { mUnknownItemString = str; CalculateWidth(); }
    void DrawLabel(bool draw) { mDrawLabel = draw; }
    void SetWidth(int width) { mWidth = width; }
    void SetDrawTriangle(bool draw) { mDrawTriangle = draw; }
@@ -105,7 +105,7 @@ public:
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    bool InvertScrollDirection() override { return true; }
    void Increment(float amount) override;
    void Poll() override;
@@ -130,11 +130,11 @@ private:
    int mModalWidth;
    int mColumns;
    int mMaxPerColumn;
-   vector<DropdownListElement> mElements;
+   std::vector<DropdownListElement> mElements;
    int* mVar;
    DropdownListModal mModalList;
    IDropdownListener* mOwner;
-   string mUnknownItemString;
+   std::string mUnknownItemString;
    bool mDrawLabel;
    float mLabelSize;
    float mSliderVal;

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -159,7 +159,7 @@ void DrumPlayer::DrumHit::CreateUIControls(DrumPlayer* owner, int index)
 
 namespace
 {
-   static list<string> sHitDirectories;
+   static std::list<std::string> sHitDirectories;
 }
 
 //static
@@ -204,14 +204,14 @@ void DrumPlayer::SetUpNewDrumPlayer()
    ofxJSONElement root;
    root.open(ofToDataPath("drums/drums.json"));
 
-   array<string, NUM_DRUM_HITS> categories = { "808kit/Kick", "808kit/Snare", "808kit/HatClosed", "808kit/HatOpen", "808kit/Kick", "808kit/Clap", "808kit/HatClosed", "808kit/Perc",
+   std::array<std::string, NUM_DRUM_HITS> categories = { "808kit/Kick", "808kit/Snare", "808kit/HatClosed", "808kit/HatOpen", "808kit/Kick", "808kit/Clap", "808kit/HatClosed", "808kit/Perc",
                                                "808kit/Kick", "808kit/Snare", "808kit/HatClosed", "808kit/HatOpen", "808kit/Kick", "808kit/Clap", "808kit/HatClosed", "808kit/Perc" };
    for (size_t i = 0; i < root["directories"].size() && i < categories.size(); ++i)
       categories[i] = root["directories"][i].asString();
 
    for (int i = 0; i < NUM_DRUM_HITS; ++i)
    {
-      string category = categories[i % categories.size()];
+      std::string category = categories[i % categories.size()];
       File dir(ofToDataPath("drums/" + category));
       if (dir.exists())
       {
@@ -535,7 +535,7 @@ void DrumPlayer::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
    }
 }
 
-void DrumPlayer::FilesDropped(vector<string> files, int x, int y)
+void DrumPlayer::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    x -= 5;
    y -= 70;
@@ -858,7 +858,7 @@ void DrumPlayer::SaveKits()
          for (int j=0; j<NUM_DRUM_HITS; ++j)
          {
             //get relative path if it's in our data dir
-            string path = mDrumHits[j].mSample.GetReadPath();
+            std::string path = mDrumHits[j].mSample.GetReadPath();
             ofStringReplace(path, File(ofToDataPath("")).getFullPathName().toStdString(), "");
             
             mKits[i].mSampleFiles[j] = path;
@@ -972,7 +972,7 @@ void DrumPlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
       {
          mAuditionSampleIdx = ofClamp(mAuditionSampleIdx,0,files.size()-1);
          
-         string file = files[mAuditionSampleIdx].getFullPathName().toStdString();
+         std::string file = files[mAuditionSampleIdx].getFullPathName().toStdString();
          if (mSelectedHitIdx >= 0 && mSelectedHitIdx < NUM_DRUM_HITS)
          {
             LoadSampleLock();
@@ -1066,7 +1066,7 @@ void DrumPlayer::DrumHit::LoadRandomSample()
 
    if (files.size() > 0)
    {
-      string file = files[gRandom() % files.size()].getFullPathName().toStdString();
+      std::string file = files[gRandom() % files.size()].getFullPathName().toStdString();
       
       mOwner->LoadSampleLock();
       mSample.Read(file.c_str());
@@ -1081,9 +1081,9 @@ void DrumPlayer::TextEntryComplete(TextEntry* entry)
 {
 }
 
-vector<IUIControl*> DrumPlayer::ControlsToNotSetDuringLoadState() const
+std::vector<IUIControl*> DrumPlayer::ControlsToNotSetDuringLoadState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mKitSelector);
    for (int i=0; i<NUM_DRUM_HITS; ++i)
       ignore.push_back(mDrumHits[i].mHitCategoryDropdown);

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -56,7 +56,7 @@ public:
    ~DrumPlayer();
    static IDrawableModule* Create() { return new DrumPlayer(); }
    
-   string GetTitleLabel() override { return "drumplayer"; }
+   std::string GetTitleLabel() override { return "drumplayer"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -76,7 +76,7 @@ public:
    void SendCC(int control, int value, int voiceIdx = -1) override {}
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    
@@ -103,8 +103,8 @@ private:
 
    struct StoredDrumKit
    {
-      string mName;
-      string mSampleFiles[NUM_DRUM_HITS];
+      std::string mName;
+      std::string mSampleFiles[NUM_DRUM_HITS];
       int mLinkIds[NUM_DRUM_HITS];
       float mVols[NUM_DRUM_HITS];
       float mSpeeds[NUM_DRUM_HITS];
@@ -128,7 +128,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
    void OnClicked(int x, int y, bool right) override;
-   vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
+   std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
    
    ChannelBuffer mOutputBuffer;
    float mSpeed;
@@ -147,7 +147,7 @@ private:
    int mAuditionSampleIdx;
    float mAuditionInc;
    FloatSlider* mAuditionSlider;
-   string mAuditionDir;
+   std::string mAuditionDir;
    char mNewKitName[MAX_TEXTENTRY_LENGTH];
    TextEntry* mNewKitNameEntry;
    ofMutex mLoadSamplesAudioMutex;
@@ -267,7 +267,7 @@ private:
       float mPan;
       int mWiden;
       bool mHasIndividualOutput;
-      string mHitDirectory;
+      std::string mHitDirectory;
       int mButtonHeldVelocity;
       
       DrumPlayer* mOwner;
@@ -285,11 +285,11 @@ private:
       DropdownList* mHitCategoryDropdown;
       FloatSlider* mStartOffsetSlider;
       int mHitCategoryIndex;
-      string mHitCategory;
+      std::string mHitCategory;
       RollingBuffer mWidenerBuffer;
       int mSamplesRemainingToProcess;
 
-      array<Playhead,2> mPlayheads;
+      std::array<Playhead,2> mPlayheads;
       int mCurrentPlayheadIndex;
    };
    

--- a/Source/DrumSynth.cpp
+++ b/Source/DrumSynth.cpp
@@ -190,7 +190,7 @@ void DrumSynth::DrawModule()
          
          ofSetColor(255,255,255,gModuleDrawAlpha);
          
-         string name = ofToString(i);
+         std::string name = ofToString(i);
          DrawTextNormal(name,mHits[i]->mX+5,mHits[i]->mY+12);
          
          mHits[i]->Draw();

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -59,7 +59,7 @@ public:
    ~DrumSynth();
    static IDrawableModule* Create() { return new DrumSynth(); }
    
-   string GetTitleLabel() override { return "drumsynth"; }
+   std::string GetTitleLabel() override { return "drumsynth"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/EQEffect.h
+++ b/Source/EQEffect.h
@@ -46,7 +46,7 @@ public:
    
    static IAudioEffect* Create() { return new EQEffect(); }
    
-   string GetTitleLabel() override { return "basiceq"; }
+   std::string GetTitleLabel() override { return "basiceq"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -55,7 +55,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "basiceq"; }
+   std::string GetType() override { return "basiceq"; }
    
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -42,7 +42,7 @@ public:
    virtual ~EQModule();
    static IDrawableModule* Create() { return new EQModule(); }
 
-   string GetTitleLabel() override { return "eq"; }
+   std::string GetTitleLabel() override { return "eq"; }
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -76,7 +76,7 @@ void EffectChain::Init()
    mInitialized = true;
 }
 
-void EffectChain::AddEffect(string type, bool onTheFly /*=false*/)
+void EffectChain::AddEffect(std::string type, bool onTheFly /*=false*/)
 {
    assert(mEffects.size() < MAX_EFFECTS_IN_CHAIN - 1);
  
@@ -84,10 +84,10 @@ void EffectChain::AddEffect(string type, bool onTheFly /*=false*/)
    if (effect == nullptr)
       throw UnknownEffectTypeException();
    assert(effect->GetType() == type);  //make sure things are named the same in code
-   vector<string> otherEffectNames;
+   std::vector<std::string> otherEffectNames;
    for (auto* e : mEffects)
       otherEffectNames.push_back(e->Name());
-   string name = GetUniqueName(type, otherEffectNames);
+   std::string name = GetUniqueName(type, otherEffectNames);
    effect->SetName(name.c_str());
    effect->SetTypeName(type);
    effect->SetParent(this);
@@ -193,7 +193,7 @@ void EffectChain::DrawModule()
    mEffectSpawnList->SetShowing(mShowSpawnList);
    mSpawnEffectButton->SetShowing(mShowSpawnList && mSpawnIndex != -1);
    if (mSpawnIndex != -1)
-      mSpawnEffectButton->SetLabel((string("spawn ") + mEffectSpawnList->GetLabel(mSpawnIndex)).c_str());
+      mSpawnEffectButton->SetLabel((std::string("spawn ") + mEffectSpawnList->GetLabel(mSpawnIndex)).c_str());
 
    for (int i=0; i<mEffects.size(); ++i)
    {
@@ -320,7 +320,7 @@ ofVec2f EffectChain::GetEffectPos(int index) const
    return ofVec2f(xPos, yPos);
 }
 
-void EffectChain::GetPush2OverrideControls(vector<IUIControl*>& controls) const
+void EffectChain::GetPush2OverrideControls(std::vector<IUIControl*>& controls) const
 {
    int effectIndex = -1;
    if (mPush2DisplayEffect != nullptr)
@@ -497,7 +497,7 @@ void EffectChain::ButtonClicked(ClickButton* button)
       if (button == mEffectControls[i].mPush2DisplayEffectButton)
       {
          mPush2DisplayEffect = mEffects[i];
-         mPush2ExitEffectButton->SetLabel((string("exit ") + mEffects[i]->Name()).c_str());
+         mPush2ExitEffectButton->SetLabel((std::string("exit ") + mEffects[i]->Name()).c_str());
       }
    }
 }
@@ -522,14 +522,14 @@ void EffectChain::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-vector<IUIControl*> EffectChain::ControlsToIgnoreInSaveState() const
+std::vector<IUIControl*> EffectChain::ControlsToIgnoreInSaveState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mSpawnEffectButton);
    return ignore;
 }
 
-void EffectChain::UpdateOldControlName(string& oldName)
+void EffectChain::UpdateOldControlName(std::string& oldName)
 {
    IDrawableModule::UpdateOldControlName(oldName);
 
@@ -537,7 +537,7 @@ void EffectChain::UpdateOldControlName(string& oldName)
       ofStringReplace(oldName, "dw", "mix");
 }
 
-void EffectChain::LoadBasics(const ofxJSONElement& moduleInfo, string typeName)
+void EffectChain::LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName)
 {
    IDrawableModule::LoadBasics(moduleInfo, typeName);
    
@@ -545,7 +545,7 @@ void EffectChain::LoadBasics(const ofxJSONElement& moduleInfo, string typeName)
    
    for (int i=0; i<effects.size(); ++i)
    {
-      string type = effects[i]["type"].asString();
+      std::string type = effects[i]["type"].asString();
       AddEffect(type);
    }
 }
@@ -561,7 +561,7 @@ void EffectChain::LoadLayout(const ofxJSONElement& moduleInfo)
    assert(mEffects.size() == effects.size());
    for (int i=0; i<mEffects.size(); ++i)
    {
-      string type = effects[i]["type"].asString();
+      std::string type = effects[i]["type"].asString();
       assert(mEffects[i]->GetType() == type);
       mEffects[i]->LoadLayout(effects[i]);
    }

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -46,13 +46,13 @@ public:
    virtual ~EffectChain();
    static IDrawableModule* Create() { return new EffectChain(); }
    
-   string GetTitleLabel() override { return "effect chain"; }
+   std::string GetTitleLabel() override { return "effect chain"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    void Init() override;
    void Poll() override;
-   void AddEffect(string type, bool onTheFly = false);
+   void AddEffect(std::string type, bool onTheFly = false);
    void SetWideCount(int count) { mNumFXWide = count; }
    
    //IAudioSource
@@ -62,25 +62,25 @@ public:
    void KeyReleased(int key) override;
 
    bool HasPush2OverrideControls() const override { return true; }
-   void GetPush2OverrideControls(vector<IUIControl*>& controls) const override;
+   void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const override;
 
    void ButtonClicked(ClickButton* button) override;
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    
-   virtual void LoadBasics(const ofxJSONElement& moduleInfo, string typeName) override;
+   virtual void LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName) override;
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
-   virtual void UpdateOldControlName(string& oldName) override;
+   virtual void UpdateOldControlName(std::string& oldName) override;
    
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
+   std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
    
    int GetRowHeight(int row) const;
    int NumRows() const;
@@ -98,9 +98,9 @@ private:
       ClickButton* mPush2DisplayEffectButton;
    };
    
-   vector<IAudioEffect*> mEffects;
+   std::vector<IAudioEffect*> mEffects;
    ChannelBuffer mDryBuffer;
-   vector<EffectControls> mEffectControls;
+   std::vector<EffectControls> mEffectControls;
    std::array<float, MAX_EFFECTS_IN_CHAIN> mDryWetLevels;
    
    double mSwapTime;
@@ -116,7 +116,7 @@ private:
    int mWantToDeleteEffectAtIndex;
    IAudioEffect* mPush2DisplayEffect;
    
-   std::vector<string> mEffectTypesToSpawn;
+   std::vector<std::string> mEffectTypesToSpawn;
    int mSpawnIndex;
    DropdownList* mEffectSpawnList;
    ClickButton* mSpawnEffectButton;

--- a/Source/EffectFactory.cpp
+++ b/Source/EffectFactory.cpp
@@ -72,12 +72,12 @@ EffectFactory::EffectFactory()
    Register("gainstage", &(GainStageEffect::Create));
 }
 
-void EffectFactory::Register(string type, CreateEffectFn creator)
+void EffectFactory::Register(std::string type, CreateEffectFn creator)
 {
    mFactoryMap[type] = creator;
 }
 
-IAudioEffect* EffectFactory::MakeEffect(string type)
+IAudioEffect* EffectFactory::MakeEffect(std::string type)
 {
    if (type == "eq") //fix up old save data
       type = "basiceq";
@@ -88,9 +88,9 @@ IAudioEffect* EffectFactory::MakeEffect(string type)
    return nullptr;
 }
 
-vector<string> EffectFactory::GetSpawnableEffects()
+std::vector<std::string> EffectFactory::GetSpawnableEffects()
 {
-   vector<string> effects;
+   std::vector<std::string> effects;
    for (auto iter = mFactoryMap.begin(); iter != mFactoryMap.end(); ++iter)
       effects.push_back(iter->first);
    sort(effects.begin(), effects.end());

--- a/Source/EffectFactory.h
+++ b/Source/EffectFactory.h
@@ -36,11 +36,11 @@ class EffectFactory
 {
 public:
    EffectFactory();
-   IAudioEffect* MakeEffect(string type);
-   vector<string> GetSpawnableEffects();
+   IAudioEffect* MakeEffect(std::string type);
+   std::vector<std::string> GetSpawnableEffects();
 private:
-   void Register(string type, CreateEffectFn creator);
-   map<string, CreateEffectFn> mFactoryMap;
+   void Register(std::string type, CreateEffectFn creator);
+   std::map<std::string, CreateEffectFn> mFactoryMap;
 };
 
 #endif /* defined(__Bespoke__EffectFactory__) */

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -84,7 +84,7 @@ public:
    void SetEnabled(bool enabled) override {} //don't use this one
    bool Enabled() const override { return true; }
    bool HasTitleBar() const override { return mPinned; }
-   string GetTitleLabel() override { return mPinned ? "envelope editor" : ""; }
+   std::string GetTitleLabel() override { return mPinned ? "envelope editor" : ""; }
    bool IsSaveable() override { return mPinned; }
    void CreateUIControls() override;
    void MouseReleased() override;

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -220,7 +220,7 @@ void EnvelopeModulator::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -51,7 +51,7 @@ public:
    void Start(double time, const ::ADSR& adsr);
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    bool Enabled() const override { return mEnabled; }
-   string GetTitleLabel() override { return "envelope"; }
+   std::string GetTitleLabel() override { return "envelope"; }
    void CreateUIControls() override;
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -429,7 +429,7 @@ void EventCanvas::SaveState(FileStreamOut& out)
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
    {
-      string path = "";
+      std::string path = "";
       if (cable->GetTarget())
          path = cable->GetTarget()->Path();
       out << path;
@@ -451,7 +451,7 @@ void EventCanvas::LoadState(FileStreamIn& in)
    mControlCables.resize(size);
    for (auto cable : mControlCables)
    {
-      string path;
+      std::string path;
       in >> path;
       cable->SetTarget(TheSynth->FindUIControl(path));
    }
@@ -459,9 +459,9 @@ void EventCanvas::LoadState(FileStreamIn& in)
    mCanvas->LoadState(in);
 }
 
-vector<IUIControl*> EventCanvas::ControlsToIgnoreInSaveState() const
+std::vector<IUIControl*> EventCanvas::ControlsToIgnoreInSaveState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mCanvas);
    return ignore;
 }

--- a/Source/EventCanvas.h
+++ b/Source/EventCanvas.h
@@ -45,7 +45,7 @@ public:
    ~EventCanvas();
    static IDrawableModule* Create() { return new EventCanvas(); }
    
-   string GetTitleLabel() override { return "event canvas"; }
+   std::string GetTitleLabel() override { return "event canvas"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -62,7 +62,7 @@ public:
    
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
    
-   vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
+   std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
@@ -96,8 +96,8 @@ private:
    NoteInterval mInterval;
    DropdownList* mIntervalSelector;
    float mPosition;
-   vector<PatchCableSource*> mControlCables;
-   vector<ofColor> mRowColors;
+   std::vector<PatchCableSource*> mControlCables;
+   std::vector<ofColor> mRowColors;
    bool mRecord;
    Checkbox* mRecordCheckbox;
    float mPreviousPosition;
@@ -109,7 +109,7 @@ private:
    };
    
    const int kMaxEventRows = 256;
-   vector<ControlConnection> mRowConnections;
+   std::vector<ControlConnection> mRowConnections;
 };
 
 #endif /* defined(__Bespoke__EventCanvas__) */

--- a/Source/FFTtoAdditive.h
+++ b/Source/FFTtoAdditive.h
@@ -46,7 +46,7 @@ public:
    virtual ~FFTtoAdditive();
    static IDrawableModule* Create() { return new FFTtoAdditive(); }
    
-   string GetTitleLabel() override { return "fft to additive"; }
+   std::string GetTitleLabel() override { return "fft to additive"; }
    void CreateUIControls() override;
 
    //IAudioReceiver

--- a/Source/FMSynth.cpp
+++ b/Source/FMSynth.cpp
@@ -188,7 +188,7 @@ void FMSynth::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modul
 
    if (mDrawDebug)
    {
-      vector<string> lines = ofSplitString(mDebugLines, "\n");
+      std::vector<std::string> lines = ofSplitString(mDebugLines, "\n");
       mDebugLines = "";
       const int kNumDisplayLines = 10;
       for (int i = 0; i < kNumDisplayLines - 1; ++i)
@@ -197,7 +197,7 @@ void FMSynth::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modul
          if (lineIndex >= 0)
             mDebugLines += lines[lineIndex] + "\n";
       }
-      string debugLine = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
+      std::string debugLine = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
       mDebugLines += debugLine;
       ofLog() << debugLine;
    }

--- a/Source/FMSynth.h
+++ b/Source/FMSynth.h
@@ -44,7 +44,7 @@ public:
    ~FMSynth();
    static IDrawableModule* Create() { return new FMSynth(); }
    
-   string GetTitleLabel() override { return "FM"; }
+   std::string GetTitleLabel() override { return "FM"; }
    void CreateUIControls() override;
 
    //IAudioSource
@@ -100,7 +100,7 @@ private:
 
    ChannelBuffer mWriteBuffer;
 
-   string mDebugLines;
+   std::string mDebugLines;
 };
 
 #endif /* defined(__modularSynth__FMSynth__) */

--- a/Source/FeedbackModule.h
+++ b/Source/FeedbackModule.h
@@ -40,7 +40,7 @@ public:
    virtual ~FeedbackModule();
    static IDrawableModule* Create() { return new FeedbackModule(); }
    
-   string GetTitleLabel() override { return "feedback"; }
+   std::string GetTitleLabel() override { return "feedback"; }
    void CreateUIControls() override;
    
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/FillSaveDropdown.h
+++ b/Source/FillSaveDropdown.h
@@ -32,7 +32,7 @@
 template <class T> void FillDropdown(DropdownList* list)
 {
    assert(list);
-   vector<string> modules = TheSynth->GetModuleNames<T>();
+   std::vector<std::string> modules = TheSynth->GetModuleNames<T>();
    list->AddLabel("",-1);
    for (int i=0; i<modules.size(); ++i)
       list->AddLabel(modules[i].c_str(), i);

--- a/Source/FilterViz.h
+++ b/Source/FilterViz.h
@@ -42,7 +42,7 @@ public:
    ~FilterViz();
    static IDrawableModule* Create() { return new FilterViz(); }
    
-   string GetTitleLabel() override { return "filter viz"; }
+   std::string GetTitleLabel() override { return "filter viz"; }
    void CreateUIControls() override;
    
    //IDrawableModule
@@ -65,7 +65,7 @@ private:
    float* mFFTOutImag;
    
    bool mNeedUpdate;
-   vector<IAudioEffect*> mFilters;
+   std::vector<IAudioEffect*> mFilters;
 };
 
 #endif /* defined(__Bespoke__FilterViz__) */

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -88,7 +88,7 @@ public:
    FloatSlider* GetOwner() { return mTarget; }
    bool Enabled() const override { return mEnabled; }
    bool HasTitleBar() const override { return mPinned; }
-   string GetTitleLabel() override { return mPinned ? "lfo" : ""; }
+   std::string GetTitleLabel() override { return mPinned ? "lfo" : ""; }
    bool IsSaveable() override { return mPinned; }
    void CreateUIControls() override;
    bool IsPinned() const { return mPinned; }

--- a/Source/FollowingSong.h
+++ b/Source/FollowingSong.h
@@ -45,7 +45,7 @@ public:
    ~FollowingSong();
    static IDrawableModule* Create() { return new FollowingSong(); }
    
-   string GetTitleLabel() override { return "following song"; }
+   std::string GetTitleLabel() override { return "following song"; }
    void CreateUIControls() override;
    
    void LoadSample(const char* file);

--- a/Source/FormantFilterEffect.cpp
+++ b/Source/FormantFilterEffect.cpp
@@ -141,7 +141,7 @@ void FormantFilterEffect::UpdateFilters()
    if (total == 0)
       return;
    
-   vector<float> formant;
+   std::vector<float> formant;
    formant.resize(NUM_FORMANT_BANDS);
    formant.assign(NUM_FORMANT_BANDS, 0);
    

--- a/Source/FormantFilterEffect.h
+++ b/Source/FormantFilterEffect.h
@@ -42,7 +42,7 @@ public:
    
    static IAudioEffect* Create() { return new FormantFilterEffect(); }
    
-   string GetTitleLabel() override { return "formant"; }
+   std::string GetTitleLabel() override { return "formant"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -51,7 +51,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "formant"; }
+   std::string GetType() override { return "formant"; }
    
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void CheckboxUpdated(Checkbox* checkbox) override;
@@ -87,7 +87,7 @@ private:
    FloatSlider* mESlider;
    FloatSlider* mUSlider;
    FloatSlider* mASlider;
-   vector<FloatSlider*> mSliders;
+   std::vector<FloatSlider*> mSliders;
    bool mRescaling;
    float mWidth;
    float mHeight;
@@ -108,7 +108,7 @@ private:
       float mGains[NUM_FORMANT_BANDS];
    };
    
-   vector<Formants> mFormants;
+   std::vector<Formants> mFormants;
    float* mOutputBuffer;
 };
 

--- a/Source/FourOnTheFloor.h
+++ b/Source/FourOnTheFloor.h
@@ -39,7 +39,7 @@ public:
    ~FourOnTheFloor();
    static IDrawableModule* Create() { return new FourOnTheFloor(); }
    
-   string GetTitleLabel() override { return "four on the floor"; }
+   std::string GetTitleLabel() override { return "four on the floor"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/FreeverbEffect.h
+++ b/Source/FreeverbEffect.h
@@ -40,14 +40,14 @@ public:
    
    static IAudioEffect* Create() { return new FreeverbEffect(); }
    
-   string GetTitleLabel() override { return "freeverb"; }
+   std::string GetTitleLabel() override { return "freeverb"; }
    void CreateUIControls() override;
    
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "freeverb"; }
+   std::string GetType() override { return "freeverb"; }
    
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/FreqDelay.h
+++ b/Source/FreqDelay.h
@@ -40,7 +40,7 @@ public:
    virtual ~FreqDelay();
    static IDrawableModule* Create() { return new FreqDelay(); }
    
-   string GetTitleLabel() override { return "freq delay"; }
+   std::string GetTitleLabel() override { return "freq delay"; }
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/FreqDomainBoilerplate.h
+++ b/Source/FreqDomainBoilerplate.h
@@ -43,7 +43,7 @@ public:
    virtual ~FreqDomainBoilerplate();
    static IDrawableModule* Create() { return new FreqDomainBoilerplate(); }
    
-   string GetTitleLabel() override { return "freq domain"; }
+   std::string GetTitleLabel() override { return "freq domain"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -510,7 +510,7 @@ void FubbleModule::LoadLayout(const ofxJSONElement& moduleInfo)
 void FubbleModule::SetUpFromSaveData()
 {
    {
-      string controlPathH = mModuleSaveData.GetString("uicontrol_h");
+      std::string controlPathH = mModuleSaveData.GetString("uicontrol_h");
       if (!controlPathH.empty())
       {
          auto uicontrol = TheSynth->FindUIControl(controlPathH);
@@ -523,7 +523,7 @@ void FubbleModule::SetUpFromSaveData()
    }
    
    {
-      string controlPathV = mModuleSaveData.GetString("uicontrol_v");
+      std::string controlPathV = mModuleSaveData.GetString("uicontrol_v");
       if (!controlPathV.empty())
       {
          auto uicontrol = TheSynth->FindUIControl(controlPathV);

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -47,7 +47,7 @@ public:
    ~FubbleModule();
    static IDrawableModule* Create() { return new FubbleModule(); }
    
-   string GetTitleLabel() override { return "fubble"; }
+   std::string GetTitleLabel() override { return "fubble"; }
    void CreateUIControls() override;
    
    //IDrawableModule

--- a/Source/GainStageEffect.h
+++ b/Source/GainStageEffect.h
@@ -36,13 +36,13 @@ public:
    GainStageEffect();
    static IAudioEffect* Create() { return new GainStageEffect(); }
    
-   string GetTitleLabel() override { return "gain stage"; }
+   std::string GetTitleLabel() override { return "gain stage"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   string GetType() override { return "gainstage"; }
+   std::string GetType() override { return "gainstage"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/GateEffect.h
+++ b/Source/GateEffect.h
@@ -37,7 +37,7 @@ public:
    GateEffect();
    static IAudioEffect* Create() { return new GateEffect(); }
    
-   string GetTitleLabel() override { return "gate"; }
+   std::string GetTitleLabel() override { return "gate"; }
    void CreateUIControls() override;
    
    void SetAttack(float ms) { mAttackTime = ms; }
@@ -47,7 +47,7 @@ public:
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   string GetType() override { return "gate"; }
+   std::string GetType() override { return "gate"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void IntSliderUpdated(IntSlider* slider, int oldVal) override;

--- a/Source/GlobalControls.cpp
+++ b/Source/GlobalControls.cpp
@@ -121,9 +121,9 @@ void GlobalControls::SaveLayout(ofxJSONElement& moduleInfo)
    IDrawableModule::SaveLayout(moduleInfo);
 }
 
-vector<IUIControl*> GlobalControls::ControlsToNotSetDuringLoadState() const
+std::vector<IUIControl*> GlobalControls::ControlsToNotSetDuringLoadState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mZoomSlider);
    ignore.push_back(mXSlider);
    ignore.push_back(mYSlider);

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -38,7 +38,7 @@ public:
    virtual ~GlobalControls();
    static IDrawableModule* Create() { return new GlobalControls(); }
 
-   string GetTitleLabel() override { return "global controls"; }
+   std::string GetTitleLabel() override { return "global controls"; }
    void CreateUIControls() override;
    void Poll() override;
 
@@ -49,7 +49,7 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
-   vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
+   std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 
 private:
    //IDrawableModule

--- a/Source/GridController.h
+++ b/Source/GridController.h
@@ -128,7 +128,7 @@ private:
    int mControls[MAX_GRIDCONTROLLER_COLS][MAX_GRIDCONTROLLER_ROWS];
    float mInput[MAX_GRIDCONTROLLER_COLS][MAX_GRIDCONTROLLER_ROWS];
    int mLights[MAX_GRIDCONTROLLER_COLS][MAX_GRIDCONTROLLER_ROWS];
-   vector<int> mColors;
+   std::vector<int> mColors;
    MidiMessageType mMessageType;
    MidiController* mMidiController;
    int mControllerPage;

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -222,7 +222,7 @@ void GridModule::SetCellColor(int col, int row, int colorIndex)
    
 }
 
-void GridModule::SetLabel(int row, string label)
+void GridModule::SetLabel(int row, std::string label)
 {
    if (row >= (int)mLabels.size())
       mLabels.resize(row+1);

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -46,13 +46,13 @@ public:
    ~GridModule();
    static IDrawableModule* Create() { return new GridModule(); }
    
-   string GetTitleLabel() override { return "grid"; }
+   std::string GetTitleLabel() override { return "grid"; }
    void CreateUIControls() override;
    
    void Init() override;
    
    void SetGrid(int cols, int rows) { mGrid->SetGrid(cols, rows); }
-   void SetLabel(int row, string label);
+   void SetLabel(int row, std::string label);
    void Set(int col, int row, float value) { mGrid->SetVal(col, row, value, !K(notifyListener)); UpdateLights(); }
    float Get(int col, int row) { return mGrid->GetVal(col, row); }
    void HighlightCell(int col, int row, double time, double duration, int colorIndex);
@@ -113,8 +113,8 @@ private:
    IGridControllerListener* mGridControllerOwner;
    
    UIGrid* mGrid;
-   vector<string> mLabels;
-   vector<ofColor> mColors;
+   std::vector<std::string> mLabels;
+   std::vector<ofColor> mColors;
    
    struct HighlightCellElement
    {

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -229,7 +229,7 @@ void GridSliders::SaveState(FileStreamOut& out)
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
    {
-      string path = "";
+      std::string path = "";
       if (cable->GetTarget())
          path = cable->GetTarget()->Path();
       out << path;
@@ -248,7 +248,7 @@ void GridSliders::LoadState(FileStreamIn& in)
    in >> size;
    for (int i=0; i<size; ++i)
    {
-      string path;
+      std::string path;
       in >> path;
       if (i < (int)mControlCables.size())
          mControlCables[i]->SetTarget(TheSynth->FindUIControl(path));

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -42,7 +42,7 @@ public:
    ~GridSliders();
    static IDrawableModule* Create() { return new GridSliders(); }
 
-   string GetTitleLabel() override { return "grid sliders"; }
+   std::string GetTitleLabel() override { return "grid sliders"; }
    void CreateUIControls() override;
 
    //IDrawableModule

--- a/Source/GroupControl.cpp
+++ b/Source/GroupControl.cpp
@@ -110,7 +110,7 @@ void GroupControl::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["uicontrols"].resize((unsigned int)mControlCables.size()-1);
    for (int i=0; i<mControlCables.size()-1; ++i)
    {
-      string controlName = "";
+      std::string controlName = "";
       if (mControlCables[i]->GetTarget())
          controlName = mControlCables[i]->GetTarget()->Path();
       moduleInfo["uicontrols"][i] = controlName;
@@ -123,7 +123,7 @@ void GroupControl::LoadLayout(const ofxJSONElement& moduleInfo)
    
    for (int i=0; i<controls.size(); ++i)
    {
-      string controlPath = controls[i].asString();
+      std::string controlPath = controls[i].asString();
       IUIControl* control = nullptr;
       if (!controlPath.empty())
          control = TheSynth->FindUIControl(controlPath);

--- a/Source/GroupControl.h
+++ b/Source/GroupControl.h
@@ -38,7 +38,7 @@ public:
    ~GroupControl();
    static IDrawableModule* Create() { return new GroupControl(); }
    
-   string GetTitleLabel() override { return "group control"; }
+   std::string GetTitleLabel() override { return "group control"; }
    void CreateUIControls() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;
@@ -59,7 +59,7 @@ private:
    Checkbox* mGroupCheckbox;
    bool mGroupEnabled;
    
-   vector<PatchCableSource*> mControlCables;
+   std::vector<PatchCableSource*> mControlCables;
 };
 
 #endif /* defined(__Bespoke__GroupControl__) */

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -35,7 +35,7 @@
 
 bool HelpDisplay::sShowTooltips = false;
 bool HelpDisplay::sTooltipsLoaded = false;
-list<HelpDisplay::ModuleTooltipInfo> HelpDisplay::sTooltips;
+std::list<HelpDisplay::ModuleTooltipInfo> HelpDisplay::sTooltips;
 
 HelpDisplay::HelpDisplay()
 : mShowTooltipsCheckbox(nullptr)
@@ -73,7 +73,7 @@ void HelpDisplay::LoadHelp()
    juce::File file(ofToResourcePath("help.txt").c_str());
    if (file.existsAsFile())
    {
-      string help = file.loadFileAsString().toStdString();
+      std::string help = file.loadFileAsString().toStdString();
       ofStringReplace(help, "\r", "");
       mHelpText = ofSplitString(help, "\n");
    }
@@ -87,7 +87,7 @@ void HelpDisplay::DrawModule()
    ofRect(0,0,mWidth,mHeight);
    ofPopStyle();
 
-   DrawTextLeftJustify(juce::JUCEApplication::getInstance()->getApplicationVersion().toStdString() + " (" + string(__DATE__) + " " + string(__TIME__) + ")", mWidth-5, 12);
+   DrawTextLeftJustify(juce::JUCEApplication::getInstance()->getApplicationVersion().toStdString() + " (" + std::string(__DATE__) + " " + std::string(__TIME__) + ")", mWidth-5, 12);
    
    mShowTooltipsCheckbox->Draw();
    mDumpModuleInfoButton->SetShowing(GetKeyModifiers() == kModifier_Shift);
@@ -116,11 +116,11 @@ void HelpDisplay::DrawModule()
    {
       if (mScreenshotModule != nullptr)
       {
-         string typeName = mScreenshotModule->GetTypeName();
+         std::string typeName = mScreenshotModule->GetTypeName();
          if (!mScreenshotsToProcess.empty())
          {
             typeName = *mScreenshotsToProcess.begin();
-            ofStringReplace(typeName, " " + string(ModuleFactory::kEffectChainSuffix), "");   //strip this suffix if it's there
+            ofStringReplace(typeName, " " + std::string(ModuleFactory::kEffectChainSuffix), "");   //strip this suffix if it's there
             mScreenshotsToProcess.pop_front();
          }
 
@@ -176,7 +176,7 @@ void HelpDisplay::CheckboxUpdated(Checkbox* checkbox)
 
 void HelpDisplay::LoadTooltips()
 {
-   string tooltipsPath;
+   std::string tooltipsPath;
    if (TheSynth->GetUserPrefs()["tooltips"].isNull() || !juce::File(ofToResourcePath(TheSynth->GetUserPrefs()["tooltips"].asString())).existsAsFile())
       tooltipsPath = ofToResourcePath("tooltips_eng.txt");
    else
@@ -198,7 +198,7 @@ void HelpDisplay::LoadTooltips()
          if (lines[i].isNotEmpty())
          {
             juce::String line = lines[i].replace("\\n", "\n");
-            vector<string> tokens = ofSplitString(line.toStdString(), "~");
+            std::vector<std::string> tokens = ofSplitString(line.toStdString(), "~");
             if (tokens.size() == 2)
             {
                if (!moduleInfo.module.empty())
@@ -222,7 +222,7 @@ void HelpDisplay::LoadTooltips()
    sTooltipsLoaded = true;
 }
 
-HelpDisplay::ModuleTooltipInfo* HelpDisplay::FindModuleInfo(string moduleTypeName)
+HelpDisplay::ModuleTooltipInfo* HelpDisplay::FindModuleInfo(std::string moduleTypeName)
 {
    for (auto& info : sTooltips)
    {
@@ -256,7 +256,7 @@ namespace
 
       // lookup table for storing results of
       // subproblems
-      std::vector<std::vector<bool>> lookup(n+1, vector<bool>(m+1));
+      std::vector<std::vector<bool>> lookup(n+1, std::vector<bool>(m+1));
 
       // empty pattern can match with empty string
       lookup[0][0] = true;
@@ -305,7 +305,7 @@ HelpDisplay::UIControlTooltipInfo* HelpDisplay::FindControlInfo(IUIControl* cont
       moduleInfo = FindModuleInfo(parent->GetTypeName());
    if (moduleInfo)
    {
-      string controlName = control->Name();
+      std::string controlName = control->Name();
       for (auto& info : moduleInfo->controlTooltips)
       {
          if (StringMatch(info.controlName, controlName))
@@ -319,7 +319,7 @@ HelpDisplay::UIControlTooltipInfo* HelpDisplay::FindControlInfo(IUIControl* cont
       moduleInfo = FindModuleInfo(parent->GetTypeName());
    if (moduleInfo)
    {
-      string controlName = control->Name();
+      std::string controlName = control->Name();
       for (auto& info : moduleInfo->controlTooltips)
       {
          if (StringMatch(info.controlName, controlName))
@@ -330,10 +330,10 @@ HelpDisplay::UIControlTooltipInfo* HelpDisplay::FindControlInfo(IUIControl* cont
    return nullptr;
 }
 
-string HelpDisplay::GetUIControlTooltip(IUIControl* control)
+std::string HelpDisplay::GetUIControlTooltip(IUIControl* control)
 {
-   string name = control->Name();
-   string tooltip;
+   std::string name = control->Name();
+   std::string tooltip;
 
    UIControlTooltipInfo* controlInfo = FindControlInfo(control);
    if (controlInfo && controlInfo->tooltip.size() > 0)
@@ -344,7 +344,7 @@ string HelpDisplay::GetUIControlTooltip(IUIControl* control)
    return name + ": " + tooltip;
 }
 
-string HelpDisplay::GetModuleTooltip(IDrawableModule* module)
+std::string HelpDisplay::GetModuleTooltip(IDrawableModule* module)
 {
    if (module == TheTitleBar)
       return "";
@@ -352,9 +352,9 @@ string HelpDisplay::GetModuleTooltip(IDrawableModule* module)
    return GetModuleTooltipFromName(module->GetTypeName());
 }
 
-string HelpDisplay::GetModuleTooltipFromName(string moduleTypeName)
+std::string HelpDisplay::GetModuleTooltipFromName(std::string moduleTypeName)
 {
-   string tooltip;
+   std::string tooltip;
 
    ModuleTooltipInfo* moduleInfo = FindModuleInfo(moduleTypeName);
    if (moduleInfo && moduleInfo->tooltip.size() > 0)
@@ -383,7 +383,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
    {
       LoadTooltips();
 
-      vector<ModuleType> moduleTypes = {
+      std::vector<ModuleType> moduleTypes = {
                                           kModuleType_Note,
                                           kModuleType_Synth,
                                           kModuleType_Audio,
@@ -395,13 +395,13 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
                                        };
       for (auto type : moduleTypes)
       {
-         vector<string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
+         std::vector<std::string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
          for (auto toSpawn : spawnable)
             TheSynth->SpawnModuleOnTheFly(toSpawn, 0, 0);
       }
 
-      string output;
-      vector<IDrawableModule*> modules;
+      std::string output;
+      std::vector<IDrawableModule*> modules;
       TheSynth->GetAllModules(modules);
 
       for (auto* topLevelModule : modules)
@@ -409,24 +409,24 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
          if (topLevelModule->GetTypeName() == "effectchain")
          {
             EffectChain* effectChain = dynamic_cast<EffectChain*>(topLevelModule);
-            vector<string> effects = TheSynth->GetEffectFactory()->GetSpawnableEffects();
-            for (string effect : effects)
+            std::vector<std::string> effects = TheSynth->GetEffectFactory()->GetSpawnableEffects();
+            for (std::string effect : effects)
                effectChain->AddEffect(effect);
          }
          
-         vector<IDrawableModule*> toDump;
+         std::vector<IDrawableModule*> toDump;
          toDump.push_back(topLevelModule);
          for (auto* child : topLevelModule->GetChildren())
             toDump.push_back(child);
 
-         list<string> addedModuleNames;
+         std::list<std::string> addedModuleNames;
          for (auto* module : toDump)
          {
             if (ListContains(module->GetTypeName(), addedModuleNames) || module->GetTypeName().length() == 0)
                continue;
             addedModuleNames.push_back(module->GetTypeName());
             
-            string moduleTooltip = "[no tooltip]";
+            std::string moduleTooltip = "[no tooltip]";
             ModuleTooltipInfo* moduleInfo = FindModuleInfo(module->GetTypeName());
             if (moduleInfo)
             {
@@ -434,17 +434,17 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
                ofStringReplace(moduleTooltip,"\n","\\n");
             }
             output += "\n\n\n" + module->GetTypeName() + "~"+moduleTooltip+"\n";
-            vector<IUIControl*> controls = module->GetUIControls();
-            list<string> addedControlNames;
+            std::vector<IUIControl*> controls = module->GetUIControls();
+            std::list<std::string> addedControlNames;
             for (auto* control : controls)
             {
                if (control->GetParent() != module && VectorContains(dynamic_cast<IDrawableModule*>(control->GetParent()), toDump))
                   continue;   //we'll print this control's info when we are printing for the specific parent module
                
-               string controlName = control->Name();
+               std::string controlName = control->Name();
                if (controlName != "enabled")
                {
-                  string controlTooltip = "[no tooltip]";
+                  std::string controlTooltip = "[no tooltip]";
                   UIControlTooltipInfo* controlInfo = FindControlInfo(control);
                   if (controlInfo)
                   {
@@ -471,7 +471,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
       mScreenshotsToProcess.push_back("drumplayer");
       mScreenshotsToProcess.push_back("notesequencer");*/
 
-      vector<ModuleType> moduleTypes = {
+      std::vector<ModuleType> moduleTypes = {
                                           kModuleType_Note,
                                           kModuleType_Synth,
                                           kModuleType_Audio,
@@ -483,7 +483,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
       };
       for (auto type : moduleTypes)
       {
-         vector<string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
+         std::vector<std::string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
          for (auto toSpawn : spawnable)
             mScreenshotsToProcess.push_back(toSpawn);
       }
@@ -504,7 +504,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
             docs[moduleType.module]["controls"][control.controlName] = control.tooltip;
          }
 
-         string typeName = "unknown";
+         std::string typeName = "unknown";
          if (moduleType.module == "scale" || moduleType.module == "transport" || moduleType.module == "vstplugin")
             typeName = "other";
 
@@ -514,7 +514,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
          docs[moduleType.module]["canReceivePulses"] = false;
       }
 
-      vector<ModuleType> moduleTypes = {
+      std::vector<ModuleType> moduleTypes = {
                                           kModuleType_Note,
                                           kModuleType_Synth,
                                           kModuleType_Audio,
@@ -526,12 +526,12 @@ void HelpDisplay::ButtonClicked(ClickButton* button)
       };
       for (auto type : moduleTypes)
       {
-         vector<string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
+         std::vector<std::string> spawnable = TheSynth->GetModuleFactory()->GetSpawnableModules(type);
          for (auto toSpawn : spawnable)
          {
             IDrawableModule* module = TheSynth->SpawnModuleOnTheFly(toSpawn, 100, 300);
 
-            string moduleType;
+            std::string moduleType;
             switch (module->GetModuleType())
             {
                case kModuleType_Note: moduleType = "note effects"; break;
@@ -566,7 +566,7 @@ void HelpDisplay::ScreenshotModule(IDrawableModule* module)
    mScreenshotModule = module;
 }
 
-void HelpDisplay::RenderScreenshot(int x, int y, int width, int height, string filename)
+void HelpDisplay::RenderScreenshot(int x, int y, int width, int height, std::string filename)
 {
    float scale = gDrawScale * TheSynth->GetPixelRatio();
    x = (x + TheSynth->GetDrawOffset().x) * scale;

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -37,14 +37,14 @@ public:
    virtual ~HelpDisplay();
    static IDrawableModule* Create() { return new HelpDisplay(); }
    
-   string GetTitleLabel() override { return "help"; }
+   std::string GetTitleLabel() override { return "help"; }
    bool IsSaveable() override { return false; }
    bool HasTitleBar() const override { return false; }
    void CreateUIControls() override;
 
-   string GetUIControlTooltip(IUIControl* control);
-   string GetModuleTooltip(IDrawableModule* module);
-   string GetModuleTooltipFromName(string moduleTypeName);
+   std::string GetUIControlTooltip(IUIControl* control);
+   std::string GetModuleTooltip(IDrawableModule* module);
+   std::string GetModuleTooltipFromName(std::string moduleTypeName);
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
@@ -60,27 +60,27 @@ private:
    bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
 
-   void RenderScreenshot(int x, int y, int width, int height, string filename);
+   void RenderScreenshot(int x, int y, int width, int height, std::string filename);
    
    struct UIControlTooltipInfo
    {
-      string controlName;
-      string tooltip;
+      std::string controlName;
+      std::string tooltip;
    };
 
    struct ModuleTooltipInfo
    {
-      string module;
-      string tooltip;
-      list<UIControlTooltipInfo> controlTooltips;
+      std::string module;
+      std::string tooltip;
+      std::list<UIControlTooltipInfo> controlTooltips;
    };
 
    void LoadHelp();
    void LoadTooltips();
-   ModuleTooltipInfo* FindModuleInfo(string moduleTypeName);
+   ModuleTooltipInfo* FindModuleInfo(std::string moduleTypeName);
    UIControlTooltipInfo* FindControlInfo(IUIControl* control);
    
-   vector<string> mHelpText;
+   std::vector<std::string> mHelpText;
    Checkbox* mShowTooltipsCheckbox;
    ClickButton* mDumpModuleInfoButton;
    ClickButton* mDoModuleScreenshotsButton;
@@ -91,9 +91,9 @@ private:
    float mWidth;
    float mHeight;
    static bool sTooltipsLoaded;
-   static list<ModuleTooltipInfo> sTooltips;
+   static std::list<ModuleTooltipInfo> sTooltips;
 
-   list<string> mScreenshotsToProcess;
+   std::list<std::string> mScreenshotsToProcess;
    IDrawableModule* mScreenshotModule;
 };
 

--- a/Source/IAudioEffect.h
+++ b/Source/IAudioEffect.h
@@ -36,7 +36,7 @@ public:
    virtual void ProcessAudio(double time, ChannelBuffer* buffer) = 0;
    void SetEnabled(bool enabled) override = 0;
    virtual float GetEffectAmount() { return 0; }
-   virtual string GetType() = 0;
+   virtual std::string GetType() = 0;
    bool CanMinimize() override { return false; }
    bool IsSaveable() override { return false; }
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override {}

--- a/Source/IClickable.cpp
+++ b/Source/IClickable.cpp
@@ -30,8 +30,8 @@
 
 #include <cstring>
 
-string IClickable::sLoadContext = "";
-string IClickable::sSaveContext = "";
+std::string IClickable::sLoadContext = "";
+std::string IClickable::sSaveContext = "";
 
 IClickable::IClickable()
 : mX(0)
@@ -145,12 +145,12 @@ IDrawableModule* IClickable::GetModuleParent()
    return dynamic_cast<IDrawableModule*>(parent);
 }
 
-string IClickable::Path(bool ignoreContext)
+std::string IClickable::Path(bool ignoreContext)
 {
    if (mName[0] == 0)  //must have a name
       return "";
    
-   string path = mName;
+   std::string path = mName;
    if (mParent != nullptr)
       path = mParent->Path(true) + "~" + mName;
    

--- a/Source/IClickable.h
+++ b/Source/IClickable.h
@@ -58,7 +58,7 @@ public:
    }
    const char* Name() const { return mName; }
    char* NameMutable() { return mName; }
-   string Path(bool ignoreContext = false);
+   std::string Path(bool ignoreContext = false);
    virtual bool CheckNeedsDraw();
    virtual void SetShowing(bool showing) { mShowing = showing; }
    bool IsShowing() const { return mShowing; }
@@ -73,8 +73,8 @@ public:
    static void SetSaveContext(IClickable* context) { sSaveContext = context->Path() + "~"; }
    static void ClearSaveContext() { sSaveContext = ""; }
    
-   static string sLoadContext;
-   static string sSaveContext;
+   static std::string sLoadContext;
+   static std::string sSaveContext;
    
 protected:
    virtual void OnClicked(int x, int y, bool right) {}

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -203,7 +203,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
       if (audioSource)
       {
          RollingBuffer* vizBuff = audioSource->GetVizBuffer();
-         int numSamples = min(500,vizBuff->Size());
+         int numSamples = std::min(500,vizBuff->Size());
          float sample;
          float mag = 0;
          for (int ch=0; ch<vizBuff->NumChannels(); ++ch)
@@ -550,10 +550,10 @@ void IDrawableModule::SetTarget(IClickable* target)
    mMainPatchCableSource->SetTarget(target);
 }
 
-void IDrawableModule::SetUpPatchCables(string targets)
+void IDrawableModule::SetUpPatchCables(std::string targets)
 {
    assert(mMainPatchCableSource != nullptr);
-   vector<string> targetVec = ofSplitString(targets, ",");
+   std::vector<std::string> targetVec = ofSplitString(targets, ",");
    if (targetVec.empty() || targets == "")
    {
       mMainPatchCableSource->Clear();
@@ -746,12 +746,12 @@ void IDrawableModule::RemoveChild(IDrawableModule* child)
    RemoveFromVector(child, mChildren);
 }
 
-vector<IUIControl*> IDrawableModule::GetUIControls() const
+std::vector<IUIControl*> IDrawableModule::GetUIControls() const
 {
-   vector<IUIControl*> controls = mUIControls;
+   std::vector<IUIControl*> controls = mUIControls;
    for (int i=0; i<mChildren.size(); ++i)
    {
-      vector<IUIControl*> childControls = mChildren[i]->GetUIControls();
+      std::vector<IUIControl*> childControls = mChildren[i]->GetUIControls();
       controls.insert(controls.end(), childControls.begin(), childControls.end());
    }
    return controls;
@@ -778,7 +778,7 @@ void IDrawableModule::GetDimensions(float& width, float& height)
 
 float IDrawableModule::GetMinimizedWidth()
 {
-   string titleLabel = GetTitleLabel();
+   std::string titleLabel = GetTitleLabel();
    if (titleLabel != mLastTitleLabel)
    {
       mLastTitleLabel = titleLabel;
@@ -812,7 +812,7 @@ void IDrawableModule::AddUIControl(IUIControl* control)
 {
    try
    {
-      string name = control->Name();
+      std::string name = control->Name();
       if (CanSaveState() && name.empty() == false)
       {
          IUIControl* dupe = FindUIControl(name.c_str(), false);
@@ -1009,7 +1009,7 @@ bool IDrawableModule::CheckNeedsDraw()
    return false;
 }
 
-void IDrawableModule::LoadBasics(const ofxJSONElement& moduleInfo, string typeName)
+void IDrawableModule::LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName)
 {
    int x = moduleInfo["position"][0u].asInt();
    int y = moduleInfo["position"][1u].asInt();
@@ -1055,7 +1055,7 @@ void IDrawableModule::SaveState(FileStreamOut& out)
    
    out << kSaveStateRev;
    
-   vector<IUIControl*> controlsToSave;
+   std::vector<IUIControl*> controlsToSave;
    for (auto* control : mUIControls)
    {
       if (!VectorContains(control, ControlsToIgnoreInSaveState()) && control->GetShouldSaveState())
@@ -1066,7 +1066,7 @@ void IDrawableModule::SaveState(FileStreamOut& out)
    for (auto* control : controlsToSave)
    {
       //ofLog() << "Saving control " << control->Name();
-      out << string(control->Name());
+      out << std::string(control->Name());
       control->SaveState(out);
       for (int i=0; i<kControlSeparatorLength; ++i)
          out << kControlSeparator[i];
@@ -1079,7 +1079,7 @@ void IDrawableModule::SaveState(FileStreamOut& out)
    
    for (auto* child : mChildren)
    {
-      out << string(child->Name());
+      out << std::string(child->Name());
       child->SaveState(out);
    }
    
@@ -1100,7 +1100,7 @@ void IDrawableModule::LoadState(FileStreamIn& in)
    in >> numUIControls;
    for (int i=0; i<numUIControls; ++i)
    {
-      string uicontrolname;
+      std::string uicontrolname;
       in >> uicontrolname;
 
       UpdateOldControlName(uicontrolname);
@@ -1129,7 +1129,7 @@ void IDrawableModule::LoadState(FileStreamIn& in)
                //something went wrong, let's print some info to try to figure it out
                ofLog() << "Read char " + ofToString(separatorChar) + " but expected " + kControlSeparator[j] + "!";
                ofLog() << "Save state file position is " + ofToString(in.GetFilePosition()) + ", EoF is " + (in.Eof() ? "true" : "false");
-               string nextFewChars = "Next 10 characters are:";
+               std::string nextFewChars = "Next 10 characters are:";
                for (int c=0;c<10;++c)
                {
                   char ch;
@@ -1152,7 +1152,7 @@ void IDrawableModule::LoadState(FileStreamIn& in)
       
       if (threwException)
       {
-         TheSynth->LogEvent("Error in module \""+string(Name())+"\" loading state for control \""+uicontrolname+"\"", kLogEventType_Error);
+         TheSynth->LogEvent("Error in module \""+std::string(Name())+"\" loading state for control \""+uicontrolname+"\"", kLogEventType_Error);
          
          //read through the rest of the module until we find the spacer, so we can continue loading the next module
          int separatorProgress = 0;
@@ -1179,7 +1179,7 @@ void IDrawableModule::LoadState(FileStreamIn& in)
    
    for (int i=0; i<numChildren; ++i)
    {
-      string childName;
+      std::string childName;
       in >> childName;
       //ofLog() << "Loading " << childName;
       IDrawableModule* child = FindChild(childName.c_str());
@@ -1210,12 +1210,12 @@ void IDrawableModule::LoadState(FileStreamIn& in)
    }
 }
 
-vector<IUIControl*> IDrawableModule::ControlsToNotSetDuringLoadState() const
+std::vector<IUIControl*> IDrawableModule::ControlsToNotSetDuringLoadState() const
 {
-   return vector<IUIControl*>(); //empty
+   return std::vector<IUIControl*>(); //empty
 }
 
-vector<IUIControl*> IDrawableModule::ControlsToIgnoreInSaveState() const
+std::vector<IUIControl*> IDrawableModule::ControlsToIgnoreInSaveState() const
 {
-   return vector<IUIControl*>(); //empty
+   return std::vector<IUIControl*>(); //empty
 }

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -85,7 +85,7 @@ public:
    void AddUIControl(IUIControl* control);
    void RemoveUIControl(IUIControl* control);
    IUIControl* FindUIControl(const char* name, bool fail = true) const;
-   vector<IUIControl*> GetUIControls() const;
+   std::vector<IUIControl*> GetUIControls() const;
    void AddChild(IDrawableModule* child);
    void RemoveChild(IDrawableModule* child);
    IDrawableModule* FindChild(const char* name) const;
@@ -96,8 +96,8 @@ public:
    bool IsInitialized() const { return mInitialized; }
    bool Minimized() const { return mMinimizeAnimation > 0; }
    virtual void MouseReleased() override;
-   virtual void FilesDropped(vector<string> files, int x, int y) {}
-   virtual string GetTitleLabel() { return "&&&fixme&&&"; }
+   virtual void FilesDropped(std::vector<std::string> files, int x, int y) {}
+   virtual std::string GetTitleLabel() { return "&&&fixme&&&"; }
    virtual bool HasTitleBar() const { return true; }
    static float TitleBarHeight() { return mTitleBarHeight; }
    static ofColor GetColor(ModuleType type);
@@ -108,16 +108,16 @@ public:
    void BasePoll();  //calls poll, using this to guarantee base poll is always called
    bool IsWithinRect(const ofRectangle& rect);
    bool IsVisible();
-   vector<IDrawableModule*> GetChildren() const { return mChildren; }
+   std::vector<IDrawableModule*> GetChildren() const { return mChildren; }
    virtual bool IsResizable() const { return false; }
    virtual void Resize(float width, float height) { assert(false); }
-   void SetTypeName(string type) { mTypeName = type; }
+   void SetTypeName(std::string type) { mTypeName = type; }
    void SetTarget(IClickable* target);
-   void SetUpPatchCables(string targets);
+   void SetUpPatchCables(std::string targets);
    void AddPatchCableSource(PatchCableSource* source);
    void RemovePatchCableSource(PatchCableSource* source);
    bool TestClick(int x, int y, bool right, bool testOnly = false) override;
-   string GetTypeName() const { return mTypeName; }
+   std::string GetTypeName() const { return mTypeName; }
    ModuleType GetModuleType() const { return mModuleType; }
    virtual bool IsSingleton() const { return false; }
    virtual bool CanBeDeleted() const { return (IsSingleton() ? false : true); }
@@ -139,7 +139,7 @@ public:
    
    virtual void CheckboxUpdated(Checkbox* checkbox) {}
    
-   virtual void LoadBasics(const ofxJSONElement& moduleInfo, string typeName);
+   virtual void LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName);
    virtual void CreateUIControls();
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) {}
    virtual void SaveLayout(ofxJSONElement& moduleInfo);
@@ -149,18 +149,18 @@ public:
    virtual void SaveState(FileStreamOut& out);
    virtual void LoadState(FileStreamIn& in);
    virtual void PostLoadState() {}
-   virtual vector<IUIControl*> ControlsToNotSetDuringLoadState() const;
-   virtual vector<IUIControl*> ControlsToIgnoreInSaveState() const;
-   virtual void UpdateOldControlName(string& oldName) {}
+   virtual std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const;
+   virtual std::vector<IUIControl*> ControlsToIgnoreInSaveState() const;
+   virtual void UpdateOldControlName(std::string& oldName) {}
    virtual bool CanSaveState() const { return true; }
    virtual size_t GetExpectedSaveStateNumChildren() const { return mChildren.size(); }
    virtual bool HasDebugDraw() const { return false; }
    virtual bool HasPush2OverrideControls() const { return false; }
-   virtual void GetPush2OverrideControls(vector<IUIControl*>& controls) const { }
+   virtual void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const { }
    
    //IPatchable
    PatchCableSource* GetPatchCableSource(int index=0) override { if (index == 0) return mMainPatchCableSource; else return mPatchCableSources[index]; }
-   vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
+   std::vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
    
    static void FindClosestSides(float xThis, float yThis, float wThis, float hThis, float xThat, float yThat, float wThat, float hThat, float& startX, float& startY, float& endX, float& endY, bool sidesOnly = false);
    
@@ -191,11 +191,11 @@ private:
    float GetMinimizedWidth();
    PatchCableOld GetPatchCableOld(IClickable* target);
 
-   vector<IUIControl*> mUIControls;
-   vector<IDrawableModule*> mChildren;
-   vector<FloatSlider*> mFloatSliders;
+   std::vector<IUIControl*> mUIControls;
+   std::vector<IDrawableModule*> mChildren;
+   std::vector<FloatSlider*> mFloatSliders;
    static const int mTitleBarHeight = 12;
-   string mTypeName;
+   std::string mTypeName;
    static const int sResizeCornerSize = 8;
    ModuleContainer* mOwningContainer;
 
@@ -204,7 +204,7 @@ private:
    float mMinimizeAnimation;
    bool mUIControlsCreated;
    bool mInitialized;
-   string mLastTitleLabel;
+   std::string mLastTitleLabel;
    float mTitleLabelWidth;
    bool mShouldDrawOutline;
    bool mHoveringOverResizeHandle;
@@ -216,7 +216,7 @@ private:
    ofMutex mSliderMutex;
    
    PatchCableSource* mMainPatchCableSource;
-   vector<PatchCableSource*> mPatchCableSources;
+   std::vector<PatchCableSource*> mPatchCableSources;
 };
 
 #endif

--- a/Source/INonstandardController.h
+++ b/Source/INonstandardController.h
@@ -38,7 +38,7 @@ public:
    virtual bool IsInputConnected() { return true; }
    virtual bool Reconnect() { return true; }
    virtual void Poll() {}
-   virtual string GetControlTooltip(MidiMessageType type, int control) { return MidiController::GetDefaultTooltip(type, control); }
+   virtual std::string GetControlTooltip(MidiMessageType type, int control) { return MidiController::GetDefaultTooltip(type, control); }
    virtual void SetLayoutData(ofxJSONElement& layout) {}
    virtual void SaveState(FileStreamOut& out) = 0;
    virtual void LoadState(FileStreamIn& in) = 0;

--- a/Source/INoteSource.cpp
+++ b/Source/INoteSource.cpp
@@ -95,9 +95,9 @@ bool NoteOutput::HasHeldNotes()
    return false;
 }
 
-list<int> NoteOutput::GetHeldNotesList()
+std::list<int> NoteOutput::GetHeldNotesList()
 {
-   list<int> notes;
+   std::list<int> notes;
    for (int i=0; i<128; ++i)
    {
       if (mNotes[i])

--- a/Source/INoteSource.h
+++ b/Source/INoteSource.h
@@ -54,7 +54,7 @@ public:
    void ResetStackDepth() { mStackDepth = 0; }
    bool* GetNotes() { return mNotes; }
    bool HasHeldNotes();
-   list<int> GetHeldNotesList();
+   std::list<int> GetHeldNotesList();
 private:
    bool mNotes[128]{};
    double mNoteOnTimes[128]{};

--- a/Source/IPulseReceiver.cpp
+++ b/Source/IPulseReceiver.cpp
@@ -33,7 +33,7 @@ void IPulseSource::DispatchPulse(PatchCableSource* destination, double time, flo
    if (time == destination->GetLastOnEventTime())   //avoid stack overflow
       return;
    
-   const vector<IPulseReceiver*>& receivers = destination->GetPulseReceivers();
+   const std::vector<IPulseReceiver*>& receivers = destination->GetPulseReceivers();
    destination->AddHistoryEvent(time, true);
    destination->AddHistoryEvent(time + 15, false);
    for (auto* receiver : receivers)

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -56,7 +56,7 @@ public:
    virtual float GetValue() const { return 0; }
    virtual float GetMidiValue() const { return 0; }
    virtual int GetNumValues() { return 0; } //the number of distinct values that you can have for this control, zero indicates infinite (like a float slider)
-   virtual string GetDisplayValue(float val) const { return "unimplemented"; }
+   virtual std::string GetDisplayValue(float val) const { return "unimplemented"; }
    virtual void Init() {}
    virtual void Poll() {}
    virtual void KeyPressed(int key, bool isRepeat) {}

--- a/Source/InputChannel.h
+++ b/Source/InputChannel.h
@@ -38,7 +38,7 @@ public:
    virtual ~InputChannel();
    static IDrawableModule* Create() { return new InputChannel(); }
    
-   string GetTitleLabel() override { return "input"; }
+   std::string GetTitleLabel() override { return "input"; }
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/Inverter.h
+++ b/Source/Inverter.h
@@ -40,7 +40,7 @@ public:
    virtual ~Inverter();
    static IDrawableModule* Create() { return new Inverter(); }
    
-   string GetTitleLabel() override { return "inverter"; }
+   std::string GetTitleLabel() override { return "inverter"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/KarplusStrong.h
+++ b/Source/KarplusStrong.h
@@ -46,7 +46,7 @@ public:
    ~KarplusStrong();
    static IDrawableModule* Create() { return new KarplusStrong(); }
    
-   string GetTitleLabel() override { return "karplus/strong"; }
+   std::string GetTitleLabel() override { return "karplus/strong"; }
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -35,7 +35,7 @@ public:
    KeyboardDisplay();
    static IDrawableModule* Create() { return new KeyboardDisplay(); }
    
-   string GetTitleLabel() override { return "keyboard"; }
+   std::string GetTitleLabel() override { return "keyboard"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Kicker.h
+++ b/Source/Kicker.h
@@ -40,7 +40,7 @@ public:
    Kicker();
    static IDrawableModule* Create() { return new Kicker(); }
    
-   string GetTitleLabel() override { return "kicker"; }
+   std::string GetTitleLabel() override { return "kicker"; }
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void SetDrumPlayer(DrumPlayer* drumPlayer) { mDrumPlayer = drumPlayer; }

--- a/Source/KompleteKontrol.cpp
+++ b/Source/KompleteKontrol.cpp
@@ -162,7 +162,7 @@ void KompleteKontrol::UpdateKeys()
       bool isHeld = false;
       bool isInPentatonic = pitch >= 0 && TheScale->IsInPentatonic(pitch);
       
-      list<int> heldNotes = mNoteOutput.GetHeldNotesList();
+      std::list<int> heldNotes = mNoteOutput.GetHeldNotesList();
       for (int iter : heldNotes)
       {
          if (iter == pitch)
@@ -199,7 +199,7 @@ void KompleteKontrol::UpdateText()
       return;
    
    uint16_t sliders[NUM_SLIDER_SEGMENTS];
-   string text;
+   std::string text;
    for (int i=0; i<9; ++i)
    {
       int numPeriods1 = 0;

--- a/Source/KompleteKontrol.h
+++ b/Source/KompleteKontrol.h
@@ -46,7 +46,7 @@ public:
    ~KompleteKontrol();
    static IDrawableModule* Create() { return new KompleteKontrol(); }
    
-   string GetTitleLabel() override { return "komplete kontrol"; }
+   std::string GetTitleLabel() override { return "komplete kontrol"; }
    void CreateUIControls() override;
    
    void Poll() override;
@@ -75,8 +75,8 @@ private:
       TextBox() : slider(false), amount(0) {}
       bool slider;
       float amount;
-      string line1;
-      string line2;
+      std::string line1;
+      std::string line2;
    };
    
    void UpdateKeys();
@@ -91,7 +91,7 @@ private:
    bool mInitialized;
    int mKeyOffset;
    bool mNeedKeysUpdate;
-   string mCurrentText;
+   std::string mCurrentText;
    uint16_t mCurrentSliders[NUM_SLIDER_SEGMENTS];
    TextBox mTextBoxes[9];
    MidiController* mController;

--- a/Source/LFOController.h
+++ b/Source/LFOController.h
@@ -45,7 +45,7 @@ public:
    static IDrawableModule* Create() { return new LFOController(); }
    static bool CanCreate() { return TheLFOController == nullptr; }
    
-   string GetTitleLabel() override { return "LFO control"; }
+   std::string GetTitleLabel() override { return "LFO control"; }
    void CreateUIControls() override;
    
    void SetSlider(FloatSlider* slider);

--- a/Source/LaunchpadInterpreter.cpp
+++ b/Source/LaunchpadInterpreter.cpp
@@ -71,7 +71,7 @@ bool LaunchpadInterpreter::IsMonome() const
    return strcmp(mController->Name(),"monome") == 0;
 }
 
-void LaunchpadInterpreter::UpdateLights(vector<LightUpdate> lightUpdates, bool force /*=false*/)
+void LaunchpadInterpreter::UpdateLights(std::vector<LightUpdate> lightUpdates, bool force /*=false*/)
 {
    if (mController == nullptr)
       return;

--- a/Source/LaunchpadInterpreter.h
+++ b/Source/LaunchpadInterpreter.h
@@ -56,7 +56,7 @@ public:
    void SetController(MidiController* controller, int controllerPage);
    void OnMidiNote(MidiNote& note);
    void OnMidiControl(MidiControl& control);
-   void UpdateLights(vector<LightUpdate> lightUpdates, bool force = false);
+   void UpdateLights(std::vector<LightUpdate> lightUpdates, bool force = false);
    void Draw(ofVec2f vPos);
    void ResetLaunchpad();
    bool HasLaunchpad() { return mController != nullptr; }

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -67,7 +67,7 @@ LaunchpadKeyboard::LaunchpadKeyboard()
 
    mHeldChordTones.push_back(0);
    
-   vector<int> chord;
+   std::vector<int> chord;
    //triad
    chord.push_back(0);
    chord.push_back(4);

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -48,7 +48,7 @@ public:
    ~LaunchpadKeyboard();
    static IDrawableModule* Create() { return new LaunchpadKeyboard(); }
    
-   string GetTitleLabel() override { return "gridkeyboard"; }
+   std::string GetTitleLabel() override { return "gridkeyboard"; }
    void CreateUIControls() override;
    void Init() override;
 
@@ -127,11 +127,11 @@ private:
    LaunchpadLayout mLayout;
    DropdownList* mLayoutDropdown;
    int mCurrentChord;
-   vector< vector<int> > mChords;
+   std::vector< std::vector<int> > mChords;
    LaunchpadNoteDisplayer* mDisplayer;
    ArrangementMode mArrangementMode;
    DropdownList* mArrangementModeDropdown;
-   list<int> mHeldChordTones;
+   std::list<int> mHeldChordTones;
    Chorder* mChorder;
    bool mLatchChords;
    Checkbox* mLatchChordsCheckbox;

--- a/Source/LaunchpadNoteDisplayer.h
+++ b/Source/LaunchpadNoteDisplayer.h
@@ -39,7 +39,7 @@ public:
    LaunchpadNoteDisplayer();
    static IDrawableModule* Create() { return new LaunchpadNoteDisplayer(); }
    
-   string GetTitleLabel() override { return "grid display"; }
+   std::string GetTitleLabel() override { return "grid display"; }
 
    void SetLaunchpad(LaunchpadKeyboard* launchpad) { mLaunchpad = launchpad; }
 

--- a/Source/LinnstrumentControl.cpp
+++ b/Source/LinnstrumentControl.cpp
@@ -97,7 +97,7 @@ void LinnstrumentControl::InitController()
 {
    BuildControllerList();
    
-   const std::vector<string>& devices = mDevice.GetPortList(false);
+   const std::vector<std::string>& devices = mDevice.GetPortList(false);
    for (int i=0; i<devices.size(); ++i)
    {
       if (strstr(devices[i].c_str(), "LinnStrument") != nullptr)
@@ -126,7 +126,7 @@ void LinnstrumentControl::DrawModule()
 void LinnstrumentControl::BuildControllerList()
 {
    mControllerList->Clear();
-   const std::vector<string>& devices = mDevice.GetPortList(false);
+   const std::vector<std::string>& devices = mDevice.GetPortList(false);
    for (int i=0; i<devices.size(); ++i)
       mControllerList->AddLabel(devices[i].c_str(), i);
 }

--- a/Source/LinnstrumentControl.h
+++ b/Source/LinnstrumentControl.h
@@ -46,7 +46,7 @@ public:
    virtual ~LinnstrumentControl();
    static IDrawableModule* Create() { return new LinnstrumentControl(); }
    
-   string GetTitleLabel() override { return "linnstrument control"; }
+   std::string GetTitleLabel() override { return "linnstrument control"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -118,8 +118,8 @@ private:
    
    static const int kRows = 8;
    static const int kCols = 25;
-   array<LinnstrumentColor, kRows*kCols> mGridColorState;
-   array<NoteAge, 128> mNoteAge;
+   std::array<LinnstrumentColor, kRows*kCols> mGridColorState;
+   std::array<NoteAge, 128> mNoteAge;
    float mDecayMs;
    FloatSlider* mDecaySlider;
    bool mBlackout;
@@ -136,7 +136,7 @@ private:
    int mLastReceivedNRPNValueMSB;
    int mLastReceivedNRPNValueLSB;
    
-   array<ModulationParameters, kNumVoices> mModulators;
+   std::array<ModulationParameters, kNumVoices> mModulators;
    
    double mRequestedOctaveTime;
    

--- a/Source/Lissajous.h
+++ b/Source/Lissajous.h
@@ -40,7 +40,7 @@ public:
    virtual ~Lissajous();
    static IDrawableModule* Create() { return new Lissajous(); }
    
-   string GetTitleLabel() override { return "lissajous"; }
+   std::string GetTitleLabel() override { return "lissajous"; }
    void CreateUIControls() override;
    
    bool IsResizable() const override { return true; }

--- a/Source/LiveGranulator.h
+++ b/Source/LiveGranulator.h
@@ -46,7 +46,7 @@ public:
    
    static IAudioEffect* Create() { return new LiveGranulator(); }
    
-   string GetTitleLabel() override { return "granulator"; }
+   std::string GetTitleLabel() override { return "granulator"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -54,7 +54,7 @@ public:
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "granulator"; }
+   std::string GetType() override { return "granulator"; }
    
    void OnTimeEvent(double time) override;
    

--- a/Source/LocationZoomer.cpp
+++ b/Source/LocationZoomer.cpp
@@ -119,7 +119,7 @@ void LocationZoomer::ExitVanityPanningMode()
 
 void LocationZoomer::PickNewVanityPanningDestination()
 {
-   vector<IDrawableModule*> modules;
+   std::vector<IDrawableModule*> modules;
    TheSynth->GetAllModules(modules);
    
    ofVec2f allModulesCenter;

--- a/Source/LocationZoomer.h
+++ b/Source/LocationZoomer.h
@@ -53,7 +53,7 @@ private:
       ofVec2f mOffset;
    };
    
-   map<int, Location> mLocations;
+   std::map<int, Location> mLocations;
    Location mStart;
    Location mDestination;
    float mCurrentProgress;

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -385,7 +385,7 @@ void LoopStorer::SampleData::Init(LoopStorer* storer, int index)
       mSelectCheckbox->Delete();
    }
    
-   string indexStr = ofToString(index + 1);
+   std::string indexStr = ofToString(index + 1);
    
    int y = storer->GetRowY(index);
    mSelectCheckbox = new Checkbox(storer,("select "+indexStr).c_str(),110,y+20,&mIsCurrentBuffer);

--- a/Source/LoopStorer.h
+++ b/Source/LoopStorer.h
@@ -47,7 +47,7 @@ public:
    ~LoopStorer();
    static IDrawableModule* Create() { return new LoopStorer(); }
    
-   string GetTitleLabel() override { return "loop storer"; }
+   std::string GetTitleLabel() override { return "loop storer"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -112,7 +112,7 @@ private:
    ClickButton* mClearButton;
    ofMutex mLoadMutex;
    
-   vector<SampleData*> mSamples;
+   std::vector<SampleData*> mSamples;
    int mCurrentBufferIdx;
    
    PatchCableSource* mLooperCable;

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1033,7 +1033,7 @@ void Looper::Commit(RollingBuffer* commitBuffer /* = nullptr */)
    }
 }
 
-void Looper::FilesDropped(vector<string> files, int x, int y)
+void Looper::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample sample;
    sample.Read(files[0].c_str());

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -54,7 +54,7 @@ public:
    ~Looper();
    static IDrawableModule* Create() { return new Looper(); }
    
-   string GetTitleLabel() override { return "looper"; }
+   std::string GetTitleLabel() override { return "looper"; }
    void CreateUIControls() override;
 
    void SetRecorder(LooperRecorder* recorder);
@@ -94,7 +94,7 @@ public:
    void SendCC(int control, int value, int voiceIdx = -1) override {}
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
 
    void MergeIn(Looper* otherLooper);
    void SwapBuffers(Looper* otherLooper);

--- a/Source/LooperGranulator.cpp
+++ b/Source/LooperGranulator.cpp
@@ -148,7 +148,7 @@ void LooperGranulator::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
 
-   string targetPath = "";
+   std::string targetPath = "";
    if (mLooperCable->GetTarget())
       targetPath = mLooperCable->GetTarget()->Path();
 

--- a/Source/LooperGranulator.h
+++ b/Source/LooperGranulator.h
@@ -46,7 +46,7 @@ public:
    virtual ~LooperGranulator();
    static IDrawableModule* Create() { return new LooperGranulator(); }
 
-   string GetTitleLabel() override { return "looper granulator"; }
+   std::string GetTitleLabel() override { return "looper granulator"; }
    void CreateUIControls() override;
 
    void ProcessFrame(double time, float bufferOffset, float* output);

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -360,9 +360,9 @@ void LooperRecorder::DrawModule()
       int pitch = int(rootPitch + .5f);
       int cents = (rootPitch - pitch) * 100;
       
-      string speed = "speed "+ofToString(mSpeed,2)+", ";
+      std::string speed = "speed "+ofToString(mSpeed,2)+", ";
       
-      string detune = NoteName(pitch);
+      std::string detune = NoteName(pitch);
       if (cents > 0)
          detune += " +" + ofToString(cents) + " cents";
       if (cents < 0)
@@ -805,7 +805,7 @@ void LooperRecorder::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["loopers"].resize((unsigned int)mLoopers.size());
    for (int i=0; i<mLoopers.size(); ++i)
    {
-      string name;
+      std::string name;
       if (mLoopers[i])
          name = mLoopers[i]->Name();
       moduleInfo["loopers"][i] = name;

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -48,7 +48,7 @@ public:
    ~LooperRecorder();
    static IDrawableModule* Create() { return new LooperRecorder(); }
    
-   string GetTitleLabel() override { return "looper recorder"; }
+   std::string GetTitleLabel() override { return "looper recorder"; }
    void CreateUIControls() override;
 
    void Init() override;
@@ -117,7 +117,7 @@ private:
    float mWidth;
    float mHeight;
    RollingBuffer mRecordBuffer;
-   vector<Looper*> mLoopers;
+   std::vector<Looper*> mLoopers;
    int mNumBars;
    DropdownList* mNumBarsSelector;
    float mSpeed;
@@ -144,7 +144,7 @@ private:
    FloatSlider* mCommitDelaySlider;
    ChannelBuffer mWriteBuffer;
    Looper* mCommitToLooper;
-   vector<PatchCableSource*> mLooperPatchCables;
+   std::vector<PatchCableSource*> mLooperPatchCables;
    ClickButton* mCommit1BarButton;
    ClickButton* mCommit2BarsButton;
    ClickButton* mCommit4BarsButton;

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -26,7 +26,7 @@ public:
    virtual ~M185Sequencer();
    static IDrawableModule* Create() { return new M185Sequencer(); }
 
-   string GetTitleLabel() override { return "m185 sequencer"; }
+   std::string GetTitleLabel() override { return "m185 sequencer"; }
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/MPESmoother.h
+++ b/Source/MPESmoother.h
@@ -41,7 +41,7 @@ public:
    virtual ~MPESmoother();
    static IDrawableModule* Create() { return new MPESmoother(); }
    
-   string GetTitleLabel() override { return "mpe smoother"; }
+   std::string GetTitleLabel() override { return "mpe smoother"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void Init() override;

--- a/Source/MPETweaker.h
+++ b/Source/MPETweaker.h
@@ -40,7 +40,7 @@ public:
    virtual ~MPETweaker();
    static IDrawableModule* Create() { return new MPETweaker(); }
    
-   string GetTitleLabel() override { return "mpe tweaker"; }
+   std::string GetTitleLabel() override { return "mpe tweaker"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -79,7 +79,7 @@ void MacroSlider::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["num_mappings"] = (int)mMappings.size();
    for (int i=0; i<mMappings.size(); ++i)
    {
-      string targetPath = "";
+      std::string targetPath = "";
       if (mMappings[i]->GetCableSource()->GetTarget())
          targetPath = mMappings[i]->GetCableSource()->GetTarget()->Path();
       
@@ -97,7 +97,7 @@ void MacroSlider::LoadLayout(const ofxJSONElement& moduleInfo)
    const Json::Value& mappings = moduleInfo["mappings"];
    for (int i=0; i<mappings.size(); ++i)
    {
-      string target = mappings[i]["target"].asString();
+      std::string target = mappings[i]["target"].asString();
       Mapping* mapping = new Mapping(this, i);
       mapping->CreateUIControls();
       FloatSlider* slider = dynamic_cast<FloatSlider*>(TheSynth->FindUIControl(target));

--- a/Source/MacroSlider.h
+++ b/Source/MacroSlider.h
@@ -40,7 +40,7 @@ public:
    virtual ~MacroSlider();
    static IDrawableModule* Create() { return new MacroSlider(); }
    
-   string GetTitleLabel() override { return "macroslider"; }
+   std::string GetTitleLabel() override { return "macroslider"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -84,7 +84,7 @@ private:
    
    FloatSlider* mSlider;
    float mValue;
-   vector<Mapping*> mMappings;
+   std::vector<Mapping*> mMappings;
 };
 
 #endif /* defined(__Bespoke__MacroSlider__) */

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -216,10 +216,10 @@ public:
       mGlobalManagers.mDeviceManager.getAvailableDeviceTypes();   //scans for device types ("Windows Audio", "DirectSound", etc)
 
       ofxJSONElement userPrefs;
-      const string kAutoDevice = "auto";
-      const string kNoneDevice = "none";
-      string outputDevice = kAutoDevice;
-      string inputDevice = kNoneDevice;
+      const std::string kAutoDevice = "auto";
+      const std::string kNoneDevice = "none";
+      std::string outputDevice = kAutoDevice;
+      std::string inputDevice = kNoneDevice;
       int sampleRate = 48000;
       int bufferSize = 256;
       bool loaded = userPrefs.open(ModularSynth::GetUserPrefsPath(false));
@@ -497,15 +497,15 @@ private:
    
    void filesDropped(const StringArray& files, int x, int y) override
    {
-      vector<string> strFiles;
+      std::vector<std::string> strFiles;
       for (auto file : files)
          strFiles.push_back(file.toStdString());
       mSynth.FilesDropped(strFiles, x, y);
    }
    
-   string GetAudioDevices()
+   std::string GetAudioDevices()
    {
-      string ret;
+      std::string ret;
       OwnedArray<AudioIODeviceType> types;
       mGlobalManagers.mDeviceManager.createAudioDeviceTypes(types);
       for (int i = 0; i < types.size(); ++i)
@@ -544,7 +544,7 @@ private:
    NVGcontext* mFontBoundsVG;
    int64 mLastFpsUpdateTime;
    int mFrameCountAccum;
-   list<int> mPressedKeys;
+   std::list<int> mPressedKeys;
    double mPixelRatio;
    juce::Point<int> mScreenPosition;
    juce::Point<int> mDesiredInitialPosition;

--- a/Source/Metronome.h
+++ b/Source/Metronome.h
@@ -41,7 +41,7 @@ public:
    ~Metronome();
    static IDrawableModule* Create() { return new Metronome(); }
    
-   string GetTitleLabel() override { return "metronome"; }
+   std::string GetTitleLabel() override { return "metronome"; }
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/MidiCapturer.h
+++ b/Source/MidiCapturer.h
@@ -58,7 +58,7 @@ public:
    virtual ~MidiCapturer();
    static IDrawableModule* Create() { return new MidiCapturer(); }
    
-   string GetTitleLabel() override { return "midi capturer"; }
+   std::string GetTitleLabel() override { return "midi capturer"; }
    void Init() override;
    
    void AddDummyController(MidiCapturerDummyController* controller);
@@ -82,6 +82,6 @@ private:
    static const int kRingBufferLength = 1000;
    int mRingBufferPos;
    juce::MidiMessage mMessages[kRingBufferLength];
-   list<MidiCapturerDummyController*> mDummyControllers;
+   std::list<MidiCapturerDummyController*> mDummyControllers;
    int mPlayhead;
 };

--- a/Source/MidiControlChange.h
+++ b/Source/MidiControlChange.h
@@ -41,7 +41,7 @@ public:
    MidiControlChange();
    static IDrawableModule* Create() { return new MidiControlChange(); }
    
-   string GetTitleLabel() override { return "midicc"; }
+   std::string GetTitleLabel() override { return "midicc"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -215,7 +215,7 @@ void MidiController::AddControlConnection(const ofxJSONElement& connection)
          GridLayout* grid = mGrids[index];
          for (int page=0; page<connection["grid_pages"].size(); ++page)
          {
-            string path = connection["grid_pages"][page].asString();
+            std::string path = connection["grid_pages"][page].asString();
             if (path.length() > 0)
                grid->mGridControlTarget[page] = dynamic_cast<GridControlTarget*>(GetOwningContainer()->FindUIControl(path));
             else
@@ -226,8 +226,8 @@ void MidiController::AddControlConnection(const ofxJSONElement& connection)
    }
    
    int control = connection["control"].asInt() % MIDI_PAGE_WIDTH;
-   string path = connection["uicontrol"].asString();
-   string type = connection["type"].asString();
+   std::string path = connection["uicontrol"].asString();
+   std::string type = connection["type"].asString();
    MidiMessageType msgType = kMidiMessage_Control;
    if (type == "control")
    {
@@ -1172,7 +1172,7 @@ void MidiController::DrawModule()
       //DrawTextNormal("                                                                                                                                                                MIDI out                           all", 12, 34);
       //DrawTextNormal("midi       num   chan    path                                                           type       value        inc        feedback    off    on    blink  pages", 12, 46);
       
-      list<UIControlConnection*> toDraw;
+      std::list<UIControlConnection*> toDraw;
       //draw pageless ones first
       for (auto iter = mConnections.begin(); iter != mConnections.end(); ++iter)
       {
@@ -1231,7 +1231,7 @@ namespace
 void MidiController::DrawModuleUnclipped()
 {
    const float kDisplayMs = 500;
-   string displayString;
+   std::string displayString;
    
    IUIControl* drawControl = nullptr;
    if (gTime < mLastBoundControlTime + kDisplayMs)
@@ -1269,7 +1269,7 @@ void MidiController::DrawModuleUnclipped()
 
    if (mHoveredLayoutElement != -1)
    {
-      string tooltip;
+      std::string tooltip;
       ofVec2f pos;
       if (mHoveredLayoutElement < kHoveredLayoutElement_GridOffset)
       {
@@ -1301,7 +1301,7 @@ void MidiController::DrawModuleUnclipped()
    }
 }
 
-string MidiController::GetLayoutTooltip(int controlIndex)
+std::string MidiController::GetLayoutTooltip(int controlIndex)
 {
    if (controlIndex >= 0 && controlIndex < mLayoutControls.size())
    {
@@ -1313,9 +1313,9 @@ string MidiController::GetLayoutTooltip(int controlIndex)
 }
 
 //static
-string MidiController::GetDefaultTooltip(MidiMessageType type, int control)
+std::string MidiController::GetDefaultTooltip(MidiMessageType type, int control)
 {
-   string str;
+   std::string str;
    if (type == kMidiMessage_Note)
       str = "note ";
    else if (type == kMidiMessage_Control)
@@ -1552,7 +1552,7 @@ ControlLayoutElement& MidiController::GetLayoutControl(int control, MidiMessageT
    return mLayoutControls[index];
 }
 
-void MidiController::LoadLayout(string filename)
+void MidiController::LoadLayout(std::string filename)
 {
    mLastLoadedLayoutFile = ofToDataPath("controllers/"+filename);
    for (int i = 0; i < mLayoutFileDropdown->GetNumValues(); ++i)
@@ -1776,7 +1776,7 @@ void MidiController::LoadLayout(string filename)
 
 void MidiController::OnDeviceChanged()
 {
-   string filename = mDeviceIn + ".json";
+   std::string filename = mDeviceIn + ".json";
    ofStringReplace(filename, "/", "");
    LoadLayout(filename);
 
@@ -2030,14 +2030,14 @@ int MidiController::GetLayoutControlIndexForMidi(MidiMessageType type, int contr
    return -1;
 }
 
-static vector<string> sCachedInputDevices;
+static std::vector<std::string> sCachedInputDevices;
 //static
-vector<string> MidiController::GetAvailableInputDevices()
+std::vector<std::string> MidiController::GetAvailableInputDevices()
 {
    if (!juce::MessageManager::existsAndIsCurrentThread())
       return sCachedInputDevices;
    
-   vector<string> devices;
+   std::vector<std::string> devices;
    for (auto& d : MidiInput::getAvailableDevices())
    {
       if (d.identifier == "blah")   //my BCF-2000 and BCR-2000 both report as a BCF-2000, come up with some hack here to name it correctly
@@ -2054,14 +2054,14 @@ vector<string> MidiController::GetAvailableInputDevices()
    return devices;
 }
 
-static vector<string> sCachedOutputDevices;
+static std::vector<std::string> sCachedOutputDevices;
 //static
-vector<string> MidiController::GetAvailableOutputDevices()
+std::vector<std::string> MidiController::GetAvailableOutputDevices()
 {
    if (!juce::MessageManager::existsAndIsCurrentThread())
       return sCachedOutputDevices;
    
-   vector<string> devices;
+   std::vector<std::string> devices;
    for (auto& d : MidiOutput::getDevices())
       devices.push_back(d.toStdString());
 
@@ -2103,8 +2103,8 @@ void MidiController::ConnectDevice()
    mDevice.DisconnectOutput();
    ResyncTwoWay();
 
-   string deviceInName = mControllerList->GetLabel(mControllerIndex);
-   string deviceOutName = String(deviceInName).replace("Input", "Output").replace("input", "output").toStdString();
+   std::string deviceInName = mControllerList->GetLabel(mControllerIndex);
+   std::string deviceOutName = String(deviceInName).replace("Input", "Output").replace("input", "output").toStdString();
    bool hasOutput = MidiOutput::getDevices().contains(String(deviceOutName));
    mDeviceIn = deviceInName;
    mDeviceOut = hasOutput ? deviceOutName : "";
@@ -2381,7 +2381,7 @@ void MidiController::LoadState(FileStreamIn& in)
    }
 }
 
-void UIControlConnection::SetUIControl(string path)
+void UIControlConnection::SetUIControl(std::string path)
 {
    if (mUIControl)
       mUIControl->RemoveRemoteController();
@@ -2404,7 +2404,7 @@ void UIControlConnection::SetUIControl(string path)
       {
          mUIControl = mUIOwner->GetOwningContainer()->FindUIControl(path);
       }
-      catch (exception e)
+      catch (std::exception e)
       {
       }
       mSpecialBinding = kSpecialBinding_None;

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -157,7 +157,7 @@ struct UIControlConnection
    
    void SetNext(UIControlConnection* next);
    
-   void SetUIControl(string path);
+   void SetUIControl(std::string path);
    void CreateUIControls(int index);
    void PreDraw();
    void DrawList(int index);
@@ -207,7 +207,7 @@ struct UIControlConnection
    Checkbox* mPagelessCheckbox;
    ClickButton* mRemoveButton;
    ClickButton* mCopyButton;
-   list<IUIControl*> mEditorControls;
+   std::list<IUIControl*> mEditorControls;
 };
 
 enum ControlDrawType
@@ -249,8 +249,8 @@ struct GridLayout
    ofVec2f mPosition;
    ofVec2f mDimensions;
    MidiMessageType mType;
-   vector<int> mControls;
-   vector<int> mColors;
+   std::vector<int> mControls;
+   std::vector<int> mColors;
    
    PatchCableSource* mGridCable;
    GridControlTarget* mGridControlTarget[MAX_MIDI_PAGES];
@@ -265,7 +265,7 @@ public:
    ~MidiController();
    static IDrawableModule* Create() { return new MidiController(); }
    
-   string GetTitleLabel() override { return Name() + string("   "); }
+   std::string GetTitleLabel() override { return Name() + std::string("   "); }
    void CreateUIControls() override;
    
    void Init() override;
@@ -278,8 +278,8 @@ public:
    void AddScriptListener(ScriptModule* script);
    int GetPage() const { return mControllerPage; }
    bool IsInputConnected(bool immediate);
-   string GetDeviceIn() const { return mDeviceIn; }
-   string GetDeviceOut() const { return mDeviceOut; }
+   std::string GetDeviceIn() const { return mDeviceIn; }
+   std::string GetDeviceOut() const { return mDeviceOut; }
    UIControlConnection* GetConnectionForControl(MidiMessageType messageType, int control);
    bool JustBoundControl() const { return gTime - mLastBoundControlTime < 500; }
    
@@ -296,8 +296,8 @@ public:
 
    INonstandardController* GetNonstandardController() { return mNonstandardController; }
 
-   static vector<string> GetAvailableInputDevices();
-   static vector<string> GetAvailableOutputDevices();
+   static std::vector<std::string> GetAvailableInputDevices();
+   static std::vector<std::string> GetAvailableOutputDevices();
 
    //IDrawableModule
    void Poll() override;
@@ -334,7 +334,7 @@ public:
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
 
-   static string GetDefaultTooltip(MidiMessageType type, int control);
+   static std::string GetDefaultTooltip(MidiMessageType type, int control);
    
 private:
    enum MappingDisplayMode
@@ -363,9 +363,9 @@ private:
    void OnDeviceChanged();
    int GetLayoutControlIndexForCable(PatchCableSource* cable) const;
    int GetLayoutControlIndexForMidi(MidiMessageType type, int control) const;
-   string GetLayoutTooltip(int controlIndex);
+   std::string GetLayoutTooltip(int controlIndex);
    void UpdateControllerIndex();
-   void LoadLayout(string filename);
+   void LoadLayout(std::string filename);
    
    float mVelocityMult;
    bool mUseChannelAsVoice;
@@ -378,13 +378,13 @@ private:
 
    Modulations mModulation;
 
-   string mDeviceIn;
-   string mDeviceOut;
+   std::string mDeviceIn;
+   std::string mDeviceOut;
    int mOutChannel;
    MidiDevice mDevice;
    double mInitialConnectionTime;
    ofxJSONElement mConnectionsJson;
-   list<UIControlConnection*> mConnections;
+   std::list<UIControlConnection*> mConnections;
    bool mUseNegativeEdge;  //for midi toggle, accept on or off as a button press
    bool mSlidersDefaultToIncremental;
    bool mBindMode;
@@ -418,16 +418,16 @@ private:
    bool mBlink;
    int mControllerPage;
    DropdownList* mPageSelector;
-   vector< list<MidiDeviceListener*> > mListeners;
-   vector<ScriptModule*> mScriptListeners;
+   std::vector< std::list<MidiDeviceListener*> > mListeners;
+   std::vector<ScriptModule*> mScriptListeners;
    bool mPrintInput;
-   string mLastInput;
+   std::string mLastInput;
    INonstandardController* mNonstandardController;
    bool mIsConnected;
    bool mHasCreatedConnectionUIControls;
    float mReconnectWaitTimer;
    ChannelFilter mChannelFilter;
-   string mLastLoadedLayoutFile;
+   std::string mLastLoadedLayoutFile;
    ofxJSONElement mLayoutData;
    
    std::array<ControlLayoutElement, NUM_LAYOUT_CONTROLS> mLayoutControls;
@@ -435,7 +435,7 @@ private:
    int mHoveredLayoutElement;
    int mLayoutWidth;
    int mLayoutHeight;
-   vector<GridLayout*> mGrids;
+   std::vector<GridLayout*> mGrids;
    bool mFoundLayoutFile;
    
    ofMutex mQueuedMessageMutex;

--- a/Source/MidiDevice.cpp
+++ b/Source/MidiDevice.cpp
@@ -147,9 +147,9 @@ bool MidiDevice::IsInputConnected(bool immediate)
    return false;
 }
 
-vector<string> MidiDevice::GetPortList(bool forInput)
+std::vector<std::string> MidiDevice::GetPortList(bool forInput)
 {
-   vector<string> portList;
+   std::vector<std::string> portList;
    
    if (forInput)
    {

--- a/Source/MidiDevice.h
+++ b/Source/MidiDevice.h
@@ -100,7 +100,7 @@ public:
 
    const char* Name() { return mIsInputEnabled ? mDeviceNameIn.toRawUTF8() : mDeviceNameOut.toRawUTF8(); }
    
-   vector<string> GetPortList(bool forInput);
+   std::vector<std::string> GetPortList(bool forInput);
    
    void SendNote(double time, int pitch, int velocity, bool forceNoteOn, int channel);
    void SendCC(int ctl, int value, int channel = -1);
@@ -117,7 +117,7 @@ private:
    juce::String mDeviceNameIn;
    juce::String mDeviceNameOut;
    
-   unique_ptr<juce::MidiOutput> mMidiOut;
+   std::unique_ptr<juce::MidiOutput> mMidiOut;
    MidiDeviceListener* mListener;
    int mOutputChannel;
    bool mIsInputEnabled;

--- a/Source/MidiOutput.cpp
+++ b/Source/MidiOutput.cpp
@@ -77,7 +77,7 @@ void MidiOutputModule::InitController()
    
    BuildControllerList();
    
-   const std::vector<string>& devices = mDevice.GetPortList(false);
+   const std::vector<std::string>& devices = mDevice.GetPortList(false);
    for (int i=0; i<devices.size(); ++i)
    {
       if (strcmp(devices[i].c_str(),mDevice.Name()) == 0)
@@ -96,7 +96,7 @@ void MidiOutputModule::DrawModule()
 void MidiOutputModule::BuildControllerList()
 {
    mControllerList->Clear();
-   const std::vector<string>& devices = mDevice.GetPortList(false);
+   const std::vector<std::string>& devices = mDevice.GetPortList(false);
    for (int i=0; i<devices.size(); ++i)
       mControllerList->AddLabel(devices[i].c_str(), i);
 }

--- a/Source/MidiOutput.h
+++ b/Source/MidiOutput.h
@@ -42,7 +42,7 @@ public:
    virtual ~MidiOutputModule();
    static IDrawableModule* Create() { return new MidiOutputModule(); }
    
-   string GetTitleLabel() override { return mDevice.Name(); }
+   std::string GetTitleLabel() override { return mDevice.Name(); }
    void CreateUIControls() override;
    
    void Init() override;
@@ -86,7 +86,7 @@ private:
       float mLastPressure;
    };
    
-   vector<ChannelModulations> mChannelModulations;
+   std::vector<ChannelModulations> mChannelModulations;
 };
 
 #endif /* defined(__Bespoke__MidiOutput__) */

--- a/Source/ModWheel.h
+++ b/Source/ModWheel.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModWheel();
    static IDrawableModule* Create() { return new ModWheel(); }
    
-   string GetTitleLabel() override { return "modwheel"; }
+   std::string GetTitleLabel() override { return "modwheel"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModWheelToCV.cpp
+++ b/Source/ModWheelToCV.cpp
@@ -84,7 +84,7 @@ void ModWheelToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModWheelToCV.h
+++ b/Source/ModWheelToCV.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModWheelToCV();
    static IDrawableModule* Create() { return new ModWheelToCV(); }
    
-   string GetTitleLabel() override { return "modwheel to cv"; }
+   std::string GetTitleLabel() override { return "modwheel to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -136,7 +136,7 @@ LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 
 void ModularSynth::DumpStats(bool isCrash, void* crashContext)
 {
-   string filename;
+   std::string filename;
    if (isCrash)
       filename = ofToDataPath(ofGetTimestampString("crash_%Y-%m-%d_%H-%M.txt"));
    else
@@ -227,7 +227,7 @@ void ModularSynth::DumpStats(bool isCrash, void* crashContext)
    log.appendText("display language: " + juce::SystemStats::getDisplayLanguage() + "\n");
    log.appendText("description: " + juce::SystemStats::getDeviceDescription() + "\n");
    log.appendText("manufacturer: " + juce::SystemStats::getDeviceManufacturer() + "\n");
-   log.appendText("build: bespoke " + JUCEApplication::getInstance()->getApplicationVersion() + " (" + string(__DATE__) + " " + string(__TIME__) + ")\n");
+   log.appendText("build: bespoke " + JUCEApplication::getInstance()->getApplicationVersion() + " (" + std::string(__DATE__) + " " + std::string(__TIME__) + ")\n");
 }
 
 bool ModularSynth::IsReady()
@@ -319,9 +319,9 @@ void ModularSynth::InitIOBuffers(int inputChannelCount, int outputChannelCount)
 }
 
 
-string ModularSynth::GetUserPrefsPath(bool relative)
+std::string ModularSynth::GetUserPrefsPath(bool relative)
 {
-   string filename = "userprefs.json";
+   std::string filename = "userprefs.json";
    if (JUCEApplication::getCommandLineParameterArray().size() > 0)
    {
       juce::String specified = JUCEApplication::getCommandLineParameterArray()[0];
@@ -343,7 +343,7 @@ void ModularSynth::Poll()
 {
    if (mFatalError == "")
    {
-      string defaultLayout = "layouts/blank.json";
+      std::string defaultLayout = "layouts/blank.json";
       if (!mUserPrefs["layout"].isNull())
          defaultLayout = mUserPrefs["layout"].asString();
       
@@ -504,14 +504,14 @@ void ModularSynth::Draw(void* vg)
    
    if (gTime == 1 && mFatalError == "")
    {
-      string loading("Bespoke is initializing audio...");
+      std::string loading("Bespoke is initializing audio...");
       DrawTextNormal(loading,ofGetWidth()/2-GetStringWidth(loading,30)/2,ofGetHeight()/2-6, 30);
       return;
    }
    
    if (!mInitialized && mFatalError == "")
    {
-      string loading("Bespoke is loading...");
+      std::string loading("Bespoke is loading...");
       DrawTextNormal(loading,ofGetWidth()/2-GetStringWidth(loading,30)/2,ofGetHeight()/2-6, 30);
       return;
    }
@@ -632,7 +632,7 @@ void ModularSynth::Draw(void* vg)
       ofPopMatrix();
    }
    
-   string tooltip = "";
+   std::string tooltip = "";
    ModuleContainer* tooltipContainer = nullptr;
    if (HelpDisplay::sShowTooltips && 
        !IUIControl::WasLastHoverSetViaTab() &&
@@ -641,14 +641,14 @@ void ModularSynth::Draw(void* vg)
    {
       HelpDisplay* helpDisplay = TheTitleBar->GetHelpDisplay();
 
-      bool hasValidHoveredControl = gHoveredUIControl && string(gHoveredUIControl->Name()) != "enabled";
+      bool hasValidHoveredControl = gHoveredUIControl && std::string(gHoveredUIControl->Name()) != "enabled";
       
       if (gHoveredModule && (!hasValidHoveredControl || (gHoveredUIControl != nullptr && gHoveredUIControl->GetModuleParent() != gHoveredModule)))
       {
          if (gHoveredModule == mQuickSpawn)
          {
-            string name = mQuickSpawn->GetHoveredModuleTypeName();
-            ofStringReplace(name, " " + string(ModuleFactory::kEffectChainSuffix), "");   //strip this suffix if it's there
+            std::string name = mQuickSpawn->GetHoveredModuleTypeName();
+            ofStringReplace(name, " " + std::string(ModuleFactory::kEffectChainSuffix), "");   //strip this suffix if it's there
             tooltip = helpDisplay->GetModuleTooltipFromName(name);
             tooltipContainer = mQuickSpawn->GetOwningContainer();
          }
@@ -657,14 +657,14 @@ void ModularSynth::Draw(void* vg)
             DropdownListModal* list = dynamic_cast<DropdownListModal*>(gHoveredModule);
             if (list->GetOwner()->GetModuleParent() == TheTitleBar)
             {
-               string moduleTypeName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
+               std::string moduleTypeName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
                ofStringReplace(moduleTypeName, " (exp.)", "");
                tooltip = helpDisplay->GetModuleTooltipFromName(moduleTypeName);
                tooltipContainer = &mUILayerModuleContainer;
             }
             else if (dynamic_cast<EffectChain*>(list->GetOwner()->GetParent()) != nullptr)
             {
-               string effectName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
+               std::string effectName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
                tooltip = helpDisplay->GetModuleTooltipFromName(effectName);
                tooltipContainer = list->GetModuleParent()->GetOwningContainer();
             }
@@ -836,7 +836,7 @@ void ModularSynth::DrawConsole()
          else
             ofSetColor(200, 200, 200);
          DrawTextNormal(it->text, 10, consoleY);
-         vector<string> lines = ofSplitString(it->text, "\n");
+         std::vector<std::string> lines = ofSplitString(it->text, "\n");
          ofPopStyle();
          consoleY += 15 * lines.size();
       }
@@ -849,7 +849,7 @@ void ModularSynth::DrawConsole()
          for (auto it = mErrors.begin(); it != mErrors.end(); ++it)
          {
             DrawTextNormal(*it, 600, consoleY);
-            vector<string> lines = ofSplitString(*it, "\n");
+            std::vector<std::string> lines = ofSplitString(*it, "\n");
             consoleY += 15 * lines.size();
          }
          ofPopStyle();
@@ -1188,8 +1188,8 @@ void ModularSynth::MouseDragged(int intX, int intY, int button)
    
    if (GetKeyModifiers() == kModifier_Alt && !mHasDuplicatedDuringDrag)
    {
-      vector<IDrawableModule*> newGroupSelectedModules;
-      map<IDrawableModule*, IDrawableModule*> oldToNewModuleMap;
+      std::vector<IDrawableModule*> newGroupSelectedModules;
+      std::map<IDrawableModule*, IDrawableModule*> oldToNewModuleMap;
       for (auto module : mGroupSelectedModules)
       {
          if (!module->IsSingleton())
@@ -1542,7 +1542,7 @@ void ModularSynth::OnModuleDeleted(IDrawableModule* module)
    
    mAudioThreadMutex.Lock("delete");
    
-   list<PatchCable*> cablesToRemove;
+   std::list<PatchCable*> cablesToRemove;
    for (auto* cable : mPatchCables)
    {
       if (cable->GetOwningModule() == module)
@@ -1730,7 +1730,7 @@ void ModularSynth::TriggerClapboard()
    mLastClapboardTime = gTime; //for synchronizing internally recorded audio and externally recorded video
 }
 
-void ModularSynth::FilesDropped(vector<string> files, int intX, int intY)
+void ModularSynth::FilesDropped(std::vector<std::string> files, int intX, int intY)
 {
    if (files.size() > 0)
    {
@@ -1753,14 +1753,14 @@ struct SourceDepInfo
 {
    SourceDepInfo(IAudioSource* me) : mMe(me) {}
    IAudioSource* mMe;
-   vector<IAudioSource*> mDeps;
+   std::vector<IAudioSource*> mDeps;
 };
 
 void ModularSynth::ArrangeAudioSourceDependencies()
 {
    //ofLog() << "Calculating audio source dependencies:";
    
-   vector<SourceDepInfo> deps;
+   std::vector<SourceDepInfo> deps;
    for (int i=0; i<mSources.size(); ++i)
       deps.push_back(SourceDepInfo(mSources[i]));
       
@@ -1854,7 +1854,7 @@ void ModularSynth::ResetLayout()
    
    mErrors.clear();
    
-   vector<PatchCable*> cablesToDelete = mPatchCables;
+   std::vector<PatchCable*> cablesToDelete = mPatchCables;
    for (auto cable : cablesToDelete)
       delete cable;
    assert(mPatchCables.size() == 0); //everything should have been cleared out by that
@@ -1915,7 +1915,7 @@ void ModularSynth::ResetLayout()
    SetUIScale(uiScale);
 }
 
-bool ModularSynth::LoadLayoutFromFile(string jsonFile, bool makeDefaultLayout /*= true*/)
+bool ModularSynth::LoadLayoutFromFile(std::string jsonFile, bool makeDefaultLayout /*= true*/)
 {
    ofLog() << "Loading layout: " << jsonFile;
    mLoadedLayoutPath = String(jsonFile).replace(ofToDataPath("").c_str(), "").toStdString();
@@ -1971,7 +1971,7 @@ bool ModularSynth::LoadLayoutFromFile(string jsonFile, bool makeDefaultLayout /*
    return true;
 }
 
-bool ModularSynth::LoadLayoutFromString(string jsonString)
+bool ModularSynth::LoadLayoutFromString(std::string jsonString)
 {
    ofxJSONElement root;
    bool loaded = root.parse(jsonString);
@@ -1995,7 +1995,7 @@ void ModularSynth::LoadLayout(ofxJSONElement json)
    //ofLoadURLAsync("http://bespoke.com/telemetry/"+jsonFile);
    
    ScopedMutex mutex(&mAudioThreadMutex, "LoadLayout()");
-   std::lock_guard<recursive_mutex> renderLock(mRenderLock);
+   std::lock_guard<std::recursive_mutex> renderLock(mRenderLock);
    
    ResetLayout();
    
@@ -2032,7 +2032,7 @@ IDrawableModule* ModularSynth::CreateModule(const ofxJSONElement& moduleInfo)
    if (moduleInfo["comment_out"].asBool()) //hack since json doesn't allow comments
       return nullptr;
 
-   string type = moduleInfo["type"].asString();
+   std::string type = moduleInfo["type"].asString();
    type = ModuleFactory::FixUpTypeName(type);
    
    try
@@ -2096,7 +2096,7 @@ void ModularSynth::ScheduleEnvelopeEditorSpawn(ADSRDisplay* adsrDisplay)
    mScheduledEnvelopeEditorSpawnDisplay = adsrDisplay;
 }
 
-IDrawableModule* ModularSynth::FindModule(string name, bool fail)
+IDrawableModule* ModularSynth::FindModule(std::string name, bool fail)
 {
    if (name[0] == '$')
    {
@@ -2111,7 +2111,7 @@ IDrawableModule* ModularSynth::FindModule(string name, bool fail)
    return mModuleContainer.FindModule(IClickable::sLoadContext+name, fail);
 }
 
-MidiController* ModularSynth::FindMidiController(string name, bool fail)
+MidiController* ModularSynth::FindMidiController(std::string name, bool fail)
 {
    if (name == "")
       return nullptr;
@@ -2136,7 +2136,7 @@ MidiController* ModularSynth::FindMidiController(string name, bool fail)
    return m;
 }
 
-IUIControl* ModularSynth::FindUIControl(string path)
+IUIControl* ModularSynth::FindUIControl(std::string path)
 {
    if (path == "")
       return nullptr;
@@ -2176,7 +2176,7 @@ void ModularSynth::GrabSample(ChannelBuffer* data, bool window, int numBars)
    }
 }
 
-void ModularSynth::GrabSample(string filePath)
+void ModularSynth::GrabSample(std::string filePath)
 {
    delete mHeldSample;
    mHeldSample = new Sample();
@@ -2189,7 +2189,7 @@ void ModularSynth::ClearHeldSample()
    mHeldSample = nullptr;
 }
 
-void ModularSynth::LogEvent(string event, LogEventType type)
+void ModularSynth::LogEvent(std::string event, LogEventType type)
 {
    if (type == kLogEventType_Warning)
    {
@@ -2215,9 +2215,9 @@ IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
    
    ofxJSONElement layoutData;
    module->SaveLayout(layoutData);
-   vector<IDrawableModule*> allModules;
+   std::vector<IDrawableModule*> allModules;
    mModuleContainer.GetAllModules(allModules);
-   string newName = GetUniqueName(layoutData["name"].asString(), allModules);
+   std::string newName = GetUniqueName(layoutData["name"].asString(), allModules);
    layoutData["name"] = newName;
    
    IDrawableModule* newModule = CreateModule(layoutData);
@@ -2251,7 +2251,7 @@ ofxJSONElement ModularSynth::GetLayout()
    return root;
 }
 
-void ModularSynth::SaveLayout(string jsonFile, bool makeDefaultLayout /*= true*/)
+void ModularSynth::SaveLayout(std::string jsonFile, bool makeDefaultLayout /*= true*/)
 {
    if (jsonFile.empty())
       jsonFile = ofToDataPath(mLoadedLayoutPath);
@@ -2303,13 +2303,13 @@ void ModularSynth::LoadStatePopupImp()
       LoadState(chooser.getResult().getFullPathName().toStdString());
 }
 
-void ModularSynth::SaveState(string file, bool autosave)
+void ModularSynth::SaveState(std::string file, bool autosave)
 {
    if (!autosave)
    {
       mCurrentSaveStatePath = file;
       mLastSaveTime = gTime;
-      string filename = File(mCurrentSaveStatePath).getFileName().toStdString();
+      std::string filename = File(mCurrentSaveStatePath).getFileName().toStdString();
       mMainComponent->getTopLevelComponent()->setName("bespoke synth - "+filename);
    }
 
@@ -2323,7 +2323,7 @@ void ModularSynth::SaveState(string file, bool autosave)
    mAudioThreadMutex.Unlock();
 }
 
-void ModularSynth::LoadState(string file)
+void ModularSynth::LoadState(std::string file)
 {
    ofLog() << "LoadState() " << file;
 
@@ -2345,7 +2345,7 @@ void ModularSynth::LoadState(string file)
    
    FileStreamIn in(ofToDataPath(file));
    
-   string jsonString;
+   std::string jsonString;
    in >> jsonString;
    bool layoutLoaded = LoadLayoutFromString(jsonString);
    
@@ -2359,7 +2359,7 @@ void ModularSynth::LoadState(string file)
    }
    
    mCurrentSaveStatePath = file;
-   string filename = File(mCurrentSaveStatePath).getFileName().toStdString();
+   std::string filename = File(mCurrentSaveStatePath).getFileName().toStdString();
    mMainComponent->getTopLevelComponent()->setName("bespoke synth - " + filename);
 
    mAudioThreadMutex.Lock("LoadState()");
@@ -2370,7 +2370,7 @@ void ModularSynth::LoadState(string file)
    mAudioThreadMutex.Unlock();
 }
 
-IAudioReceiver* ModularSynth::FindAudioReceiver(string name, bool fail)
+IAudioReceiver* ModularSynth::FindAudioReceiver(std::string name, bool fail)
 {
    IAudioReceiver* a = nullptr;
    
@@ -2395,7 +2395,7 @@ IAudioReceiver* ModularSynth::FindAudioReceiver(string name, bool fail)
    return a;
 }
 
-INoteReceiver* ModularSynth::FindNoteReceiver(string name, bool fail)
+INoteReceiver* ModularSynth::FindNoteReceiver(std::string name, bool fail)
 {
    INoteReceiver* n = nullptr;
    
@@ -2422,7 +2422,7 @@ INoteReceiver* ModularSynth::FindNoteReceiver(string name, bool fail)
 
 void ModularSynth::OnConsoleInput()
 {
-   vector<string> tokens = ofSplitString(mConsoleText," ",true,true);
+   std::vector<std::string> tokens = ofSplitString(mConsoleText," ",true,true);
    if (tokens.size() > 0)
    {
       if (tokens[0] == "")
@@ -2469,7 +2469,7 @@ void ModularSynth::OnConsoleInput()
       }
       else if (tokens[0] == "minimizeall")
       {
-         const vector<IDrawableModule*> modules = mModuleContainer.GetModules();
+         const std::vector<IDrawableModule*> modules = mModuleContainer.GetModules();
          for (auto iter = modules.begin(); iter != modules.end(); ++iter)
          {
             (*iter)->SetMinimized(true);
@@ -2590,23 +2590,23 @@ void ModularSynth::DoAutosave()
    SaveState(ofToDataPath(ofGetTimestampString("savestate/autosave/autosave_%Y-%m-%d_%H-%M-%S.bsk")), true);
 }
 
-IDrawableModule* ModularSynth::SpawnModuleOnTheFly(string moduleName, float x, float y, bool addToContainer)
+IDrawableModule* ModularSynth::SpawnModuleOnTheFly(std::string moduleName, float x, float y, bool addToContainer)
 {
    if (mInitialized)
       TitleBar::sShowInitialHelpOverlay = false;  //don't show initial help popup
 
-   vector<string> tokens = ofSplitString(moduleName," ");
+   std::vector<std::string> tokens = ofSplitString(moduleName," ");
    if (tokens.size() == 0)
       return nullptr;
 
    if (sShouldAutosave)
       DoAutosave();
 
-   string moduleType = tokens[0];
+   std::string moduleType = tokens[0];
    
    moduleType = ModuleFactory::FixUpTypeName(moduleType);
 
-   string vstToSetUp = "";
+   std::string vstToSetUp = "";
    if (tokens.size() > 1 && tokens[tokens.size() - 1] == ModuleFactory::kVSTSuffix)
    {
       moduleType = "vstplugin";
@@ -2618,7 +2618,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(string moduleName, float x, f
       }
    }
 
-   string prefabToSetUp = "";
+   std::string prefabToSetUp = "";
    if (tokens.size() > 1 && tokens[tokens.size() - 1] == ModuleFactory::kPrefabSuffix)
    {
       moduleType = "prefab";
@@ -2630,7 +2630,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(string moduleName, float x, f
       }
    }
 
-   string midiControllerToSetUp = "";
+   std::string midiControllerToSetUp = "";
    if (tokens.size() > 1 && tokens[tokens.size() - 1] == ModuleFactory::kMidiControllerSuffix)
    {
       moduleType = "midicontroller";
@@ -2642,7 +2642,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(string moduleName, float x, f
       }
    }
 
-   string effectToSetUp = "";
+   std::string effectToSetUp = "";
    if (tokens.size() > 1 && tokens[tokens.size() - 1] == ModuleFactory::kEffectChainSuffix)
    {
       moduleType = "effectchain";
@@ -2656,7 +2656,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(string moduleName, float x, f
 
    ofxJSONElement dummy;
    dummy["type"] = moduleType;
-   vector<IDrawableModule*> allModules;
+   std::vector<IDrawableModule*> allModules;
    mModuleContainer.GetAllModules(allModules);
    dummy["name"] = GetUniqueName(moduleType, allModules);
    dummy["onthefly"] = true;
@@ -2756,11 +2756,11 @@ void ModularSynth::SaveOutput()
 {
    ScopedMutex mutex(&mAudioThreadMutex, "SaveOutput()");
 
-   string recordingsPath = "recordings/";
+   std::string recordingsPath = "recordings/";
    if (!mUserPrefs["recordings_path"].isNull())
       recordingsPath = mUserPrefs["recordings_path"].asString();
    
-   string filename = ofGetTimestampString(recordingsPath + "recording_%Y-%m-%d_%H-%M.wav");
+   std::string filename = ofGetTimestampString(recordingsPath + "recording_%Y-%m-%d_%H-%M.wav");
    //string filenamePos = ofGetTimestampString("recordings/pos_%Y-%m-%d_%H-%M.wav");
 
    assert(mRecordingLength <= mGlobalRecordBuffer->Size());
@@ -2793,7 +2793,7 @@ void ModularSynth::ReadClipboardTextFromSystem() {
    TheClipboard = SystemClipboard::getTextFromClipboard();
 }
 
-void ModularSynth::SetFatalError(string error)
+void ModularSynth::SetFatalError(std::string error)
 {
    if (mFatalError == "")
    {

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -80,7 +80,7 @@ public:
    void MouseReleased(int x, int y, int button);
    void MouseScrolled(float x, float y, bool canZoomCanvas);
    void MouseMagnify(int x, int y, float scaleFactor);
-   void FilesDropped(vector<string> files, int x, int y);
+   void FilesDropped(std::vector<std::string> files, int x, int y);
    
    void AddExtraPoller(IPollable* poller);
    void RemoveExtraPoller(IPollable* poller);
@@ -97,7 +97,7 @@ public:
    
    void AddMidiDevice(MidiDevice* device);
    void ArrangeAudioSourceDependencies();
-   IDrawableModule* SpawnModuleOnTheFly(string moduleName, float x, float y, bool addToContainer = true);
+   IDrawableModule* SpawnModuleOnTheFly(std::string moduleName, float x, float y, bool addToContainer = true);
    void SetMoveModule(IDrawableModule* module, float offsetX, float offsetY);
    
    int GetNumInputChannels() const { return (int)mInputBuffers.size(); }
@@ -105,35 +105,35 @@ public:
    float* GetInputBuffer(int channel);
    float* GetOutputBuffer(int channel);
    
-   IDrawableModule* FindModule(string name, bool fail = false);
-   IAudioReceiver* FindAudioReceiver(string name, bool fail = false);
-   INoteReceiver* FindNoteReceiver(string name, bool fail = false);
-   IUIControl* FindUIControl(string path);
-   MidiController* FindMidiController(string name, bool fail = false);
+   IDrawableModule* FindModule(std::string name, bool fail = false);
+   IAudioReceiver* FindAudioReceiver(std::string name, bool fail = false);
+   INoteReceiver* FindNoteReceiver(std::string name, bool fail = false);
+   IUIControl* FindUIControl(std::string path);
+   MidiController* FindMidiController(std::string name, bool fail = false);
    void MoveToFront(IDrawableModule* module);
    bool InMidiMapMode();
-   void GetAllModules(vector<IDrawableModule*>& out) { mModuleContainer.GetAllModules(out); }
+   void GetAllModules(std::vector<IDrawableModule*>& out) { mModuleContainer.GetAllModules(out); }
    
    void PushModalFocusItem(IDrawableModule* item);
    void PopModalFocusItem();
    IDrawableModule* GetTopModalFocusItem() const;
-   vector<IDrawableModule*> GetModalFocusItemStack() const { return mModalFocusItemStack; }
+   std::vector<IDrawableModule*> GetModalFocusItemStack() const { return mModalFocusItemStack; }
    bool IsModalFocusItem(IDrawableModule* item) const;
    
-   void LogEvent(string event, LogEventType type);
-   void SetNextDrawTooltip(string tooltip) { mNextDrawTooltip = tooltip; }
+   void LogEvent(std::string event, LogEventType type);
+   void SetNextDrawTooltip(std::string tooltip) { mNextDrawTooltip = tooltip; }
    
-   bool LoadLayoutFromFile(string jsonFile, bool makeDefaultLayout = true);
-   bool LoadLayoutFromString(string jsonString);
+   bool LoadLayoutFromFile(std::string jsonFile, bool makeDefaultLayout = true);
+   bool LoadLayoutFromString(std::string jsonString);
    void LoadLayout(ofxJSONElement json);
-   string GetLoadedLayout() const { return mLoadedLayoutPath; }
+   std::string GetLoadedLayout() const { return mLoadedLayoutPath; }
    void ReloadInitialLayout() { mWantReloadInitialLayout = true; }
    
    void AddLissajousDrawer(IDrawableModule* module) { mLissajousDrawers.push_back(module); }
    bool IsLissajousDrawer(IDrawableModule* module) { return VectorContains(module, mLissajousDrawers); }
    
    void GrabSample(ChannelBuffer* data, bool window = false, int numBars = -1);
-   void GrabSample(string filePath);
+   void GrabSample(std::string filePath);
    Sample* GetHeldSample() const { return mHeldSample; }
    void ClearHeldSample();
    
@@ -171,14 +171,14 @@ public:
    juce::OpenGLContext* GetOpenGLContext() { return mOpenGLContext; }
    IDrawableModule* GetLastClickedModule() const;
    EffectFactory* GetEffectFactory() { return &mEffectFactory; }
-   const vector<IDrawableModule*>& GetGroupSelectedModules() const { return mGroupSelectedModules; }
+   const std::vector<IDrawableModule*>& GetGroupSelectedModules() const { return mGroupSelectedModules; }
    bool ShouldAccentuateActiveModules() const;
    LocationZoomer* GetLocationZoomer() { return &mZoomer; }
    
    void RegisterPatchCable(PatchCable* cable);
    void UnregisterPatchCable(PatchCable* cable);
    
-   template<class T> vector<string> GetModuleNames() { return mModuleContainer.GetModuleNames<T>(); }
+   template<class T> std::vector<std::string> GetModuleNames() { return mModuleContainer.GetModuleNames<T>(); }
    
    void LockRender(bool lock) { if (lock) { mRenderLock.lock(); } else { mRenderLock.unlock(); } }
    void UpdateFrameRate(float fps) { mFrameRate = fps; }
@@ -198,21 +198,21 @@ public:
    bool IsLoadingModule() const { return mIsLoadingModule; }
    void SetIsLoadingState(bool loading) { mIsLoadingState = loading; }
    
-   static string GetUserPrefsPath(bool relative);
+   static std::string GetUserPrefsPath(bool relative);
    static void CrashHandler(void*);
    static void DumpStats(bool isCrash, void* crashContext);
    
-   void SaveLayout(string jsonFile = "", bool makeDefaultLayout = true);
+   void SaveLayout(std::string jsonFile = "", bool makeDefaultLayout = true);
    ofxJSONElement GetLayout();
    void SaveLayoutAsPopup();
    void SaveOutput();
-   void SaveState(string file, bool autosave);
-   void LoadState(string file);
+   void SaveState(std::string file, bool autosave);
+   void LoadState(std::string file);
    void SaveCurrentState();
    void SaveStatePopup();
    void LoadStatePopup();
    double GetLastSaveTime() { return mLastSaveTime; }
-   string GetLastSavePath() { return mCurrentSaveStatePath; }
+   std::string GetLastSavePath() { return mCurrentSaveStatePath; }
 
    ofxJSONElement GetUserPrefs() { return mUserPrefs; }
    UserPrefsEditor* GetUserPrefsEditor() { return mUserPrefsEditor; }
@@ -220,7 +220,7 @@ public:
    const juce::String& GetTextFromClipboard() const;
    void CopyTextToClipboard(const juce::String& text);
    
-   void SetFatalError(string error);
+   void SetFatalError(std::string error);
 
    static bool sShouldAutosave;
    static float sBackgroundLissajousR;
@@ -244,11 +244,11 @@ private:
    
    int mIOBufferSize;
    
-   vector<IAudioSource*> mSources;
-   vector<IDrawableModule*> mLissajousDrawers;
-   vector<IDrawableModule*> mDeletedModules;
+   std::vector<IAudioSource*> mSources;
+   std::vector<IDrawableModule*> mLissajousDrawers;
+   std::vector<IDrawableModule*> mDeletedModules;
    
-   vector<IDrawableModule*> mModalFocusItemStack;
+   std::vector<IDrawableModule*> mModalFocusItemStack;
    
    IDrawableModule* mMoveModule;
    int mMoveModuleOffsetX;
@@ -257,7 +257,7 @@ private:
    ofVec2f mLastMoveMouseScreenPos;
    ofVec2f mLastMouseDragPos;
    bool mIsMousePanning;
-   array<bool, 5> mIsMouseButtonHeld{ false };
+   std::array<bool, 5> mIsMouseButtonHeld{ false };
    struct SpaceMouseInfo
    {
       SpaceMouseInfo() : mTwist(0), mZoom(0), mPan(0, 0), mUsingTwist(false), mUsingZoom(false), mUsingPan(false) {}
@@ -285,13 +285,13 @@ private:
    
    struct LogEventItem
    {
-      LogEventItem(double _time, string _text, LogEventType _type) : time(_time), text(_text), type(_type) {}
+      LogEventItem(double _time, std::string _text, LogEventType _type) : time(_time), text(_text), type(_type) {}
       double time;
-      string text;
+      std::string text;
       LogEventType type;
    };
    std::list<LogEventItem> mEvents;
-   std::list<string> mErrors;
+   std::list<std::string> mErrors;
    
    NamedMutex mAudioThreadMutex;
    
@@ -304,9 +304,9 @@ private:
    int mClickStartX; //to detect click and release in place
    int mClickStartY;
    
-   string mLoadedLayoutPath;
+   std::string mLoadedLayoutPath;
    bool mWantReloadInitialLayout;
-   string mCurrentSaveStatePath;
+   std::string mCurrentSaveStatePath;
    double mLastSaveTime;
    
    Sample* mHeldSample;
@@ -320,7 +320,7 @@ private:
    
    ofRectangle mDrawRect;
    
-   vector<IDrawableModule*> mGroupSelectedModules;
+   std::vector<IDrawableModule*> mGroupSelectedModules;
    ModuleContainer* mGroupSelectContext;
    bool mHasDuplicatedDuringDrag;
    bool mHasAutopatchedToTargetDuringDrag;
@@ -329,13 +329,13 @@ private:
    
    bool mShowLoadStatePopup;
    
-   vector<PatchCable*> mPatchCables;
+   std::vector<PatchCable*> mPatchCables;
    
    ofMutex mKeyInputMutex;
-   vector< pair<int,bool> > mQueuedKeyInput;
+   std::vector< std::pair<int,bool> > mQueuedKeyInput;
    
    ofVec2f mMousePos;
-   string mNextDrawTooltip;
+   std::string mNextDrawTooltip;
    
    juce::AudioDeviceManager* mGlobalAudioDeviceManager;
    juce::AudioFormatManager* mGlobalAudioFormatManager;
@@ -353,9 +353,9 @@ private:
    
    bool mIsLoadingModule;
    
-   list<IPollable*> mExtraPollers;
+   std::list<IPollable*> mExtraPollers;
    
-   string mFatalError;
+   std::string mFatalError;
    
    double mLastClapboardTime;
 
@@ -364,8 +364,8 @@ private:
 
    double mPixelRatio;
 
-   vector<float*> mInputBuffers;
-   vector<float*> mOutputBuffers;
+   std::vector<float*> mInputBuffers;
+   std::vector<float*> mOutputBuffers;
 };
 
 extern ModularSynth* TheSynth;

--- a/Source/ModulationChain.h
+++ b/Source/ModulationChain.h
@@ -83,7 +83,7 @@ public:
    ModulationChain* GetPressure(int voiceIdx);
 private:
    ModulationCollection mGlobalModulation;
-   vector<ModulationCollection> mVoiceModulations;
+   std::vector<ModulationCollection> mVoiceModulations;
 };
 
 #endif /* defined(__Bespoke__ModulationChain__) */

--- a/Source/ModulationVisualizer.cpp
+++ b/Source/ModulationVisualizer.cpp
@@ -80,9 +80,9 @@ void ModulationVisualizer::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-string ModulationVisualizer::VizVoice::GetInfoString()
+std::string ModulationVisualizer::VizVoice::GetInfoString()
 {
-   string info;
+   std::string info;
    if (mModulators.pitchBend)
       info += "bend:"+ofToString(mModulators.pitchBend->GetValue(0),2)+"  ";
    if (mModulators.modWheel)

--- a/Source/ModulationVisualizer.h
+++ b/Source/ModulationVisualizer.h
@@ -37,7 +37,7 @@ public:
    ModulationVisualizer();
    static IDrawableModule* Create() { return new ModulationVisualizer(); }
    
-   string GetTitleLabel() override { return "modulation visualizer"; }
+   std::string GetTitleLabel() override { return "modulation visualizer"; }
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
@@ -56,13 +56,13 @@ private:
    struct VizVoice
    {
       VizVoice() : mActive(false) {}
-      string GetInfoString();
+      std::string GetInfoString();
       bool mActive;
       ModulationParameters mModulators;
    };
    
    VizVoice mGlobalModulation;
-   vector<VizVoice> mVoices;
+   std::vector<VizVoice> mVoices;
 };
 
 #endif /* defined(__Bespoke__ModulationVisualizer__) */

--- a/Source/ModulatorAccum.cpp
+++ b/Source/ModulatorAccum.cpp
@@ -105,7 +105,7 @@ void ModulatorAccum::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
 
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
 

--- a/Source/ModulatorAccum.h
+++ b/Source/ModulatorAccum.h
@@ -43,7 +43,7 @@ public:
    virtual ~ModulatorAccum();
    static IDrawableModule* Create() { return new ModulatorAccum(); }
 
-   string GetTitleLabel() override { return "accum"; }
+   std::string GetTitleLabel() override { return "accum"; }
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/ModulatorAdd.cpp
+++ b/Source/ModulatorAdd.cpp
@@ -89,7 +89,7 @@ void ModulatorAdd::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorAdd.h
+++ b/Source/ModulatorAdd.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorAdd();
    static IDrawableModule* Create() { return new ModulatorAdd(); }
    
-   string GetTitleLabel() override { return "add"; }
+   std::string GetTitleLabel() override { return "add"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorAddCentered.cpp
+++ b/Source/ModulatorAddCentered.cpp
@@ -94,7 +94,7 @@ void ModulatorAddCentered::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorAddCentered.h
+++ b/Source/ModulatorAddCentered.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorAddCentered();
    static IDrawableModule* Create() { return new ModulatorAddCentered(); }
    
-   string GetTitleLabel() override { return "add centered"; }
+   std::string GetTitleLabel() override { return "add centered"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -124,7 +124,7 @@ void ModulatorCurve::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModulatorCurve();
    static IDrawableModule* Create() { return new ModulatorCurve(); }
    
-   string GetTitleLabel() override { return "curve"; }
+   std::string GetTitleLabel() override { return "curve"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorExpression.h
+++ b/Source/ModulatorExpression.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModulatorExpression();
    static IDrawableModule* Create() { return new ModulatorExpression(); }
    
-   string GetTitleLabel() override { return "expression"; }
+   std::string GetTitleLabel() override { return "expression"; }
    void CreateUIControls() override;
    
    //IModulator
@@ -79,7 +79,7 @@ private:
    float mE;
    FloatSlider* mESlider;
    
-   string mEntryString;
+   std::string mEntryString;
    TextEntry* mTextEntry;
    exprtk::symbol_table<float> mSymbolTable;
    exprtk::expression<float> mExpression;

--- a/Source/ModulatorGravity.cpp
+++ b/Source/ModulatorGravity.cpp
@@ -125,7 +125,7 @@ void ModulatorGravity::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorGravity.h
+++ b/Source/ModulatorGravity.h
@@ -43,7 +43,7 @@ public:
    virtual ~ModulatorGravity();
    static IDrawableModule* Create() { return new ModulatorGravity(); }
    
-   string GetTitleLabel() override { return "gravity"; }
+   std::string GetTitleLabel() override { return "gravity"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ModulatorMult.cpp
+++ b/Source/ModulatorMult.cpp
@@ -89,7 +89,7 @@ void ModulatorMult::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorMult.h
+++ b/Source/ModulatorMult.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorMult();
    static IDrawableModule* Create() { return new ModulatorMult(); }
    
-   string GetTitleLabel() override { return "mult"; }
+   std::string GetTitleLabel() override { return "mult"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorSmoother.cpp
+++ b/Source/ModulatorSmoother.cpp
@@ -100,7 +100,7 @@ void ModulatorSmoother::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorSmoother.h
+++ b/Source/ModulatorSmoother.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModulatorSmoother();
    static IDrawableModule* Create() { return new ModulatorSmoother(); }
    
-   string GetTitleLabel() override { return "smoother"; }
+   std::string GetTitleLabel() override { return "smoother"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ModulatorSubtract.cpp
+++ b/Source/ModulatorSubtract.cpp
@@ -89,7 +89,7 @@ void ModulatorSubtract::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ModulatorSubtract.h
+++ b/Source/ModulatorSubtract.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorSubtract();
    static IDrawableModule* Create() { return new ModulatorSubtract(); }
    
-   string GetTitleLabel() override { return "subtract"; }
+   std::string GetTitleLabel() override { return "subtract"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -51,7 +51,7 @@ ofVec2f ModuleContainer::GetOwnerPosition() const
    return ofVec2f();
 }
 
-void ModuleContainer::GetAllModules(vector<IDrawableModule*>& out)
+void ModuleContainer::GetAllModules(std::vector<IDrawableModule*>& out)
 {
    out.insert(out.begin(), mModules.begin(), mModules.end());
    for (int i=0; i<mModules.size(); ++i)
@@ -124,7 +124,7 @@ void ModuleContainer::Poll()
 
 void ModuleContainer::Clear()
 {
-   vector<IDrawableModule*> modulesToDelete = mModules;
+   std::vector<IDrawableModule*> modulesToDelete = mModules;
    for (auto* module : modulesToDelete)
    {
       if (module->GetContainer())
@@ -259,7 +259,7 @@ float ModuleContainer::GetDrawScale() const
    return mDrawScale;
 }
 
-void ModuleContainer::GetModulesWithinRect(ofRectangle rect, vector<IDrawableModule*>& output)
+void ModuleContainer::GetModulesWithinRect(ofRectangle rect, std::vector<IDrawableModule*>& output)
 {
    output.clear();
    for (int i=0; i<mModules.size(); ++i)
@@ -339,7 +339,7 @@ void ModuleContainer::DeleteModule(IDrawableModule* module)
    {
       if (iter->GetPatchCableSource())
       {
-         vector<PatchCable*> cablesToDestroy;
+         std::vector<PatchCable*> cablesToDestroy;
          for (auto cable : iter->GetPatchCableSource()->GetPatchCables())
          {
             if (cable->GetTarget() == module)
@@ -364,7 +364,7 @@ void ModuleContainer::DeleteModule(IDrawableModule* module)
    TheSynth->OnModuleDeleted(module);
 }
 
-IDrawableModule* ModuleContainer::FindModule(string name, bool fail)
+IDrawableModule* ModuleContainer::FindModule(std::string name, bool fail)
 {
    /*string ownerPath = "";
    if (mOwner)
@@ -381,7 +381,7 @@ IDrawableModule* ModuleContainer::FindModule(string name, bool fail)
    {
       if (name == mModules[i]->Name())
          return mModules[i];
-      vector<string> tokens = ofSplitString(name, "~");
+      std::vector<std::string> tokens = ofSplitString(name, "~");
       if (mModules[i]->GetContainer())
       {
          if (tokens[0] == mModules[i]->Name())
@@ -410,7 +410,7 @@ IDrawableModule* ModuleContainer::FindModule(string name, bool fail)
    return nullptr;
 }
 
-IUIControl* ModuleContainer::FindUIControl(string path)
+IUIControl* ModuleContainer::FindUIControl(std::string path)
 {
    /*string ownerPath = "";
    if (mOwner)
@@ -423,9 +423,9 @@ IUIControl* ModuleContainer::FindUIControl(string path)
    if (path == "")
       return nullptr;
    
-   vector<string> tokens = ofSplitString(path,"~");
-   string control = tokens[tokens.size()-1];
-   string modulePath = path.substr(0, path.length() - (control.length() + 1));
+   std::vector<std::string> tokens = ofSplitString(path,"~");
+   std::string control = tokens[tokens.size()-1];
+   std::string modulePath = path.substr(0, path.length() - (control.length() + 1));
    IDrawableModule* module = FindModule(modulePath, false);
    
    if (module)
@@ -519,7 +519,7 @@ void ModuleContainer::LoadModules(const ofxJSONElement& modules)
          TimerInstance t("init", timer);
          for (int i=0; i<mModules.size(); ++i)
          {
-            TimerInstance t(string("init ")+mModules[i]->Name(), timer);
+            TimerInstance t(std::string("init ")+mModules[i]->Name(), timer);
             if (mModules[i]->IsSingleton() == false)
                mModules[i]->Init();
          }
@@ -531,7 +531,7 @@ void ModuleContainer::LoadModules(const ofxJSONElement& modules)
 
 bool ModuleSorter(const IDrawableModule* a, const IDrawableModule* b)
 {
-   return string(a->Name()) < string(b->Name());
+   return std::string(a->Name()) < std::string(b->Name());
 }
 
 ofxJSONElement ModuleContainer::WriteModules()
@@ -544,7 +544,7 @@ ofxJSONElement ModuleContainer::WriteModules()
    
    ofxJSONElement modules;
    
-   vector<IDrawableModule*> saveModules;
+   std::vector<IDrawableModule*> saveModules;
    for (int i=0; i<mModules.size(); ++i)
    {
       IDrawableModule* module = mModules[i];
@@ -593,7 +593,7 @@ void ModuleContainer::SaveState(FileStreamOut& out)
       if (module != TheSaveDataPanel && module != TheTitleBar)
       {
          //ofLog() << "Saving " << module->Name();
-         out << string(module->Name());
+         out << std::string(module->Name());
          module->SaveState(out);
          for (int i=0; i<GetModuleSeparatorLength(); ++i)
             out << GetModuleSeparator()[i];
@@ -620,7 +620,7 @@ void ModuleContainer::LoadState(FileStreamIn& in)
    
    for (int i=0; i<savedModules; ++i)
    {
-      string moduleName;
+      std::string moduleName;
       in >> moduleName;
       //ofLog() << "Loading " << moduleName;
       IDrawableModule* module = FindModule(moduleName, false);
@@ -641,7 +641,7 @@ void ModuleContainer::LoadState(FileStreamIn& in)
                //something went wrong, let's print some info to try to figure it out
                ofLog() << "Read char " + ofToString(separatorChar) + " but expected " + GetModuleSeparator()[j] + "!";
                ofLog() << "Save state file position is " + ofToString(in.GetFilePosition()) + ", EoF is " + (in.Eof() ? "true" : "false");
-               string nextFewChars = "Next 10 characters are:";
+               std::string nextFewChars = "Next 10 characters are:";
                for (int c=0;c<10;++c)
                {
                   char ch;

--- a/Source/ModuleContainer.h
+++ b/Source/ModuleContainer.h
@@ -37,7 +37,7 @@ class ModuleContainer
 public:
    ModuleContainer();
    
-   const vector<IDrawableModule*>& GetModules() const { return mModules; }
+   const std::vector<IDrawableModule*>& GetModules() const { return mModules; }
    
    void SetOwner(IDrawableModule* owner) { mOwner = owner; }
    IDrawableModule* GetOwner() const { return mOwner; }
@@ -60,19 +60,19 @@ public:
    void MouseMoved(float x, float y);
    void MouseReleased();
    IDrawableModule* GetModuleAt(float x, float y);
-   void GetModulesWithinRect(ofRectangle rect, vector<IDrawableModule*>& output);
+   void GetModulesWithinRect(ofRectangle rect, std::vector<IDrawableModule*>& output);
    void MoveToFront(IDrawableModule* module);
    void AddModule(IDrawableModule* module);
    void TakeModule(IDrawableModule* module);
    void DeleteModule(IDrawableModule* module);
-   IDrawableModule* FindModule(string name, bool fail = true);
-   IUIControl* FindUIControl(string path);
+   IDrawableModule* FindModule(std::string name, bool fail = true);
+   IUIControl* FindUIControl(std::string path);
    bool IsHigherThan(IDrawableModule* checkFor, IDrawableModule* checkAgainst) const;
-   void GetAllModules(vector<IDrawableModule*>& out);
+   void GetAllModules(std::vector<IDrawableModule*>& out);
    
-   template<class T> vector<string> GetModuleNames()
+   template<class T> std::vector<std::string> GetModuleNames()
    {
-      vector<string> ret;
+      std::vector<std::string> ret;
       for (int i=0; i<mModules.size(); ++i)
       {
          if (dynamic_cast<T>(mModules[i]))
@@ -91,7 +91,7 @@ public:
    static bool DoesModuleHaveMoreSaveData(FileStreamIn& in);
    
 private:   
-   vector<IDrawableModule*> mModules;
+   std::vector<IDrawableModule*> mModules;
    IDrawableModule* mOwner;
 
    ofVec2f mDrawOffset;

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -472,7 +472,7 @@ ModuleFactory::ModuleFactory()
    REGISTER_HIDDEN(MultitrackRecorderTrack, multitrackrecordertrack, kModuleType_Audio);
 }
 
-void ModuleFactory::Register(string type, CreateModuleFn creator, CanCreateModuleFn canCreate, ModuleType moduleType, bool hidden, bool experimental)
+void ModuleFactory::Register(std::string type, CreateModuleFn creator, CanCreateModuleFn canCreate, ModuleType moduleType, bool hidden, bool experimental)
 {
    mFactoryMap[type] = creator;
    mCanCreateMap[type] = canCreate;
@@ -481,7 +481,7 @@ void ModuleFactory::Register(string type, CreateModuleFn creator, CanCreateModul
    mIsExperimentalModuleMap[type] = experimental;
 }
 
-IDrawableModule* ModuleFactory::MakeModule(string type)
+IDrawableModule* ModuleFactory::MakeModule(std::string type)
 {
    auto canCreate = mCanCreateMap.find(type);
    if (canCreate != mCanCreateMap.end())
@@ -496,9 +496,9 @@ IDrawableModule* ModuleFactory::MakeModule(string type)
    return nullptr;
 }
 
-vector<string> ModuleFactory::GetSpawnableModules(ModuleType moduleType)
+std::vector<std::string> ModuleFactory::GetSpawnableModules(ModuleType moduleType)
 {
-   vector<string> modules;
+   std::vector<std::string> modules;
    for (auto iter = mFactoryMap.begin(); iter != mFactoryMap.end(); ++iter)
    {
       if (mModuleTypeMap[iter->first] == moduleType &&
@@ -509,9 +509,9 @@ vector<string> ModuleFactory::GetSpawnableModules(ModuleType moduleType)
    return modules;
 }
 
-vector<string> ModuleFactory::GetSpawnableModules(char c)
+std::vector<std::string> ModuleFactory::GetSpawnableModules(char c)
 {
-   vector<string> modules;
+   std::vector<std::string> modules;
    for (auto iter = mFactoryMap.begin(); iter != mFactoryMap.end(); ++iter)
    {
       if (iter->first[0] == c &&
@@ -519,16 +519,16 @@ vector<string> ModuleFactory::GetSpawnableModules(char c)
          modules.push_back(iter->first);
    }
 
-   vector<string> vsts;
+   std::vector<std::string> vsts;
    VSTLookup::GetAvailableVSTs(vsts, false);
    for (auto vstFile : vsts)
    {
-      string vstName = juce::File(vstFile).getFileName().toStdString();
+      std::string vstName = juce::File(vstFile).getFileName().toStdString();
       if (tolower(vstName[0]) == c)
          modules.push_back(vstName + " " + kVSTSuffix);
    }
 
-   vector<string> prefabs;
+   std::vector<std::string> prefabs;
    ModuleFactory::GetPrefabs(prefabs);
    for (auto prefab : prefabs)
    {
@@ -536,14 +536,14 @@ vector<string> ModuleFactory::GetSpawnableModules(char c)
          modules.push_back(prefab + " " + kPrefabSuffix);
    }
 
-   vector<string> midicontrollers = MidiController::GetAvailableInputDevices();
+   std::vector<std::string> midicontrollers = MidiController::GetAvailableInputDevices();
    for (auto midicontroller : midicontrollers)
    {
       if (tolower(midicontroller[0]) == c)
          modules.push_back(midicontroller + " " + kMidiControllerSuffix);
    }
 
-   vector<string> effects = TheSynth->GetEffectFactory()->GetSpawnableEffects();
+   std::vector<std::string> effects = TheSynth->GetEffectFactory()->GetSpawnableEffects();
    for (auto effect : effects)
    {
       if (tolower(effect[0]) == c)
@@ -554,7 +554,7 @@ vector<string> ModuleFactory::GetSpawnableModules(char c)
    return modules;
 }
 
-ModuleType ModuleFactory::GetModuleType(string typeName)
+ModuleType ModuleFactory::GetModuleType(std::string typeName)
 {
    if (mModuleTypeMap.find(typeName) != mModuleTypeMap.end())
       return mModuleTypeMap[typeName];
@@ -567,7 +567,7 @@ ModuleType ModuleFactory::GetModuleType(string typeName)
    return kModuleType_Other;
 }
 
-bool ModuleFactory::IsExperimental(string typeName)
+bool ModuleFactory::IsExperimental(std::string typeName)
 {
    if (mIsExperimentalModuleMap.find(typeName) != mIsExperimentalModuleMap.end())
       return mIsExperimentalModuleMap[typeName];
@@ -575,7 +575,7 @@ bool ModuleFactory::IsExperimental(string typeName)
 }
 
 //static
-void ModuleFactory::GetPrefabs(vector<string>& prefabs)
+void ModuleFactory::GetPrefabs(std::vector<std::string>& prefabs)
 {
    using namespace juce;
    File dir(ofToDataPath("prefabs"));
@@ -589,7 +589,7 @@ void ModuleFactory::GetPrefabs(vector<string>& prefabs)
 }
 
 //static
-string ModuleFactory::FixUpTypeName(string name)
+std::string ModuleFactory::FixUpTypeName(std::string name)
 {
    if (name == "siggen")
       return "signalgenerator";

--- a/Source/ModuleFactory.h
+++ b/Source/ModuleFactory.h
@@ -36,25 +36,25 @@ class ModuleFactory
 {
 public:
    ModuleFactory();
-   IDrawableModule* MakeModule(string type);
-   vector<string> GetSpawnableModules(ModuleType moduleType);
-   vector<string> GetSpawnableModules(char c);
-   ModuleType GetModuleType(string typeName);
-   bool IsExperimental(string typeName);
-   static void GetPrefabs(vector<string>& prefabs);
-   static string FixUpTypeName(string typeName);
+   IDrawableModule* MakeModule(std::string type);
+   std::vector<std::string> GetSpawnableModules(ModuleType moduleType);
+   std::vector<std::string> GetSpawnableModules(char c);
+   ModuleType GetModuleType(std::string typeName);
+   bool IsExperimental(std::string typeName);
+   static void GetPrefabs(std::vector<std::string>& prefabs);
+   static std::string FixUpTypeName(std::string typeName);
 
    static constexpr const char* kVSTSuffix = "[vst]";
    static constexpr const char* kPrefabSuffix = "[prefab]";
    static constexpr const char* kMidiControllerSuffix = "[midicontroller]";
    static constexpr const char* kEffectChainSuffix = "[effectchain]";
 private:
-   void Register(string type, CreateModuleFn creator, CanCreateModuleFn canCreate, ModuleType moduleType, bool hidden, bool experimental);
-   map<string, CreateModuleFn> mFactoryMap;
-   map<string, CanCreateModuleFn> mCanCreateMap;
-   map<string, ModuleType> mModuleTypeMap;
-   map<string, bool> mIsHiddenModuleMap;
-   map<string, bool> mIsExperimentalModuleMap;
+   void Register(std::string type, CreateModuleFn creator, CanCreateModuleFn canCreate, ModuleType moduleType, bool hidden, bool experimental);
+   std::map<std::string, CreateModuleFn> mFactoryMap;
+   std::map<std::string, CanCreateModuleFn> mCanCreateMap;
+   std::map<std::string, ModuleType> mModuleTypeMap;
+   std::map<std::string, bool> mIsHiddenModuleMap;
+   std::map<std::string, bool> mIsExperimentalModuleMap;
 };
 
 #endif /* defined(__modularSynth__ModuleFactory__) */

--- a/Source/ModuleSaveData.cpp
+++ b/Source/ModuleSaveData.cpp
@@ -41,7 +41,7 @@ ModuleSaveData::~ModuleSaveData()
       delete *iter;
 }
 
-ModuleSaveData::SaveVal* ModuleSaveData::GetVal(string prop)
+ModuleSaveData::SaveVal* ModuleSaveData::GetVal(std::string prop)
 {
    for (auto iter = mValues.begin(); iter != mValues.end(); ++iter)
    {
@@ -79,14 +79,14 @@ void ModuleSaveData::Save(ofxJSONElement& moduleInfo)
    }
 }
 
-void ModuleSaveData::SetInt(string prop, int val)
+void ModuleSaveData::SetInt(std::string prop, int val)
 {
    SaveVal* save = GetVal(prop);
    assert(save && save->mType == kInt);
    save->mInt = val;
 }
 
-void ModuleSaveData::SetInt(string prop, int val, int min, int max, bool isTextField)
+void ModuleSaveData::SetInt(std::string prop, int val, int min, int max, bool isTextField)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -97,14 +97,14 @@ void ModuleSaveData::SetInt(string prop, int val, int min, int max, bool isTextF
    save->mIsTextField = isTextField;
 }
 
-void ModuleSaveData::SetFloat(string prop, float val)
+void ModuleSaveData::SetFloat(std::string prop, float val)
 {
    SaveVal* save = GetVal(prop);
    assert(save && save->mType == kFloat);
    save->mFloat = val;
 }
 
-void ModuleSaveData::SetFloat(string prop, float val, float min, float max, bool isTextField)
+void ModuleSaveData::SetFloat(std::string prop, float val, float min, float max, bool isTextField)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -115,7 +115,7 @@ void ModuleSaveData::SetFloat(string prop, float val, float min, float max, bool
    save->mIsTextField = isTextField;
 }
 
-void ModuleSaveData::SetBool(string prop, bool val)
+void ModuleSaveData::SetBool(std::string prop, bool val)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -123,7 +123,7 @@ void ModuleSaveData::SetBool(string prop, bool val)
    save->mBool = val;
 }
 
-void ModuleSaveData::SetString(string prop, string val)
+void ModuleSaveData::SetString(std::string prop, std::string val)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -131,7 +131,7 @@ void ModuleSaveData::SetString(string prop, string val)
    StringCopy(save->mString, val.c_str(), MAX_TEXTENTRY_LENGTH);
 }
 
-void ModuleSaveData::SetExtents(string prop, float min, float max)
+void ModuleSaveData::SetExtents(std::string prop, float min, float max)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -139,7 +139,7 @@ void ModuleSaveData::SetExtents(string prop, float min, float max)
    save->mMax = max;
 }
 
-bool ModuleSaveData::HasProperty(string prop)
+bool ModuleSaveData::HasProperty(std::string prop)
 {
    for (auto i=mValues.begin(); i!=mValues.end(); ++i)
    {
@@ -149,7 +149,7 @@ bool ModuleSaveData::HasProperty(string prop)
    return false;
 }
 
-int ModuleSaveData::GetInt(string prop)
+int ModuleSaveData::GetInt(std::string prop)
 {
    const SaveVal* save = GetVal(prop);
    assert(save);
@@ -157,7 +157,7 @@ int ModuleSaveData::GetInt(string prop)
    return save->mInt;
 }
 
-float ModuleSaveData::GetFloat(string prop)
+float ModuleSaveData::GetFloat(std::string prop)
 {
    const SaveVal* save = GetVal(prop);
    assert(save);
@@ -165,7 +165,7 @@ float ModuleSaveData::GetFloat(string prop)
    return save->mFloat;
 }
 
-bool ModuleSaveData::GetBool(string prop)
+bool ModuleSaveData::GetBool(std::string prop)
 {
    const SaveVal* save = GetVal(prop);
    assert(save);
@@ -173,7 +173,7 @@ bool ModuleSaveData::GetBool(string prop)
    return save->mBool;
 }
 
-string ModuleSaveData::GetString(string prop)
+std::string ModuleSaveData::GetString(std::string prop)
 {
    const SaveVal* save = GetVal(prop);
    assert(save);
@@ -181,7 +181,7 @@ string ModuleSaveData::GetString(string prop)
    return save->mString;
 }
 
-int ModuleSaveData::LoadInt(string prop, const ofxJSONElement& moduleInfo, int defaultValue, int min, int max, bool isTextField)
+int ModuleSaveData::LoadInt(std::string prop, const ofxJSONElement& moduleInfo, int defaultValue, int min, int max, bool isTextField)
 {
    int val = defaultValue;
    if (!moduleInfo[prop].isNull())
@@ -190,7 +190,7 @@ int ModuleSaveData::LoadInt(string prop, const ofxJSONElement& moduleInfo, int d
    return val;
 }
 
-int ModuleSaveData::LoadInt(string prop, const ofxJSONElement& moduleInfo, int defaultValue, IntSlider* slider, bool isTextField)
+int ModuleSaveData::LoadInt(std::string prop, const ofxJSONElement& moduleInfo, int defaultValue, IntSlider* slider, bool isTextField)
 {
    int min=0;
    int max=10;
@@ -199,7 +199,7 @@ int ModuleSaveData::LoadInt(string prop, const ofxJSONElement& moduleInfo, int d
    return LoadInt(prop, moduleInfo, defaultValue, min, max, isTextField);
 }
 
-float ModuleSaveData::LoadFloat(string prop, const ofxJSONElement& moduleInfo, float defaultValue, float min, float max, bool isTextField)
+float ModuleSaveData::LoadFloat(std::string prop, const ofxJSONElement& moduleInfo, float defaultValue, float min, float max, bool isTextField)
 {
    float val = defaultValue;
    if (!moduleInfo[prop].isNull())
@@ -208,7 +208,7 @@ float ModuleSaveData::LoadFloat(string prop, const ofxJSONElement& moduleInfo, f
    return val;
 }
 
-float ModuleSaveData::LoadFloat(string prop, const ofxJSONElement& moduleInfo, float defaultValue, FloatSlider* slider, bool isTextField)
+float ModuleSaveData::LoadFloat(std::string prop, const ofxJSONElement& moduleInfo, float defaultValue, FloatSlider* slider, bool isTextField)
 {
    float min=0;
    float max=1;
@@ -217,7 +217,7 @@ float ModuleSaveData::LoadFloat(string prop, const ofxJSONElement& moduleInfo, f
    return LoadFloat(prop, moduleInfo, defaultValue, min, max, isTextField);
 }
 
-bool ModuleSaveData::LoadBool(string prop, const ofxJSONElement& moduleInfo, bool defaultValue)
+bool ModuleSaveData::LoadBool(std::string prop, const ofxJSONElement& moduleInfo, bool defaultValue)
 {
    bool val = defaultValue;
    if (!moduleInfo[prop].isNull())
@@ -226,9 +226,9 @@ bool ModuleSaveData::LoadBool(string prop, const ofxJSONElement& moduleInfo, boo
    return val;
 }
 
-string ModuleSaveData::LoadString(string prop, const ofxJSONElement& moduleInfo, string defaultValue, FillDropdownFn fillFn)
+std::string ModuleSaveData::LoadString(std::string prop, const ofxJSONElement& moduleInfo, std::string defaultValue, FillDropdownFn fillFn)
 {
-   string val = defaultValue;
+   std::string val = defaultValue;
    if (!moduleInfo[prop].isNull())
       val = moduleInfo[prop].asString();
    SetString(prop, val);
@@ -238,7 +238,7 @@ string ModuleSaveData::LoadString(string prop, const ofxJSONElement& moduleInfo,
    return val;
 }
 
-void ModuleSaveData::UpdatePropertyMax(string prop, float max)
+void ModuleSaveData::UpdatePropertyMax(std::string prop, float max)
 {
    if (HasProperty(prop))
    {
@@ -248,7 +248,7 @@ void ModuleSaveData::UpdatePropertyMax(string prop, float max)
    }
 }
 
-void ModuleSaveData::SetEnumMapFromList(string prop, IUIControl* list)
+void ModuleSaveData::SetEnumMapFromList(std::string prop, IUIControl* list)
 {
    SaveVal* save = GetVal(prop);
    assert(save);
@@ -260,7 +260,7 @@ void ModuleSaveData::SetEnumMapFromList(string prop, IUIControl* list)
       save->mEnumValues = radioButton->GetEnumMap();
 }
 
-void ModuleSaveData::SetEnumMap(string prop, EnumMap* map)
+void ModuleSaveData::SetEnumMap(std::string prop, EnumMap* map)
 {
    SaveVal* save = GetVal(prop);
    assert(save);

--- a/Source/ModuleSaveData.h
+++ b/Source/ModuleSaveData.h
@@ -44,29 +44,29 @@ public:
    
    void Save(ofxJSONElement& moduleInfo);
    
-   void SetInt(string prop, int val);
-   void SetInt(string prop, int val, int min, int max, bool isTextField);
-   void SetFloat(string prop, float val);
-   void SetFloat(string prop, float val, float min, float max, bool isTextField);
-   void SetBool(string prop, bool val);
-   void SetString(string prop, string val);
+   void SetInt(std::string prop, int val);
+   void SetInt(std::string prop, int val, int min, int max, bool isTextField);
+   void SetFloat(std::string prop, float val);
+   void SetFloat(std::string prop, float val, float min, float max, bool isTextField);
+   void SetBool(std::string prop, bool val);
+   void SetString(std::string prop, std::string val);
    
-   void SetExtents(string prop, float min, float max);
+   void SetExtents(std::string prop, float min, float max);
    
-   bool HasProperty(string prop);
-   int GetInt(string prop);
-   float GetFloat(string prop);
-   bool GetBool(string prop);
-   string GetString(string prop);
-   template <class T> T GetEnum(string prop) { return (T)GetInt(prop); }
+   bool HasProperty(std::string prop);
+   int GetInt(std::string prop);
+   float GetFloat(std::string prop);
+   bool GetBool(std::string prop);
+   std::string GetString(std::string prop);
+   template <class T> T GetEnum(std::string prop) { return (T)GetInt(prop); }
    
-   int LoadInt(string prop, const ofxJSONElement& moduleInfo, int defaultValue = 0, int min=0, int max=10, bool isTextField = false);
-   int LoadInt(string prop, const ofxJSONElement& moduleInfo, int defaultValue, IntSlider* slider, bool isTextField = false);
-   float LoadFloat(string prop, const ofxJSONElement& moduleInfo, float defaultValue = 0, float min=0, float max=1, bool isTextField = false);
-   float LoadFloat(string prop, const ofxJSONElement& moduleInfo, float defaultValue , FloatSlider* slider, bool isTextField = false);
-   bool LoadBool(string prop, const ofxJSONElement& moduleInfo, bool defaultValue = false);
-   string LoadString(string prop, const ofxJSONElement& moduleInfo, string defaultValue = "", FillDropdownFn fillFn = nullptr);
-   template <class T> T LoadEnum(string prop, const ofxJSONElement& moduleInfo, int defaultValue, IUIControl* list = nullptr, EnumMap* map = nullptr)
+   int LoadInt(std::string prop, const ofxJSONElement& moduleInfo, int defaultValue = 0, int min=0, int max=10, bool isTextField = false);
+   int LoadInt(std::string prop, const ofxJSONElement& moduleInfo, int defaultValue, IntSlider* slider, bool isTextField = false);
+   float LoadFloat(std::string prop, const ofxJSONElement& moduleInfo, float defaultValue = 0, float min=0, float max=1, bool isTextField = false);
+   float LoadFloat(std::string prop, const ofxJSONElement& moduleInfo, float defaultValue , FloatSlider* slider, bool isTextField = false);
+   bool LoadBool(std::string prop, const ofxJSONElement& moduleInfo, bool defaultValue = false);
+   std::string LoadString(std::string prop, const ofxJSONElement& moduleInfo, std::string defaultValue = "", FillDropdownFn fillFn = nullptr);
+   template <class T> T LoadEnum(std::string prop, const ofxJSONElement& moduleInfo, int defaultValue, IUIControl* list = nullptr, EnumMap* map = nullptr)
    {
       if (list)
          SetEnumMapFromList(prop, list);
@@ -75,7 +75,7 @@ public:
       return (T)LoadInt(prop, moduleInfo, defaultValue);
    }
    
-   void UpdatePropertyMax(string prop, float max);
+   void UpdatePropertyMax(std::string prop, float max);
    
    enum Type
    {
@@ -87,9 +87,9 @@ public:
    
    struct SaveVal
    {
-      explicit SaveVal(string prop) : mProperty(std::move(prop)), mString(), mMin(0), mMax(10), mIsTextField(false), mFillDropdownFn(nullptr) {}
+      explicit SaveVal(std::string prop) : mProperty(std::move(prop)), mString(), mMin(0), mMax(10), mIsTextField(false), mFillDropdownFn(nullptr) {}
       
-      string mProperty;
+      std::string mProperty;
       Type mType;
       int mInt;
       float mFloat;
@@ -102,16 +102,16 @@ public:
       FillDropdownFn mFillDropdownFn;
    };
    
-   list<SaveVal*>& GetSavedValues() { return mValues; }
+   std::list<SaveVal*>& GetSavedValues() { return mValues; }
 
    //generally these are only used internally, needed to expose them for a special case
-   void SetEnumMapFromList(string prop, IUIControl* list);
-   void SetEnumMap(string prop, EnumMap* map);
+   void SetEnumMapFromList(std::string prop, IUIControl* list);
+   void SetEnumMap(std::string prop, EnumMap* map);
    
 private:
-   SaveVal* GetVal(string prop);
+   SaveVal* GetVal(std::string prop);
    
-   list<SaveVal*> mValues;
+   std::list<SaveVal*> mValues;
 };
 
 #endif /* defined(__modularSynth__ModuleSaveData__) */

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -85,17 +85,17 @@ void ModuleSaveDataPanel::ReloadSaveData()
    UpdateTarget(mSaveModule);
    
    int maxWidth = 40;
-   list<ModuleSaveData::SaveVal*> values = mSaveModule->GetSaveData().GetSavedValues();
+   std::list<ModuleSaveData::SaveVal*> values = mSaveModule->GetSaveData().GetSavedValues();
    for (auto iter = values.begin(); iter != values.end(); ++iter)
       mLabels.push_back((*iter)->mProperty);
    for (int i=0; i<mSaveModule->GetChildren().size(); ++i)
    {
       IDrawableModule* child = mSaveModule->GetChildren()[i];
-      list<ModuleSaveData::SaveVal*>& childValues = child->GetSaveData().GetSavedValues();
+      std::list<ModuleSaveData::SaveVal*>& childValues = child->GetSaveData().GetSavedValues();
       for (auto iter = childValues.begin(); iter != childValues.end(); ++iter)
       {
          values.push_back(*iter);
-         mLabels.push_back(string(child->Name()) + "." + (*iter)->mProperty);
+         mLabels.push_back(std::string(child->Name()) + "." + (*iter)->mProperty);
       }
    }
    for (auto iter = mLabels.begin(); iter != mLabels.end(); ++iter)

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -47,7 +47,7 @@ public:
    static IDrawableModule* Create() { return new ModuleSaveDataPanel(); }
    static bool CanCreate() { return TheSaveDataPanel == nullptr; }
    
-   string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() override { return ""; }
    bool AlwaysOnTop() override { return true; }
    bool CanMinimize() override { return false; }
    bool IsSingleton() const override { return true; }
@@ -77,12 +77,12 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    
    IDrawableModule* mSaveModule;
-   vector<IUIControl*> mSaveDataControls;
-   vector<string> mLabels;
+   std::vector<IUIControl*> mSaveDataControls;
+   std::vector<std::string> mLabels;
    ClickButton* mApplyButton;
    ClickButton* mDeleteButton;
    Checkbox* mDrawDebugCheckbox;
-   map<DropdownList*,ModuleSaveData::SaveVal*> mStringDropdowns;
+   std::map<DropdownList*,ModuleSaveData::SaveVal*> mStringDropdowns;
 
    int mHeight;
    float mAppearAmount;

--- a/Source/ModwheelToPressure.h
+++ b/Source/ModwheelToPressure.h
@@ -37,7 +37,7 @@ public:
    virtual ~ModwheelToPressure();
    static IDrawableModule* Create() { return new ModwheelToPressure(); }
    
-   string GetTitleLabel() override { return "modwheel to pressure"; }
+   std::string GetTitleLabel() override { return "modwheel to pressure"; }
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //INoteReceiver

--- a/Source/ModwheelToVibrato.h
+++ b/Source/ModwheelToVibrato.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModwheelToVibrato();
    static IDrawableModule* Create() { return new ModwheelToVibrato(); }
    
-   string GetTitleLabel() override { return "modwheel to vibrato"; }
+   std::string GetTitleLabel() override { return "modwheel to vibrato"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -154,7 +154,7 @@ void Monome::SetLightFlicker(int x, int y, float intensity)
    }
 }
 
-string Monome::GetControlTooltip(MidiMessageType type, int control)
+std::string Monome::GetControlTooltip(MidiMessageType type, int control)
 {
    if (type == kMidiMessage_Note)
       return "(" + ofToString(control % mMaxColumns) + ", " + ofToString(control/mMaxColumns) + ")";
@@ -167,7 +167,7 @@ void Monome::SetLayoutData(ofxJSONElement& layout)
       mGridRotation = layout["monome_rotation"].asInt();
 }
 
-void Monome::ConnectToDevice(string deviceDesc)
+void Monome::ConnectToDevice(std::string deviceDesc)
 {
    MonomeDevice* device = nullptr;
    for (size_t i=0; i<mConnectedDeviceList.size(); ++i)
@@ -327,7 +327,7 @@ void Monome::SaveState(FileStreamOut& out)
 {
    out << kSaveStateRev;
    
-   string connectedDeviceDesc = "";
+   std::string connectedDeviceDesc = "";
    if (mLastConnectedDeviceInfo.id != "")
       connectedDeviceDesc = mLastConnectedDeviceInfo.GetDescription();
    out << connectedDeviceDesc;

--- a/Source/Monome.h
+++ b/Source/Monome.h
@@ -53,9 +53,9 @@ public:
    void ListMonomes();
    void SetLight(int x, int y, float value);
    void SetLightFlicker(int x, int y, float flickerMs);
-   string GetControlTooltip(MidiMessageType type, int control) override;
+   std::string GetControlTooltip(MidiMessageType type, int control) override;
    void SetLayoutData(ofxJSONElement& layout) override;
-   void ConnectToDevice(string deviceDesc);
+   void ConnectToDevice(std::string deviceDesc);
    void UpdateDeviceList(DropdownList* list);
    
    void oscMessageReceived(const juce::OSCMessage& msg) override;
@@ -83,18 +83,18 @@ private:
    int mGridRotation;
    juce::String mPrefix;
    bool mJustRequestedDeviceList;
-   string mPendingDeviceDesc;
+   std::string mPendingDeviceDesc;
    
    struct MonomeDevice
    {
       void CopyFrom(MonomeDevice& other) { id = other.id; product = other.product; port = other.port; }
-      string id;
-      string product;
+      std::string id;
+      std::string product;
       int port;
-      string GetDescription() { return id + " " + product; }
+      std::string GetDescription() { return id + " " + product; }
    };
    
-   vector<MonomeDevice> mConnectedDeviceList;
+   std::vector<MonomeDevice> mConnectedDeviceList;
    
    MidiDeviceListener* mListener;
    DropdownList* mListForMidiController;
@@ -108,7 +108,7 @@ private:
       double mLastSentTime;
    };
    
-   vector<LightInfo> mLights;
+   std::vector<LightInfo> mLights;
 };
 
 #endif /* defined(__modularSynth__Monome__) */

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -39,7 +39,7 @@ public:
    Monophonify();
    static IDrawableModule* Create() { return new Monophonify(); }
    
-   string GetTitleLabel() override { return "portamento"; }
+   std::string GetTitleLabel() override { return "portamento"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/MultiBandTracker.h
+++ b/Source/MultiBandTracker.h
@@ -43,8 +43,8 @@ public:
    float GetBand(int idx);
    int NumBands() { return mNumBands; }
 private:
-   vector<CLinkwitzRiley_4thOrder> mBands;
-   vector<PeakTracker> mPeaks;
+   std::vector<CLinkwitzRiley_4thOrder> mBands;
+   std::vector<PeakTracker> mPeaks;
    int mNumBands;
    float mMinFreq;
    float mMaxFreq;

--- a/Source/MultibandCompressor.h
+++ b/Source/MultibandCompressor.h
@@ -44,7 +44,7 @@ public:
    virtual ~MultibandCompressor();
    static IDrawableModule* Create() { return new MultibandCompressor(); }
    
-   string GetTitleLabel() override { return "multiband compressor"; }
+   std::string GetTitleLabel() override { return "multiband compressor"; }
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -47,7 +47,7 @@ public:
    ~MultitapDelay();
    static IDrawableModule* Create() { return new MultitapDelay(); }
    
-   string GetTitleLabel() override { return "multitap delay"; }
+   std::string GetTitleLabel() override { return "multitap delay"; }
    void CreateUIControls() override;
    
    //INoteReceiver
@@ -125,7 +125,7 @@ private:
    };
    
    int mNumTaps;
-   vector<DelayTap> mTaps;
+   std::vector<DelayTap> mTaps;
    static const int kNumMPETaps = 16;
    DelayMPETap mMPETaps[kNumMPETaps];
    

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -128,11 +128,11 @@ void MultitrackRecorder::ButtonClicked(ClickButton* button)
 
    if (button == mBounceButton)
    {
-      string recordingsPath = "recordings/";
+      std::string recordingsPath = "recordings/";
       if (!TheSynth->GetUserPrefs()["recordings_path"].isNull())
          recordingsPath = TheSynth->GetUserPrefs()["recordings_path"].asString();
 
-      string filenamePrefix = ofGetTimestampString(recordingsPath + "multitrack_%Y-%m-%d_%H-%M_");
+      std::string filenamePrefix = ofGetTimestampString(recordingsPath + "multitrack_%Y-%m-%d_%H-%M_");
 
       int numFiles = 0;
       for (int i = 0; i < (int)mTracks.size(); ++i)
@@ -141,7 +141,7 @@ void MultitrackRecorder::ButtonClicked(ClickButton* button)
 
          if (sample)
          {
-            string filename = filenamePrefix + ofToString(i+1) + ".wav";
+            std::string filename = filenamePrefix + ofToString(i+1) + ".wav";
             sample->Write(filename.c_str());
             ++numFiles;
          }
@@ -219,7 +219,7 @@ void MultitrackRecorder::SaveState(FileStreamOut& out)
    //preserve order
    out << (int)mTracks.size();
    for (auto* track : mTracks)
-      out << (string)track->Name();
+      out << (std::string)track->Name();
 }
 
 void MultitrackRecorder::LoadState(FileStreamIn& in)
@@ -235,15 +235,15 @@ void MultitrackRecorder::LoadState(FileStreamIn& in)
    //preserve order
    int numTracks;
    in >> numTracks;
-   vector<string> sortOrder;
+   std::vector<std::string> sortOrder;
    for (int i = 0; i < numTracks; ++i)
    {
-      string name;
+      std::string name;
       in >> name;
       sortOrder.push_back(name);
    }
 
-   vector<MultitrackRecorderTrack*> sortedTracks;
+   std::vector<MultitrackRecorderTrack*> sortedTracks;
    for (auto& name : sortOrder)
    {
       for (auto& track : mTracks)

--- a/Source/MultitrackRecorder.h
+++ b/Source/MultitrackRecorder.h
@@ -43,7 +43,7 @@ public:
    virtual ~MultitrackRecorder();
    static IDrawableModule* Create() { return new MultitrackRecorder(); }
    
-   string GetTitleLabel() override { return "multitrack recorder"; }
+   std::string GetTitleLabel() override { return "multitrack recorder"; }
    void CreateUIControls() override;
    ModuleContainer* GetContainer() override { return &mModuleContainer; }
    bool IsResizable() const override { return true; }
@@ -79,8 +79,8 @@ private:
    ClickButton* mBounceButton;
    ClickButton* mClearButton;
 
-   vector<MultitrackRecorderTrack*> mTracks;
-   string mStatusString;
+   std::vector<MultitrackRecorderTrack*> mTracks;
+   std::string mStatusString;
    double mStatusStringTime;
 };
 
@@ -91,7 +91,7 @@ public:
    virtual ~MultitrackRecorderTrack();
    static IDrawableModule* Create() { return new MultitrackRecorderTrack(); }
 
-   string GetTitleLabel() override { return " "; }
+   std::string GetTitleLabel() override { return " "; }
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
 
@@ -118,7 +118,7 @@ private:
 
    MultitrackRecorder* mRecorder;
 
-   vector<ChannelBuffer*> mRecordChunks;
+   std::vector<ChannelBuffer*> mRecordChunks;
    bool mDoRecording;
    int mRecordingLength;
    ClickButton* mDeleteButton;

--- a/Source/Muter.h
+++ b/Source/Muter.h
@@ -41,13 +41,13 @@ public:
    
    static IAudioEffect* Create() { return new Muter(); }
    
-   string GetTitleLabel() override { return "muter"; }
+   std::string GetTitleLabel() override { return "muter"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override {}
-   string GetType() override { return "muter"; }
+   std::string GetType() override { return "muter"; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/NamedMutex.cpp
+++ b/Source/NamedMutex.cpp
@@ -25,7 +25,7 @@
 
 #include "NamedMutex.h"
 
-void NamedMutex::Lock(string locker)
+void NamedMutex::Lock(std::string locker)
 {
    if (mLocker == locker)
    {
@@ -49,7 +49,7 @@ void NamedMutex::Unlock()
    }
 }
 
-ScopedMutex::ScopedMutex(NamedMutex* mutex, string locker)
+ScopedMutex::ScopedMutex(NamedMutex* mutex, std::string locker)
 : mMutex(mutex)
 {
    mMutex->Lock(locker);

--- a/Source/NamedMutex.h
+++ b/Source/NamedMutex.h
@@ -32,18 +32,18 @@ class NamedMutex
 {
 public:
    NamedMutex() : mLocker("<none>"), mExtraLockCount(0) {}
-   void Lock(string locker);
+   void Lock(std::string locker);
    void Unlock();
 private:
    ofMutex mMutex;
-   string mLocker;
+   std::string mLocker;
    int mExtraLockCount;
 };
 
 class ScopedMutex
 {
 public:
-   ScopedMutex(NamedMutex* mutex, string locker);
+   ScopedMutex(NamedMutex* mutex, std::string locker);
    ~ScopedMutex();
 private:
    NamedMutex* mMutex;

--- a/Source/Neighborhooder.h
+++ b/Source/Neighborhooder.h
@@ -38,7 +38,7 @@ public:
    Neighborhooder();
    static IDrawableModule* Create() { return new Neighborhooder(); }
    
-   string GetTitleLabel() override { return "notewrap"; }
+   std::string GetTitleLabel() override { return "notewrap"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoiseEffect.h
+++ b/Source/NoiseEffect.h
@@ -38,14 +38,14 @@ public:
    
    static IAudioEffect* Create() { return new NoiseEffect(); }
    
-   string GetTitleLabel() override { return "noisify"; }
+   std::string GetTitleLabel() override { return "noisify"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "noisify"; }
+   std::string GetType() override { return "noisify"; }
 
    
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -523,7 +523,7 @@ void NoteCanvas::ClipNotes()
    bool anyHighlighted = false;
    float earliest = FLT_MAX;
    float latest = 0;
-   vector<CanvasElement*> toDelete;
+   std::vector<CanvasElement*> toDelete;
    for (auto* element : mCanvas->GetElements())
    {
       if (element->GetHighlighted())

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -47,7 +47,7 @@ public:
    ~NoteCanvas();
    static IDrawableModule* Create() { return new NoteCanvas(); }
    
-   string GetTitleLabel() override { return "note canvas"; }
+   std::string GetTitleLabel() override { return "note canvas"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -97,9 +97,9 @@ private:
    CanvasTimeline* mCanvasTimeline;
    CanvasScrollbar* mCanvasScrollbarHorizontal;
    CanvasScrollbar* mCanvasScrollbarVertical;
-   vector<CanvasElement*> mNoteChecker{128};
-   vector<NoteCanvasElement*> mInputNotes{128};
-   vector<NoteCanvasElement*> mCurrentNotes{128};
+   std::vector<CanvasElement*> mNoteChecker{128};
+   std::vector<NoteCanvasElement*> mInputNotes{128};
+   std::vector<NoteCanvasElement*> mCurrentNotes{128};
    IntSlider* mNumMeasuresSlider;
    int mNumMeasures;
    ClickButton* mQuantizeButton;
@@ -117,7 +117,7 @@ private:
    bool mShowIntervals;
    Checkbox* mShowIntervalsCheckbox;
    
-   vector<ModulationParameters> mVoiceModulations;
+   std::vector<ModulationParameters> mVoiceModulations;
 };
 
 #endif /* defined(__Bespoke__NoteCanvas__) */

--- a/Source/NoteChainNode.h
+++ b/Source/NoteChainNode.h
@@ -42,7 +42,7 @@ public:
    virtual ~NoteChainNode();
    static IDrawableModule* Create() { return new NoteChainNode(); }
    
-   string GetTitleLabel() override { return "note chain"; }
+   std::string GetTitleLabel() override { return "note chain"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteChance.h
+++ b/Source/NoteChance.h
@@ -36,7 +36,7 @@ public:
    virtual ~NoteChance();
    static IDrawableModule* Create() { return new NoteChance(); }
    
-   string GetTitleLabel() override { return "note chance"; }
+   std::string GetTitleLabel() override { return "note chance"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteCounter.h
+++ b/Source/NoteCounter.h
@@ -39,7 +39,7 @@ public:
    ~NoteCounter();
    static IDrawableModule* Create() { return new NoteCounter(); }
    
-   string GetTitleLabel() override { return "note counter"; }
+   std::string GetTitleLabel() override { return "note counter"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteCreator.h
+++ b/Source/NoteCreator.h
@@ -41,7 +41,7 @@ public:
    virtual ~NoteCreator();
    static IDrawableModule* Create() { return new NoteCreator(); }
    
-   string GetTitleLabel() override { return "note creator"; }
+   std::string GetTitleLabel() override { return "note creator"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteDelayer.h
+++ b/Source/NoteDelayer.h
@@ -40,7 +40,7 @@ public:
    ~NoteDelayer();
    static IDrawableModule* Create() { return new NoteDelayer(); }
    
-   string GetTitleLabel() override { return "note delayer"; }
+   std::string GetTitleLabel() override { return "note delayer"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteDisplayer.h
+++ b/Source/NoteDisplayer.h
@@ -35,7 +35,7 @@ public:
    NoteDisplayer() = default;
    static IDrawableModule* Create() { return new NoteDisplayer(); }
    
-   string GetTitleLabel() override { return "notedisplayer"; }
+   std::string GetTitleLabel() override { return "notedisplayer"; }
    
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/NoteFilter.h
+++ b/Source/NoteFilter.h
@@ -35,7 +35,7 @@ public:
    virtual ~NoteFilter();
    static IDrawableModule* Create() { return new NoteFilter(); }
    
-   string GetTitleLabel() override { return "note filter"; }
+   std::string GetTitleLabel() override { return "note filter"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -52,9 +52,9 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
    
-   array<bool, 128> mGate;
-   array<float, 128> mLastPlayTime;
-   vector<Checkbox*> mGateCheckboxes;
+   std::array<bool, 128> mGate;
+   std::array<float, 128> mLastPlayTime;
+   std::vector<Checkbox*> mGateCheckboxes;
    int mMinPitch;
    int mMaxPitch;
 };

--- a/Source/NoteFlusher.h
+++ b/Source/NoteFlusher.h
@@ -37,7 +37,7 @@ public:
    NoteFlusher();
    static IDrawableModule* Create() { return new NoteFlusher(); }
    
-   string GetTitleLabel() override { return "flusher"; }
+   std::string GetTitleLabel() override { return "flusher"; }
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;

--- a/Source/NoteGate.h
+++ b/Source/NoteGate.h
@@ -36,7 +36,7 @@ public:
    virtual ~NoteGate();
    static IDrawableModule* Create() { return new NoteGate(); }
    
-   string GetTitleLabel() override { return "note gate"; }
+   std::string GetTitleLabel() override { return "note gate"; }
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/NoteHocket.h
+++ b/Source/NoteHocket.h
@@ -40,7 +40,7 @@ public:
    NoteHocket();
    static IDrawableModule* Create() { return new NoteHocket(); }
    
-   string GetTitleLabel() override { return "hocket"; }
+   std::string GetTitleLabel() override { return "hocket"; }
    void CreateUIControls() override;
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteHumanizer.h
+++ b/Source/NoteHumanizer.h
@@ -43,7 +43,7 @@ public:
    ~NoteHumanizer();
    static IDrawableModule* Create() { return new NoteHumanizer(); }
    
-   string GetTitleLabel() override { return "note humanizer"; }
+   std::string GetTitleLabel() override { return "note humanizer"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteLatch.h
+++ b/Source/NoteLatch.h
@@ -37,7 +37,7 @@ public:
    NoteLatch();
    static IDrawableModule* Create() { return new NoteLatch(); }
    
-   string GetTitleLabel() override { return "note latch"; }
+   std::string GetTitleLabel() override { return "note latch"; }
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -45,7 +45,7 @@ public:
    ~NoteLooper();
    static IDrawableModule* Create() { return new NoteLooper(); }
    
-   string GetTitleLabel() override { return "note looper"; }
+   std::string GetTitleLabel() override { return "note looper"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -104,7 +104,7 @@ private:
    {
       ClickButton* mStoreButton;
       ClickButton* mLoadButton;
-      vector<CanvasElement*> mNotes;
+      std::vector<CanvasElement*> mNotes;
    };
 
    float mWidth;
@@ -117,7 +117,7 @@ private:
    Checkbox* mDeleteOrMuteCheckbox;
    IntSlider* mNumMeasuresSlider;
    int mNumMeasures;
-   vector<CanvasElement*> mNoteChecker {128};
+   std::vector<CanvasElement*> mNoteChecker {128};
    std::array<NoteCanvasElement*, 128> mInputNotes {};
    std::array<NoteCanvasElement*, 128> mCurrentNotes {};
    Canvas* mCanvas;

--- a/Source/NoteOctaver.h
+++ b/Source/NoteOctaver.h
@@ -39,7 +39,7 @@ public:
    NoteOctaver();
    static IDrawableModule* Create() { return new NoteOctaver(); }
    
-   string GetTitleLabel() override { return "octaver"; }
+   std::string GetTitleLabel() override { return "octaver"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanAlternator.h
+++ b/Source/NotePanAlternator.h
@@ -39,7 +39,7 @@ public:
    NotePanAlternator();
    static IDrawableModule* Create() { return new NotePanAlternator(); }
    
-   string GetTitleLabel() override { return "pan alternator"; }
+   std::string GetTitleLabel() override { return "pan alternator"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanRandom.h
+++ b/Source/NotePanRandom.h
@@ -38,7 +38,7 @@ public:
    NotePanRandom();
    static IDrawableModule* Create() { return new NotePanRandom(); }
    
-   string GetTitleLabel() override { return "note pan random"; }
+   std::string GetTitleLabel() override { return "note pan random"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanner.h
+++ b/Source/NotePanner.h
@@ -39,7 +39,7 @@ public:
    NotePanner();
    static IDrawableModule* Create() { return new NotePanner(); }
    
-   string GetTitleLabel() override { return "note panner"; }
+   std::string GetTitleLabel() override { return "note panner"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteQuantizer.h
+++ b/Source/NoteQuantizer.h
@@ -42,7 +42,7 @@ public:
    void CreateUIControls() override;
    void Init() override;
 
-   string GetTitleLabel() override { return "quantizer"; }
+   std::string GetTitleLabel() override { return "quantizer"; }
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/NoteRangeFilter.h
+++ b/Source/NoteRangeFilter.h
@@ -37,7 +37,7 @@ public:
    NoteRangeFilter();
    static IDrawableModule* Create() { return new NoteRangeFilter(); }
    
-   string GetTitleLabel() override { return "note range filter"; }
+   std::string GetTitleLabel() override { return "note range filter"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteRatchet.h
+++ b/Source/NoteRatchet.h
@@ -38,7 +38,7 @@ public:
    NoteRatchet();
    static IDrawableModule* Create() { return new NoteRatchet(); }
 
-   string GetTitleLabel() override { return "note ratchet"; }
+   std::string GetTitleLabel() override { return "note ratchet"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteRouter.cpp
+++ b/Source/NoteRouter.cpp
@@ -111,7 +111,7 @@ void NoteRouter::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
       if (cableSource == mDestinationCables[i]->GetPatchCableSource())
       {
          IClickable* target = cableSource->GetTarget();
-         string name = target ? target->Name() : "                      ";
+         std::string name = target ? target->Name() : "                      ";
          mRouteSelector->SetLabel(name.c_str(), i);
       }
    }

--- a/Source/NoteRouter.h
+++ b/Source/NoteRouter.h
@@ -38,7 +38,7 @@ public:
    NoteRouter();
    static IDrawableModule* Create() { return new NoteRouter(); }
    
-   string GetTitleLabel() override { return "note router"; }
+   std::string GetTitleLabel() override { return "note router"; }
    void CreateUIControls() override;
 
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
@@ -63,7 +63,7 @@ private:
 
    int mRouteMask;
    RadioButton* mRouteSelector;
-   vector<AdditionalNoteCable*> mDestinationCables;
+   std::vector<AdditionalNoteCable*> mDestinationCables;
    bool mRadioButtonMode;
 };
 

--- a/Source/NoteSinger.cpp
+++ b/Source/NoteSinger.cpp
@@ -109,7 +109,7 @@ void NoteSinger::OnTransportAdvanced(float amount)
    GetBuffer()->Reset();
 }
 
-string NoteSinger::GetTitleLabel()
+std::string NoteSinger::GetTitleLabel()
 {
    if (Minimized())
       return "notesinger";

--- a/Source/NoteSinger.h
+++ b/Source/NoteSinger.h
@@ -49,7 +49,7 @@ public:
    ~NoteSinger();
    static IDrawableModule* Create() { return new NoteSinger(); }
    
-   string GetTitleLabel() override;
+   std::string GetTitleLabel() override;
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/NoteSorter.h
+++ b/Source/NoteSorter.h
@@ -40,7 +40,7 @@ public:
    NoteSorter();
    static IDrawableModule* Create() { return new NoteSorter(); }
 
-   string GetTitleLabel() override { return "notesorter"; }
+   std::string GetTitleLabel() override { return "notesorter"; }
    void CreateUIControls() override;
 
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -189,7 +189,7 @@ NoteStepSequencer::~NoteStepSequencer()
    TheScale->RemoveListener(this);
 }
 
-void NoteStepSequencer::SetMidiController(string name)
+void NoteStepSequencer::SetMidiController(std::string name)
 {
    if (mController)
       mController->RemoveListener(this);

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -53,13 +53,13 @@ public:
    virtual ~NoteStepSequencer();
    static IDrawableModule* Create() { return new NoteStepSequencer(); }
    
-   string GetTitleLabel() override { return "note sequencer"; }
+   std::string GetTitleLabel() override { return "note sequencer"; }
    void CreateUIControls() override;
    
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
-   void SetMidiController(string name);
+   void SetMidiController(std::string name);
    
    UIGrid* GetGrid() const { return mGrid; }
    

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -40,7 +40,7 @@ public:
    NoteStepper();
    static IDrawableModule* Create() { return new NoteStepper(); }
    
-   string GetTitleLabel() override { return "note stepper"; }
+   std::string GetTitleLabel() override { return "note stepper"; }
    void CreateUIControls() override;
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteStreamDisplay.cpp
+++ b/Source/NoteStreamDisplay.cpp
@@ -176,7 +176,7 @@ void NoteStreamDisplay::PlayNote(double time, int pitch, int velocity, int voice
    
    if (mDrawDebug)
    {
-      vector<string> lines = ofSplitString(mDebugLines, "\n");
+      std::vector<std::string> lines = ofSplitString(mDebugLines, "\n");
       mDebugLines = "";
       const int kNumDisplayLines = 35;
       for (int i=0; i<kNumDisplayLines-1; ++i)
@@ -185,7 +185,7 @@ void NoteStreamDisplay::PlayNote(double time, int pitch, int velocity, int voice
          if (lineIndex >= 0)
             mDebugLines += lines[lineIndex] + "\n";
       }
-      string line = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
+      std::string line = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
       mDebugLines += line;
       ofLog() << line;
    }

--- a/Source/NoteStreamDisplay.h
+++ b/Source/NoteStreamDisplay.h
@@ -38,7 +38,7 @@ public:
    static IDrawableModule* Create() { return new NoteStreamDisplay(); }
    void CreateUIControls() override;
    
-   string GetTitleLabel() override { return "note stream"; }
+   std::string GetTitleLabel() override { return "note stream"; }
    
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
@@ -79,5 +79,5 @@ private:
    int mPitchMin;
    int mPitchMax;
    ClickButton* mResetButton;
-   string mDebugLines;
+   std::string mDebugLines;
 };

--- a/Source/NoteStrummer.h
+++ b/Source/NoteStrummer.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteStrummer();
    static IDrawableModule* Create() { return new NoteStrummer(); }
    
-   string GetTitleLabel() override { return "note strummer"; }
+   std::string GetTitleLabel() override { return "note strummer"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -63,5 +63,5 @@ private:
    float mStrum;
    float mLastStrumPos;
    FloatSlider* mStrumSlider;
-   list<int> mNotes;
+   std::list<int> mNotes;
 };

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -38,7 +38,7 @@ public:
    ~NoteSustain();
    static IDrawableModule* Create() { return new NoteSustain(); }
    
-   string GetTitleLabel() override { return "note duration"; }
+   std::string GetTitleLabel() override { return "note duration"; }
    void CreateUIControls() override;
    void Init() override;
    
@@ -70,7 +70,7 @@ private:
    
    float mSustain;
    FloatSlider* mSustainSlider;
-   list<QueuedNoteOff> mNoteOffs;
+   std::list<QueuedNoteOff> mNoteOffs;
 };
 
 

--- a/Source/NoteToFreq.cpp
+++ b/Source/NoteToFreq.cpp
@@ -78,7 +78,7 @@ void NoteToFreq::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/NoteToFreq.h
+++ b/Source/NoteToFreq.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteToFreq();
    static IDrawableModule* Create() { return new NoteToFreq(); }
    
-   string GetTitleLabel() override { return "notetofreq"; }
+   std::string GetTitleLabel() override { return "notetofreq"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteToMs.cpp
+++ b/Source/NoteToMs.cpp
@@ -78,7 +78,7 @@ void NoteToMs::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/NoteToMs.h
+++ b/Source/NoteToMs.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteToMs();
    static IDrawableModule* Create() { return new NoteToMs(); }
    
-   string GetTitleLabel() override { return "note to ms"; }
+   std::string GetTitleLabel() override { return "note to ms"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteToPulse.h
+++ b/Source/NoteToPulse.h
@@ -40,7 +40,7 @@ public:
    virtual ~NoteToPulse();
    static IDrawableModule* Create() { return new NoteToPulse(); }
    
-   string GetTitleLabel() override { return "note to pulse"; }
+   std::string GetTitleLabel() override { return "note to pulse"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteTransformer.h
+++ b/Source/NoteTransformer.h
@@ -39,7 +39,7 @@ public:
    ~NoteTransformer();
    static IDrawableModule* Create() { return new NoteTransformer(); }
    
-   string GetTitleLabel() override { return "transformer"; }
+   std::string GetTitleLabel() override { return "transformer"; }
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/NoteVibrato.h
+++ b/Source/NoteVibrato.h
@@ -41,7 +41,7 @@ public:
    virtual ~NoteVibrato();
    static IDrawableModule* Create() { return new NoteVibrato(); }
    
-   string GetTitleLabel() override { return "vibrato"; }
+   std::string GetTitleLabel() override { return "vibrato"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/OSCOutput.cpp
+++ b/Source/OSCOutput.cpp
@@ -116,21 +116,21 @@ void OSCOutput::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
    }
 }
 
-void OSCOutput::SendFloat(string address, float val)
+void OSCOutput::SendFloat(std::string address, float val)
 {
    juce::OSCMessage msg(address.c_str());
    msg.addFloat32(val);
    mOscOut.send(msg);
 }
 
-void OSCOutput::SendInt(string address, int val)
+void OSCOutput::SendInt(std::string address, int val)
 {
    juce::OSCMessage msg(address.c_str());
    msg.addInt32(val);
    mOscOut.send(msg);
 }
 
-void OSCOutput::SendString(string address, string val)
+void OSCOutput::SendString(std::string address, std::string val)
 {
    juce::OSCMessage msg(address.c_str());
    msg.addString(val);

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -47,12 +47,12 @@ public:
    
    void Init() override;
    void Poll() override;
-   string GetTitleLabel() override { return "osc output"; }
+   std::string GetTitleLabel() override { return "osc output"; }
    void CreateUIControls() override;
 
-   void SendFloat(string address, float val);
-   void SendInt(string address, int val);
-   void SendString(string address, string val);
+   void SendFloat(std::string address, float val);
+   void SendInt(std::string address, int val);
+   void SendString(std::string address, std::string val);
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
@@ -72,16 +72,16 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    
    char* mLabels[OSC_OUTPUT_MAX_PARAMS];
-   list<TextEntry*> mLabelEntry;
+   std::list<TextEntry*> mLabelEntry;
    float mParams[OSC_OUTPUT_MAX_PARAMS];
-   list<FloatSlider*> mSliders;
+   std::list<FloatSlider*> mSliders;
 
-   string mOscOutAddress;
+   std::string mOscOutAddress;
    TextEntry* mOscOutAddressEntry;
    int mOscOutPort;
    TextEntry* mOscOutPortEntry;
 
-   string mNoteOutLabel;
+   std::string mNoteOutLabel;
    TextEntry* mNoteOutLabelEntry;
    
    juce::OSCSender mOscOut;

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -67,7 +67,7 @@ ofColor ofColor::clear(0, 0, 0, 0);
 NVGcontext* gNanoVG = nullptr;
 NVGcontext* gFontBoundsNanoVG = nullptr;
 
-string ofToDataPath(string path, bool makeAbsolute)
+std::string ofToDataPath(std::string path, bool makeAbsolute)
 {
    if (path.empty() == false && path[0] == '.')
       return path;
@@ -85,10 +85,10 @@ string ofToDataPath(string path, bool makeAbsolute)
    }
    sWorkingDirectory.setAsCurrentWorkingDirectory(); //restore working directory, in case a VST plugin changed it (ROLI Studio Drums does this!)
    
-   static string sDataDir = "";
+   static std::string sDataDir = "";
    if (sDataDir == "")
    {
-      string dataDir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("BespokeSynth").getFullPathName().toStdString();
+      std::string dataDir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("BespokeSynth").getFullPathName().toStdString();
       ofStringReplace(dataDir, "\\", "/");
       UpdateUserData(dataDir);
       sDataDir = dataDir;
@@ -97,7 +97,7 @@ string ofToDataPath(string path, bool makeAbsolute)
    return sDataDir + "/" + path;
 }
 
-string ofToResourcePath(string path, bool makeAbsolute)
+std::string ofToResourcePath(std::string path, bool makeAbsolute)
 {
    if (path.empty() == false && path[0] == '.')
       return path;
@@ -115,11 +115,11 @@ string ofToResourcePath(string path, bool makeAbsolute)
    }
    sWorkingDirectory.setAsCurrentWorkingDirectory(); //restore working directory, in case a VST plugin changed it (ROLI Studio Drums does this!)
    
-   static string sResourceDir = "";
+   static std::string sResourceDir = "";
    if (sResourceDir == "")
    {
 #if JUCE_WINDOWS
-      string localResourceDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
+      std::string localResourceDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
       if (juce::File(localResourceDir).exists())
          sResourceDir = localResourceDir;
       else
@@ -127,9 +127,9 @@ string ofToResourcePath(string path, bool makeAbsolute)
       ofStringReplace(sResourceDir, "\\", "/");
 
 #elif JUCE_LINUX
-      string localDataDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
-      string cmakeDataDir = File(Bespoke::CMAKE_INSTALL_PREFIX).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString();
-      string installedDataDir = File::getSpecialLocation(File::globalApplicationsDirectory).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString(); // /usr/share/BespokeSynth/resource
+      std::string localDataDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
+      std::string cmakeDataDir = File(Bespoke::CMAKE_INSTALL_PREFIX).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString();
+      std::string installedDataDir = File::getSpecialLocation(File::globalApplicationsDirectory).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString(); // /usr/share/BespokeSynth/resource
       if (juce::File(localDataDir).exists())
          sResourceDir = localDataDir;
       else if (getenv("BESPOKE_DATA_DIR") && juce::File(getenv("BESPOKE_DATA_DIR")).exists())
@@ -168,12 +168,12 @@ string ofToResourcePath(string path, bool makeAbsolute)
       if (!foundResources) {
           // Retain the old code for now just in case
 #if DEBUG
-          string relative = "../Release/resource";
+          std::string relative = "../Release/resource";
 #else
-          string relative = "resource";
+          std::string relative = "resource";
 #endif
 
-          string localResourceDir = File::getCurrentWorkingDirectory().getChildFile(
+          std::string localResourceDir = File::getCurrentWorkingDirectory().getChildFile(
                   relative).getFullPathName().toStdString();
           if (juce::File(localResourceDir).exists()) {
               sResourceDir = localResourceDir;
@@ -204,7 +204,7 @@ struct StyleStack
    void Pop() { stack.pop_front(); }
    Style& GetStyle() { return *stack.begin(); }
    
-   list<Style> stack;
+   std::list<Style> stack;
 };
 
 static StyleStack sStyleStack;
@@ -353,19 +353,19 @@ float ofGetLastFrameTime()
    return .01666f;
 }
 
-int ofToInt(const string& intString)
+int ofToInt(const std::string& intString)
 {
    String str(intString);
    return str.getIntValue();
 }
 
-float ofToFloat(const string& floatString)
+float ofToFloat(const std::string& floatString)
 {
    String str(floatString);
    return str.getFloatValue();
 }
 
-int ofHexToInt(const string& hexString)
+int ofHexToInt(const std::string& hexString)
 {
    String str(hexString);
    return str.getHexValue32();
@@ -395,7 +395,7 @@ void ofSetLineWidth(float width)
 
 namespace
 {
-   vector<ofVec2f> gShapePoints;
+   std::vector<ofVec2f> gShapePoints;
 }
 
 void ofBeginShape()
@@ -514,7 +514,7 @@ float ofDistSquared(float x1, float y1, float x2, float y2)
    return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) );
 }
 
-vector<string> ofSplitString(string str, string splitter, bool ignoreEmpty, bool trim)
+std::vector<std::string> ofSplitString(std::string str, std::string splitter, bool ignoreEmpty, bool trim)
 {
    StringArray tokens;
    
@@ -526,14 +526,14 @@ vector<string> ofSplitString(string str, string splitter, bool ignoreEmpty, bool
    if (trim)
       tokens.trim();
    
-   vector<string> ret;
+   std::vector<std::string> ret;
    for (auto s : tokens)
       ret.push_back(s.toStdString());
    
    return ret;
 }
 
-bool ofIsStringInString(const string& haystack, const string& needle)
+bool ofIsStringInString(const std::string& haystack, const std::string& needle)
 {
    return ( strstr(haystack.c_str(), needle.c_str() ) != nullptr );
 }
@@ -559,7 +559,7 @@ void ofToggleFullscreen()
 #endif
 }
 
-void ofStringReplace(string& input, string searchStr, string replaceStr, bool firstOnly /*= false*/)
+void ofStringReplace(std::string& input, std::string searchStr, std::string replaceStr, bool firstOnly /*= false*/)
 {
    size_t uPos = 0;
    size_t uFindLen = searchStr.length();
@@ -579,7 +579,7 @@ void ofStringReplace(string& input, string searchStr, string replaceStr, bool fi
 }
 
 //%Y-%m-%d-%H-%M-%S-%i
-string ofGetTimestampString(string in)
+std::string ofGetTimestampString(std::string in)
 {
    Time time = Time::getCurrentTime();
    ofStringReplace(in, "%Y", ofToString(time.getYear()));
@@ -784,7 +784,7 @@ ofColor ofColor::operator+(const ofColor& other)
    return ofColor(r+other.r, g+other.g, b+other.b, a+other.a);
 }
 
-void RetinaTrueTypeFont::LoadFont(string path)
+void RetinaTrueTypeFont::LoadFont(std::string path)
 {
    mFontPath = ofToDataPath(path);
    File file(mFontPath.c_str());
@@ -800,7 +800,7 @@ void RetinaTrueTypeFont::LoadFont(string path)
    }
 }
 
-void RetinaTrueTypeFont::DrawString(string str, float size, float x, float y)
+void RetinaTrueTypeFont::DrawString(std::string str, float size, float x, float y)
 {
    if (!mLoaded)
       return;
@@ -815,7 +815,7 @@ void RetinaTrueTypeFont::DrawString(string str, float size, float x, float y)
    }
    else
    {
-      vector<string> lines = ofSplitString(str, "\n");
+      std::vector<std::string> lines = ofSplitString(str, "\n");
       float bounds[4];
       nvgTextBounds(gNanoVG, 0, 0, str.c_str(), nullptr, bounds);
       float lineHeight = bounds[3] - bounds[1];
@@ -827,7 +827,7 @@ void RetinaTrueTypeFont::DrawString(string str, float size, float x, float y)
    }
 }
 
-ofRectangle RetinaTrueTypeFont::DrawStringWrap(string str, float size, float x, float y, float width)
+ofRectangle RetinaTrueTypeFont::DrawStringWrap(std::string str, float size, float x, float y, float width)
 {
    if (!mLoaded)
       return ofRectangle();
@@ -843,7 +843,7 @@ ofRectangle RetinaTrueTypeFont::DrawStringWrap(string str, float size, float x, 
    return rect;
 }
 
-float RetinaTrueTypeFont::GetStringWidth(string str, float size)
+float RetinaTrueTypeFont::GetStringWidth(std::string str, float size)
 {
    if (!mLoaded)
       return str.size() * 12;
@@ -869,7 +869,7 @@ float RetinaTrueTypeFont::GetStringWidth(string str, float size)
    return width;
 }
 
-float RetinaTrueTypeFont::GetStringHeight(string str, float size)
+float RetinaTrueTypeFont::GetStringHeight(std::string str, float size)
 {
    if (!mLoaded)
       return str.size() * 12;

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -10,8 +10,6 @@
 #include <cmath>
 #include <mutex>
 
-using namespace std;
-
 class NVGcontext;
 
 extern NVGcontext* gNanoVG;
@@ -183,25 +181,25 @@ class RetinaTrueTypeFont
 {
 public:
    RetinaTrueTypeFont() : mLoaded(false) {}
-   void LoadFont(string path);
-   void DrawString(string str, float size, float x, float y);
-   ofRectangle DrawStringWrap(string str, float size, float x, float y, float width);
-   float GetStringWidth(string str, float size);
-   float GetStringHeight(string str, float size);
+   void LoadFont(std::string path);
+   void DrawString(std::string str, float size, float x, float y);
+   ofRectangle DrawStringWrap(std::string str, float size, float x, float y, float width);
+   float GetStringWidth(std::string str, float size);
+   float GetStringHeight(std::string str, float size);
    bool IsLoaded() { return mLoaded; }
    int GetFontHandle() const { return mFontHandle; }
-   string GetFontPath() const { return mFontPath; }
+   std::string GetFontPath() const { return mFontPath; }
 private:
    int mFontHandle;
    int mFontBoundsHandle;
    bool mLoaded;
-   string mFontPath;
+   std::string mFontPath;
 };
 
 typedef ofVec2f ofPoint;
 
-string ofToDataPath(string path, bool makeAboslute = false);
-string ofToResourcePath(string path, bool makeAboslute = false);
+std::string ofToDataPath(std::string path, bool makeAboslute = false);
+std::string ofToResourcePath(std::string path, bool makeAboslute = false);
 void ofPushStyle();
 void ofPopStyle();
 void ofPushMatrix();
@@ -222,9 +220,9 @@ void ofRect(float x, float y, float width, float height, float cornerRadius = 3)
 void ofRect(const ofRectangle& rect, float cornerRadius = 3);
 float ofClamp(float val, float a, float b);
 float ofGetLastFrameTime();
-int ofToInt(const string& intString);
-float ofToFloat(const string& floatString);
-int ofHexToInt(const string& hexString);
+int ofToInt(const std::string& intString);
+float ofToFloat(const std::string& floatString);
+int ofHexToInt(const std::string& hexString);
 void ofLine(float x1, float y1, float x2, float y2);
 void ofLine(ofVec2f v1, ofVec2f v2);
 void ofSetLineWidth(float width);
@@ -241,13 +239,13 @@ float ofGetHeight();
 float ofGetFrameRate();
 float ofLerp(float start, float stop, float amt);
 float ofDistSquared(float x1, float y1, float x2, float y2);
-vector<string> ofSplitString(string str, string splitter, bool ignoreEmpty = false, bool trim = false);
-bool ofIsStringInString(const string& haystack, const string& needle);
+std::vector<std::string> ofSplitString(std::string str, std::string splitter, bool ignoreEmpty = false, bool trim = false);
+bool ofIsStringInString(const std::string& haystack, const std::string& needle);
 void ofScale(float x, float y, float z);
 void ofExit();
 void ofToggleFullscreen();
-void ofStringReplace(string& str, string from, string to, bool firstOnly = false);
-string ofGetTimestampString(string in);
+void ofStringReplace(std::string& str, std::string from, std::string to, bool firstOnly = false);
+std::string ofGetTimestampString(std::string in);
 void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
 
 

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -26,7 +26,7 @@
 #include "OscController.h"
 #include "SynthGlobals.h"
 
-OscController::OscController(MidiDeviceListener* listener, string outAddress, int outPort, int inPort)
+OscController::OscController(MidiDeviceListener* listener, std::string outAddress, int outPort, int inPort)
 : mListener(listener)
 , mConnected(false)
 , mOutAddress(outAddress)
@@ -55,7 +55,7 @@ void OscController::Connect()
       
       mConnected = true;
    }
-   catch (exception e)
+   catch (std::exception e)
    {
    }
 }
@@ -80,7 +80,7 @@ bool OscController::SetInPort(int port)
    return false;
 }
 
-string OscController::GetControlTooltip(MidiMessageType type, int control)
+std::string OscController::GetControlTooltip(MidiMessageType type, int control)
 {
    if (type == kMidiMessage_Control && control >= 0 && control < mOscMap.size())
       return mOscMap[control].mAddress;
@@ -117,12 +117,12 @@ void OscController::SendValue(int page, int control, float value, bool forceNote
 
 void OscController::oscMessageReceived(const juce::OSCMessage& msg)
 {
-   string address = msg.getAddressPattern().toString().toStdString();
+   std::string address = msg.getAddressPattern().toString().toStdString();
 
    if (address == "/jockey/sync")
    {
-      string outputAddress = msg[0].getString().toStdString();
-      vector<string> tokens= ofSplitString(outputAddress, ":");
+      std::string outputAddress = msg[0].getString().toStdString();
+      std::vector<std::string> tokens= ofSplitString(outputAddress, ":");
       if (tokens.size() == 2)
       {
          mOutAddress = tokens[0];
@@ -176,7 +176,7 @@ void OscController::oscMessageReceived(const juce::OSCMessage& msg)
       mListener->OnMidiControl(control);
 }
 
-int OscController::FindControl(string address)
+int OscController::FindControl(std::string address)
 {
    for (int i = 0; i < mOscMap.size(); ++i)
    {
@@ -187,7 +187,7 @@ int OscController::FindControl(string address)
    return -1;
 }
 
-int OscController::AddControl(string address, bool isFloat)
+int OscController::AddControl(std::string address, bool isFloat)
 {
    int existing = FindControl(address);
    if (existing != -1)

--- a/Source/OscController.h
+++ b/Source/OscController.h
@@ -36,7 +36,7 @@
 struct OscMap
 {
    int mControl;
-   string mAddress;
+   std::string mAddress;
    bool mIsFloat;
    float mFloatValue;
    int mIntValue;
@@ -48,18 +48,18 @@ class OscController : public INonstandardController,
                       private juce::OSCReceiver::Listener<juce::OSCReceiver::MessageLoopCallback>
 {
 public:
-   OscController(MidiDeviceListener* listener, string outAddress, int outPort, int inPort);
+   OscController(MidiDeviceListener* listener, std::string outAddress, int outPort, int inPort);
    ~OscController();
    
    void Connect();
    void oscMessageReceived(const juce::OSCMessage& msg) override;
    void SendValue(int page, int control, float value, bool forceNoteOn = false, int channel = -1) override;
-   int AddControl(string address, bool isFloat);
+   int AddControl(std::string address, bool isFloat);
    
    bool IsInputConnected() override { return mConnected; }
    bool Reconnect() override { Connect(); return mConnected; }
    bool SetInPort(int port);
-   string GetControlTooltip(MidiMessageType type, int control) override;
+   std::string GetControlTooltip(MidiMessageType type, int control) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
@@ -67,17 +67,17 @@ public:
 private:
    MidiDeviceListener* mListener;
 
-   int FindControl(string address);
+   int FindControl(std::string address);
    void ConnectOutput();
    
-   string mOutAddress;
+   std::string mOutAddress;
    int mOutPort;
    int mInPort;
    juce::OSCSender mOscOut;
    bool mConnected;
    bool mOutputConnected;
    
-   vector<OscMap> mOscMap;
+   std::vector<OscMap> mOscMap;
 };
 
 #endif /* defined(__Bespoke__OscController__) */

--- a/Source/OutputChannel.h
+++ b/Source/OutputChannel.h
@@ -39,7 +39,7 @@ public:
    virtual ~OutputChannel();
    static IDrawableModule* Create() { return new OutputChannel(); }
    
-   string GetTitleLabel() override { return "output"; }
+   std::string GetTitleLabel() override { return "output"; }
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/PSMoveController.h
+++ b/Source/PSMoveController.h
@@ -44,7 +44,7 @@ public:
    ~PSMoveController();
    static IDrawableModule* Create() { return new PSMoveController(); }
    
-   string GetTitleLabel() override { return "ps move"; }
+   std::string GetTitleLabel() override { return "ps move"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Panner.h
+++ b/Source/Panner.h
@@ -43,7 +43,7 @@ public:
    virtual ~Panner();
    static IDrawableModule* Create() { return new Panner(); }
    
-   string GetTitleLabel() override { return "panner"; }
+   std::string GetTitleLabel() override { return "panner"; }
    void CreateUIControls() override;
    
    void SetPan(float pan) { mPan = pan; }

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -447,7 +447,7 @@ bool PatchCableSource::MouseMoved(float x, float y)
 
 void PatchCableSource::MouseReleased()
 {
-   vector<PatchCable*> cables = mPatchCables;   //copy, since list might get modified here
+   std::vector<PatchCable*> cables = mPatchCables;   //copy, since list might get modified here
    FindValidTargets();
    for (auto cable : cables)
       cable->MouseReleased();
@@ -567,7 +567,7 @@ bool PatchCableSource::IsValidTarget(IClickable* target) const
 void PatchCableSource::FindValidTargets()
 {
    mValidTargets.clear();
-   vector<IDrawableModule*> allModules;
+   std::vector<IDrawableModule*> allModules;
    TheSynth->GetAllModules(allModules);
    for (auto module : allModules)
    {
@@ -673,7 +673,7 @@ void PatchCableSource::SaveState(FileStreamOut& out)
    
    for (int i=0; i<mPatchCables.size(); ++i)
    {
-      string path = "";
+      std::string path = "";
       IClickable* target = mPatchCables[i]->GetTarget();
       if (target)
          path = target->Path();
@@ -691,7 +691,7 @@ void PatchCableSource::LoadState(FileStreamIn& in)
    
    for (int i=0; i<mPatchCables.size(); ++i)
    {
-      string path;
+      std::string path;
       in >> path;
       IClickable* target = TheSynth->FindModule(path, false);
       if (target == nullptr)

--- a/Source/PatchCableSource.h
+++ b/Source/PatchCableSource.h
@@ -87,7 +87,7 @@ public:
    PatchCableSource(IDrawableModule* owner, ConnectionType type);
    virtual ~PatchCableSource();
    PatchCable* AddPatchCable(IClickable* target);
-   const vector<PatchCable*>& GetPatchCables() const { return mPatchCables; }
+   const std::vector<PatchCable*>& GetPatchCables() const { return mPatchCables; }
    void Clear();
    void FindValidTargets();
    bool IsValidTarget(IClickable* target) const;
@@ -102,8 +102,8 @@ public:
    void RemovePatchCable(PatchCable* cable);
    void ClearPatchCables();
    void SetPatchCableTarget(PatchCable* cable, IClickable* target, bool fromUserClick);
-   const vector<INoteReceiver*>& GetNoteReceivers() const { return mNoteReceivers; }
-   const vector<IPulseReceiver*>& GetPulseReceivers() const { return mPulseReceivers; }
+   const std::vector<INoteReceiver*>& GetNoteReceivers() const { return mNoteReceivers; }
+   const std::vector<IPulseReceiver*>& GetPulseReceivers() const { return mPulseReceivers; }
    IAudioReceiver* GetAudioReceiver() const { return mAudioReceiver; }
    IClickable* GetTarget() const;
    void SetTarget(IClickable* target);
@@ -114,7 +114,7 @@ public:
    ofColor GetColor() const { return mColor; }
    void SetEnabled(bool enabled) { mEnabled = enabled; }
    bool Enabled() const;
-   void AddTypeFilter(string type) { mTypeFilter.push_back(type); }
+   void AddTypeFilter(std::string type) { mTypeFilter.push_back(type); }
    void ClearTypeFilter() { mTypeFilter.clear(); }
    void SetManualSide(Side side) { mManualSide = side; }
    void SetClickable(bool clickable) { mClickable = clickable; }
@@ -149,7 +149,7 @@ private:
    bool InAddCableMode() const;
    int GetHoverIndex(float x, float y) const;
    
-   vector<PatchCable*> mPatchCables;
+   std::vector<PatchCable*> mPatchCables;
    int mHoverIndex; //-1 = not hovered
    ConnectionType mType;
    bool mAllowMultipleTargets;
@@ -168,12 +168,12 @@ private:
    bool mHasOverrideCableDir;
    ofVec2f mOverrideCableDir;
    
-   vector<INoteReceiver*> mNoteReceivers;
-   vector<IPulseReceiver*> mPulseReceivers;
+   std::vector<INoteReceiver*> mNoteReceivers;
+   std::vector<IPulseReceiver*> mPulseReceivers;
    IAudioReceiver* mAudioReceiver;
    
-   vector<string> mTypeFilter;
-   vector<IClickable*> mValidTargets;
+   std::vector<std::string> mTypeFilter;
+   std::vector<IClickable*> mValidTargets;
    
    NoteHistory mNoteHistory;
    double mLastOnEventTime;

--- a/Source/PerformanceTimer.cpp
+++ b/Source/PerformanceTimer.cpp
@@ -26,7 +26,7 @@
 #include "PerformanceTimer.h"
 #include "SynthGlobals.h"
 
-TimerInstance::TimerInstance(string name, PerformanceTimer& manager)
+TimerInstance::TimerInstance(std::string name, PerformanceTimer& manager)
 : mName(name)
 , mManager(manager)
 {
@@ -38,7 +38,7 @@ TimerInstance::~TimerInstance()
    mManager.RecordCost(mName, ofGetSystemTimeNanos() - mTimerStart);
 }
 
-void PerformanceTimer::RecordCost(string name, long cost)
+void PerformanceTimer::RecordCost(std::string name, long cost)
 {
    mCostTable.push_back(PerformanceTimer::Cost(name,cost));
 }

--- a/Source/PerformanceTimer.h
+++ b/Source/PerformanceTimer.h
@@ -33,30 +33,30 @@ class PerformanceTimer;
 class TimerInstance
 {
 public:
-   TimerInstance(string name, PerformanceTimer& manager);
+   TimerInstance(std::string name, PerformanceTimer& manager);
    ~TimerInstance();
 private:
    long mTimerStart;
-   string mName;
+   std::string mName;
    PerformanceTimer& mManager;
 };
 
 class PerformanceTimer
 {
 public:
-   void RecordCost(string name, long cost);
+   void RecordCost(std::string name, long cost);
    void PrintCosts();
 private:
    struct Cost
    {
-      Cost(string name, long cost) : mName(name), mCost(cost) {}
-      string mName;
+      Cost(std::string name, long cost) : mName(name), mCost(cost) {}
+      std::string mName;
       long mCost;
    };
    
    static bool SortCosts(const PerformanceTimer::Cost& a, const PerformanceTimer::Cost& b);
    
-   vector<Cost> mCostTable;
+   std::vector<Cost> mCostTable;
 };
 
 #endif /* defined(__Bespoke__PerformanceTimer__) */

--- a/Source/PitchBender.h
+++ b/Source/PitchBender.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchBender();
    static IDrawableModule* Create() { return new PitchBender(); }
    
-   string GetTitleLabel() override { return "pitchbend"; }
+   std::string GetTitleLabel() override { return "pitchbend"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchChorus.h
+++ b/Source/PitchChorus.h
@@ -41,7 +41,7 @@ public:
    virtual ~PitchChorus();
    static IDrawableModule* Create() { return new PitchChorus(); }
    
-   string GetTitleLabel() override { return "pitchchorus"; }
+   std::string GetTitleLabel() override { return "pitchchorus"; }
    void CreateUIControls() override;
    
    //IAudioProcessor

--- a/Source/PitchDive.h
+++ b/Source/PitchDive.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchDive();
    static IDrawableModule* Create() { return new PitchDive(); }
    
-   string GetTitleLabel() override { return "pitchdive"; }
+   std::string GetTitleLabel() override { return "pitchdive"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/PitchPanner.h
+++ b/Source/PitchPanner.h
@@ -39,7 +39,7 @@ public:
    PitchPanner();
    static IDrawableModule* Create() { return new PitchPanner(); }
    
-   string GetTitleLabel() override { return "pitch panner"; }
+   std::string GetTitleLabel() override { return "pitch panner"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchRemap.h
+++ b/Source/PitchRemap.h
@@ -38,7 +38,7 @@ public:
    PitchRemap();
    static IDrawableModule* Create() { return new PitchRemap(); }
    
-   string GetTitleLabel() override { return "pitch remap"; }
+   std::string GetTitleLabel() override { return "pitch remap"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchSetter.h
+++ b/Source/PitchSetter.h
@@ -38,7 +38,7 @@ public:
    PitchSetter();
    static IDrawableModule* Create() { return new PitchSetter(); }
    
-   string GetTitleLabel() override { return "pitch"; }
+   std::string GetTitleLabel() override { return "pitch"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchShiftEffect.h
+++ b/Source/PitchShiftEffect.h
@@ -40,14 +40,14 @@ public:
    
    static IAudioEffect* Create() { return new PitchShiftEffect(); }
    
-   string GetTitleLabel() override { return "pitchshift"; }
+   std::string GetTitleLabel() override { return "pitchshift"; }
    void CreateUIControls() override;
    
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "pitchshift"; }
+   std::string GetType() override { return "pitchshift"; }
    
    void IntSliderUpdated(IntSlider* slider, int oldVal) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;

--- a/Source/PitchToCV.cpp
+++ b/Source/PitchToCV.cpp
@@ -86,7 +86,7 @@ void PitchToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/PitchToCV.h
+++ b/Source/PitchToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchToCV();
    static IDrawableModule* Create() { return new PitchToCV(); }
    
-   string GetTitleLabel() override { return "pitch to cv"; }
+   std::string GetTitleLabel() override { return "pitch to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchToSpeed.cpp
+++ b/Source/PitchToSpeed.cpp
@@ -86,7 +86,7 @@ void PitchToSpeed::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/PitchToSpeed.h
+++ b/Source/PitchToSpeed.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchToSpeed();
    static IDrawableModule* Create() { return new PitchToSpeed(); }
    
-   string GetTitleLabel() override { return "pitch to speed"; }
+   std::string GetTitleLabel() override { return "pitch to speed"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -47,7 +47,7 @@ public:
    ~PlaySequencer();
    static IDrawableModule* Create() { return new PlaySequencer(); }
 
-   string GetTitleLabel() override { return "play sequencer"; }
+   std::string GetTitleLabel() override { return "play sequencer"; }
    void CreateUIControls() override;
 
    void Init() override;

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -67,7 +67,7 @@ public:
    ~Polyrhythms();
    static IDrawableModule* Create() { return new Polyrhythms(); }
    
-   string GetTitleLabel() override { return "polyrhythms"; }
+   std::string GetTitleLabel() override { return "polyrhythms"; }
    void CreateUIControls() override;
    void Init() override;
    bool IsResizable() const override { return true; }

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -57,7 +57,7 @@ void Prefab::CreateUIControls()
    AddPatchCableSource(mRemoveModuleCable);
 }
 
-string Prefab::GetTitleLabel()
+std::string Prefab::GetTitleLabel()
 {
    if (mPrefabName != "")
       return "prefab: "+mPrefabName;
@@ -209,7 +209,7 @@ void Prefab::ButtonClicked(ClickButton* button)
       FileChooser chooser("Save prefab as...", File(ofToDataPath("prefabs/prefab.pfb")), "*.pfb", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
       if (chooser.browseForFileToSave(true))
       {
-         string savePath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();
+         std::string savePath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();
          SavePrefab(savePath);
       }
    }
@@ -219,7 +219,7 @@ void Prefab::ButtonClicked(ClickButton* button)
       FileChooser chooser("Load prefab...", File(ofToDataPath("prefabs")), "*.pfb", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
       if (chooser.browseForFileToOpen())
       {
-         string loadPath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();
+         std::string loadPath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();
          LoadPrefab(ofToDataPath(loadPath));
       }
    }
@@ -233,15 +233,15 @@ void Prefab::ButtonClicked(ClickButton* button)
    }
 }
 
-void Prefab::SavePrefab(string savePath)
+void Prefab::SavePrefab(std::string savePath)
 {
    ofxJSONElement root;
    
    root["modules"] = mModuleContainer.WriteModules();
    
-   stringstream ss(root.getRawString(true));
-   string line;
-   string lines;
+   std::stringstream ss(root.getRawString(true));
+   std::string line;
+   std::string lines;
    while (getline(ss,line,'\n'))
    {
       const char* pos = strstr(line.c_str(), " : \"$");
@@ -263,7 +263,7 @@ void Prefab::SavePrefab(string savePath)
    mModuleContainer.SaveState(out);
 }
 
-void Prefab::LoadPrefab(string loadPath)
+void Prefab::LoadPrefab(std::string loadPath)
 {
    sLoadingPrefab = true;
 
@@ -276,7 +276,7 @@ void Prefab::LoadPrefab(string loadPath)
 
    assert(in.OpenedOk());
    
-   string jsonString;
+   std::string jsonString;
    in >> jsonString;
    ofxJSONElement root;
    bool loaded = root.parse(jsonString);
@@ -297,9 +297,9 @@ void Prefab::LoadPrefab(string loadPath)
    sLoadingPrefab = false;
 }
 
-void Prefab::UpdatePrefabName(string path)
+void Prefab::UpdatePrefabName(std::string path)
 {
-   vector<string> tokens = ofSplitString(path, GetPathSeparator());
+   std::vector<std::string> tokens = ofSplitString(path, GetPathSeparator());
    mPrefabName = tokens[tokens.size() - 1];
    ofStringReplace(mPrefabName, ".pfb", "");
 }

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -41,7 +41,7 @@ public:
    ~Prefab();
    static IDrawableModule* Create() { return new Prefab(); }
    
-   string GetTitleLabel() override;
+   std::string GetTitleLabel() override;
    void CreateUIControls() override;
    
    ModuleContainer* GetContainer() override { return &mModuleContainer; }
@@ -60,7 +60,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
    
-   void LoadPrefab(string loadPath);
+   void LoadPrefab(std::string loadPath);
 
    static bool sSavingPrefab;
    static bool sLoadingPrefab;
@@ -77,15 +77,15 @@ private:
    bool CanAddDropModules();
    bool IsMouseHovered();
    
-   void SavePrefab(string savePath);
-   void UpdatePrefabName(string path);
+   void SavePrefab(std::string savePath);
+   void UpdatePrefabName(std::string path);
    
    PatchCableSource* mRemoveModuleCable;
    ClickButton* mSaveButton;
    ClickButton* mLoadButton;
    ClickButton* mDisbandButton;
    ModuleContainer mModuleContainer;
-   string mPrefabName;
+   std::string mPrefabName;
 };
 
 

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -29,7 +29,7 @@
 #include "ofxJSONElement.h"
 #include "PatchCableSource.h"
 
-vector<IUIControl*> Presets::sPresetHighlightControls;
+std::vector<IUIControl*> Presets::sPresetHighlightControls;
 
 Presets::Presets()
 : mGrid(nullptr)
@@ -260,7 +260,7 @@ void Presets::Store(int idx)
    }
    for (int i=0; i<mPresetModules.size(); ++i)
    {
-      vector<IUIControl*> controls = mPresetModules[i]->GetUIControls();
+      std::vector<IUIControl*> controls = mPresetModules[i]->GetUIControls();
       for (int j=0; j<controls.size(); ++j)
       {
          coll.mPresets.push_back(Preset(controls[j]));
@@ -312,7 +312,7 @@ void Presets::Load()
    mPresetCollection.clear();
    mPresetCollection.resize(maxGridSide * maxGridSide);
    
-   string presetsFile = mModuleSaveData.GetString("presetsfile");
+   std::string presetsFile = mModuleSaveData.GetString("presetsfile");
    if (!presetsFile.empty())
    {
       ofxJSONElement root;
@@ -472,7 +472,7 @@ void Presets::LoadState(FileStreamIn& in)
    
    UpdateGridValues();
    
-   string path;
+   std::string path;
    int size;
    in >> size;
    for (int i=0; i<size; ++i)
@@ -498,9 +498,9 @@ void Presets::LoadState(FileStreamIn& in)
    }
 }
 
-vector<IUIControl*> Presets::ControlsToNotSetDuringLoadState() const
+std::vector<IUIControl*> Presets::ControlsToNotSetDuringLoadState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mCurrentPresetSelector);
    return ignore;
 }

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -44,7 +44,7 @@ public:
    virtual ~Presets();
    static IDrawableModule* Create() { return new Presets(); }
    
-   string GetTitleLabel() override { return "presets"; }
+   std::string GetTitleLabel() override { return "presets"; }
    void CreateUIControls() override;
    
    //IDrawableModule
@@ -65,9 +65,9 @@ public:
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
-   vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
+   std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
    
-   static vector<IUIControl*> sPresetHighlightControls;
+   static std::vector<IUIControl*> sPresetHighlightControls;
    
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
@@ -90,9 +90,9 @@ private:
    struct Preset
    {
       Preset() {}
-      Preset(string path, float val) : mControlPath(path), mValue(val), mHasLFO(false) {}
+      Preset(std::string path, float val) : mControlPath(path), mValue(val), mHasLFO(false) {}
       Preset(IUIControl* control);
-      string mControlPath;
+      std::string mControlPath;
       float mValue;
       bool mHasLFO;
       LFOSettings mLFOSettings;
@@ -101,7 +101,7 @@ private:
    struct PresetCollection
    {
       std::vector<Preset> mPresets;
-      string mDescription;
+      std::string mDescription;
    };
    
    struct ControlRamp
@@ -114,13 +114,13 @@ private:
    std::vector<PresetCollection> mPresetCollection;
    ClickButton* mSaveButton;
    int mDrawSetPresetsCountdown;
-   vector<IDrawableModule*> mPresetModules;
-   vector<IUIControl*> mPresetControls;
+   std::vector<IDrawableModule*> mPresetModules;
+   std::vector<IUIControl*> mPresetControls;
    bool mBlending;
    float mBlendTime;
    FloatSlider* mBlendTimeSlider;
    float mBlendProgress;
-   vector<ControlRamp> mBlendRamps;
+   std::vector<ControlRamp> mBlendRamps;
    ofMutex mRampMutex;
    int mCurrentPreset;
    DropdownList* mCurrentPresetSelector;

--- a/Source/Pressure.h
+++ b/Source/Pressure.h
@@ -40,7 +40,7 @@ public:
    virtual ~Pressure();
    static IDrawableModule* Create() { return new Pressure(); }
    
-   string GetTitleLabel() override { return "pressure"; }
+   std::string GetTitleLabel() override { return "pressure"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PressureToCV.cpp
+++ b/Source/PressureToCV.cpp
@@ -84,7 +84,7 @@ void PressureToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/PressureToCV.h
+++ b/Source/PressureToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~PressureToCV();
    static IDrawableModule* Create() { return new PressureToCV(); }
    
-   string GetTitleLabel() override { return "pressure to cv"; }
+   std::string GetTitleLabel() override { return "pressure to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PressureToModwheel.h
+++ b/Source/PressureToModwheel.h
@@ -37,7 +37,7 @@ public:
    virtual ~PressureToModwheel();
    static IDrawableModule* Create() { return new PressureToModwheel(); }
    
-   string GetTitleLabel() override { return "pressure to modwheel"; }
+   std::string GetTitleLabel() override { return "pressure to modwheel"; }
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //INoteReceiver

--- a/Source/PressureToVibrato.h
+++ b/Source/PressureToVibrato.h
@@ -40,7 +40,7 @@ public:
    virtual ~PressureToVibrato();
    static IDrawableModule* Create() { return new PressureToVibrato(); }
    
-   string GetTitleLabel() override { return "pressure to vibrato"; }
+   std::string GetTitleLabel() override { return "pressure to vibrato"; }
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/PreviousNote.h
+++ b/Source/PreviousNote.h
@@ -35,7 +35,7 @@ public:
    PreviousNote();
    static IDrawableModule* Create() { return new PreviousNote(); }
    
-   string GetTitleLabel() override { return "previous note"; }
+   std::string GetTitleLabel() override { return "previous note"; }
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/Producer.cpp
+++ b/Source/Producer.cpp
@@ -159,7 +159,7 @@ void Producer::Process(double time)
    GetVizBuffer()->WriteChunk(out,bufferSize, 0);
 }
 
-void Producer::FilesDropped(vector<string> files, int x, int y)
+void Producer::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mSample->Reset();
    

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -50,7 +50,7 @@ public:
    ~Producer();
    static IDrawableModule* Create() { return new Producer(); }
    
-   string GetTitleLabel() override { return "producer"; }
+   std::string GetTitleLabel() override { return "producer"; }
    void CreateUIControls() override;
    
    //INoteReceiver
@@ -62,7 +62,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    
    
    void CheckboxUpdated(Checkbox* checkbox) override;
@@ -127,7 +127,7 @@ private:
    ClickButton* mDoubleLengthButton;
    ClickButton* mHalveLengthButton;
    BiquadFilterEffect mBiquad[PRODUCER_NUM_BIQUADS];
-   list<int> mSkipMeasures;
+   std::list<int> mSkipMeasures;
    ClickButton* mRestartButton;
 };
 

--- a/Source/Profiler.cpp
+++ b/Source/Profiler.cpp
@@ -139,7 +139,7 @@ void Profiler::Draw()
       long maxCost = cost.MaxCost();
       
       ofSetColor(255,255,255);
-      gFont.DrawString(string(sCosts[i].mName)+": "+ofToString(maxCost/1000), 15, 0, 0);
+      gFont.DrawString(std::string(sCosts[i].mName)+": "+ofToString(maxCost/1000), 15, 0, 0);
       
       if (maxCost > entireFrameUs)
          ofSetColor(255,0,0);

--- a/Source/Profiler.h
+++ b/Source/Profiler.h
@@ -53,7 +53,7 @@ private:
       void EndFrame();
       unsigned long long MaxCost() const;
       
-      string mName;
+      std::string mName;
       uint32_t mHash{0};
       unsigned long long mFrameCost{0};
       unsigned long long mHistory[PROFILER_HISTORY_LENGTH]{};

--- a/Source/PulseButton.h
+++ b/Source/PulseButton.h
@@ -38,7 +38,7 @@ public:
    virtual ~PulseButton();
    static IDrawableModule* Create() { return new PulseButton(); }
    
-   string GetTitleLabel() override { return "pulse button"; }
+   std::string GetTitleLabel() override { return "pulse button"; }
    void CreateUIControls() override;
 
    void ButtonClicked(ClickButton* button) override;

--- a/Source/PulseChance.h
+++ b/Source/PulseChance.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseChance();
    static IDrawableModule* Create() { return new PulseChance(); }
    
-   string GetTitleLabel() override { return "pulse chance"; }
+   std::string GetTitleLabel() override { return "pulse chance"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseDelayer.h
+++ b/Source/PulseDelayer.h
@@ -40,7 +40,7 @@ public:
    ~PulseDelayer();
    static IDrawableModule* Create() { return new PulseDelayer(); }
    
-   string GetTitleLabel() override { return "pulse delayer"; }
+   std::string GetTitleLabel() override { return "pulse delayer"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/PulseGate.h
+++ b/Source/PulseGate.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseGate();
    static IDrawableModule* Create() { return new PulseGate(); }
    
-   string GetTitleLabel() override { return "pulse gate"; }
+   std::string GetTitleLabel() override { return "pulse gate"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseHocket.h
+++ b/Source/PulseHocket.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseHocket();
    static IDrawableModule* Create() { return new PulseHocket(); }
    
-   string GetTitleLabel() override { return "pulse hocket"; }
+   std::string GetTitleLabel() override { return "pulse hocket"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -47,7 +47,7 @@ public:
    virtual ~PulseSequence();
    static IDrawableModule* Create() { return new PulseSequence(); }
    
-   string GetTitleLabel() override { return "pulse sequence"; }
+   std::string GetTitleLabel() override { return "pulse sequence"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -45,7 +45,7 @@ public:
    virtual ~PulseTrain();
    static IDrawableModule* Create() { return new PulseTrain(); }
    
-   string GetTitleLabel() override { return "pulse train"; }
+   std::string GetTitleLabel() override { return "pulse train"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -45,7 +45,7 @@ public:
    virtual ~Pulser();
    static IDrawableModule* Create() { return new Pulser(); }
    
-   string GetTitleLabel() override { return "pulser"; }
+   std::string GetTitleLabel() override { return "pulser"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -41,14 +41,14 @@ public:
    
    static IAudioEffect* Create() { return new Pumper(); }
    
-   string GetTitleLabel() override { return "pumper"; }
+   std::string GetTitleLabel() override { return "pumper"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "pumper"; }
+   std::string GetType() override { return "pumper"; }
 
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void CheckboxUpdated(Checkbox* checkbox) override {}

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -287,7 +287,7 @@ NBase::Result Push2Control::Initialize()
    mFontHandle = nvgCreateFont(sVG, ofToResourcePath("frabk.ttf").c_str(), ofToResourcePath("frabk.ttf").c_str());
    mFontHandleBold = nvgCreateFont(sVG, ofToResourcePath("frabk_m.ttf").c_str(), ofToResourcePath("frabk_m.ttf").c_str());
    
-   const std::vector<string>& devices = mDevice.GetPortList(false);
+   const std::vector<std::string>& devices = mDevice.GetPortList(false);
    for (int i=0; i<devices.size(); ++i)
    {
 #if JUCE_WINDOWS
@@ -329,7 +329,7 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
    nvgTextLetterSpacing(vg, sSpacing);
    
    mModules.clear();
-   vector<IDrawableModule*> modules;
+   std::vector<IDrawableModule*> modules;
    TheSynth->GetAllModules(modules);
    for (int i=0; i<modules.size(); ++i)
    {
@@ -348,11 +348,11 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
       DrawLowerModuleSelector();
       DrawDisplayModuleControls();
 
-      string stateInfo = "";
+      std::string stateInfo = "";
       if (mAllowRepatch && mHeldModule == nullptr)
          stateInfo = "repatch mode: hold a source module and tap the destination module";
       else if (mAllowRepatch && mHeldModule != nullptr)
-         stateInfo = "repatch mode: now tap destination for " + string(mHeldModule->Name());
+         stateInfo = "repatch mode: now tap destination for " + std::string(mHeldModule->Name());
       else if (mNewButtonHeld)
          stateInfo = "tap control to add favorite...";
       else if (mDeleteButtonHeld)
@@ -383,8 +383,8 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
       if (mSelectedGridSpawnListIndex == -1)
       {
          ofSetColor(255, 255, 255);
-         string text = "choose a module, then tap a grid square";
-         string moduleTypeToSpawn = GetModuleTypeToSpawn();
+         std::string text = "choose a module, then tap a grid square";
+         std::string moduleTypeToSpawn = GetModuleTypeToSpawn();
          if (moduleTypeToSpawn != "")
          {
             ofSetColor(IDrawableModule::GetColor(TheSynth->GetModuleFactory()->GetModuleType(moduleTypeToSpawn)));
@@ -755,7 +755,7 @@ ModuleType Push2Control::GetModuleTypeForSpawnList(IUIControl* control)
    return moduleType;
 }
 
-void Push2Control::DrawControls(vector<IUIControl*> controls, bool sliders, float yPos)
+void Push2Control::DrawControls(std::vector<IUIControl*> controls, bool sliders, float yPos)
 {
    for (int i=(int)controls.size()-1; i >= 0; --i)
    {
@@ -850,7 +850,7 @@ void Push2Control::Poll()
 
    if (mDisplayModule != nullptr && mDisplayModule->HasPush2OverrideControls())
    {
-      vector<IUIControl*> desiredControls;
+      std::vector<IUIControl*> desiredControls;
       mDisplayModule->GetPush2OverrideControls(desiredControls);
       bool changed = false;
       if (desiredControls.size() != mDisplayedControls.size())
@@ -874,7 +874,7 @@ void Push2Control::Poll()
    }
 }
 
-string Push2Control::GetModuleTypeToSpawn()
+std::string Push2Control::GetModuleTypeToSpawn()
 {
    for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
    {
@@ -909,7 +909,7 @@ void Push2Control::UpdateControlList()
 {
    mSliderControls.clear();
    mButtonControls.clear();
-   vector<IUIControl*> controls;
+   std::vector<IUIControl*> controls;
    if (mScreenDisplayMode == ScreenDisplayMode::kAddModule)
    {
       controls = mSpawnModuleControls;
@@ -1369,9 +1369,9 @@ bool Push2Control::IsIgnorableModule(IDrawableModule* module)
    return module == TheTitleBar || module == TheSaveDataPanel || module == TheQuickSpawnMenu || module == TheSynth->GetUserPrefsEditor();
 }
 
-vector<IDrawableModule*> Push2Control::SortModules(vector<IDrawableModule*> modules)
+std::vector<IDrawableModule*> Push2Control::SortModules(std::vector<IDrawableModule*> modules)
 {
-   vector<IDrawableModule*> output;
+   std::vector<IDrawableModule*> output;
     
    for (int i=0; i<modules.size(); ++i)
       AddModuleChain(modules[i], modules, output, 0);
@@ -1379,7 +1379,7 @@ vector<IDrawableModule*> Push2Control::SortModules(vector<IDrawableModule*> modu
    return output;
 }
 
-void Push2Control::AddModuleChain(IDrawableModule* module, vector<IDrawableModule*>& modules, vector<IDrawableModule*>& output, int depth)
+void Push2Control::AddModuleChain(IDrawableModule* module, std::vector<IDrawableModule*>& modules, std::vector<IDrawableModule*>& output, int depth)
 {
    if (depth > 100)  //avoid infinite recursion if there's a patching loop
       return;

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -46,7 +46,7 @@ public:
    virtual ~Push2Control();
    static IDrawableModule* Create() { return new Push2Control(); }
    
-   string GetTitleLabel() override { return "push 2 control"; }
+   std::string GetTitleLabel() override { return "push 2 control"; }
    void CreateUIControls() override;
    void Poll() override;
    
@@ -85,7 +85,7 @@ private:
    void DrawDisplayModuleControls();
    void DrawLowerModuleSelector();
    void SetDisplayModule(IDrawableModule* module, bool addToHistory);
-   void DrawControls(vector<IUIControl*> controls, bool sliders, float yPos);
+   void DrawControls(std::vector<IUIControl*> controls, bool sliders, float yPos);
    void UpdateControlList();
    void AddFavoriteControl(IUIControl* control);
    void RemoveFavoriteControl(IUIControl* control);
@@ -94,10 +94,10 @@ private:
    int GetPadColorForType(ModuleType type);
    bool GetGridIndex(int gridX, int gridY, int& gridIndex) { gridIndex = gridX + gridY * 8; return gridX >= 0 && gridX < 8 && gridY >= 0 && gridY < 8; }
    bool IsIgnorableModule(IDrawableModule* module);
-   vector<IDrawableModule*> SortModules(vector<IDrawableModule*> modules);
-   void AddModuleChain(IDrawableModule* module, vector<IDrawableModule*>& modules, vector<IDrawableModule*>& output, int depth);
+   std::vector<IDrawableModule*> SortModules(std::vector<IDrawableModule*> modules);
+   void AddModuleChain(IDrawableModule* module, std::vector<IDrawableModule*>& modules, std::vector<IDrawableModule*>& output, int depth);
    void DrawDisplayModuleRect(ofRectangle rect);
-   string GetModuleTypeToSpawn();
+   std::string GetModuleTypeToSpawn();
    ModuleType GetModuleTypeForSpawnList(IUIControl* control);
    ofColor GetSpawnGridColor(int index, ModuleType moduleType) const;
    int GetSpawnGridPadColor(int index, ModuleType moduleType) const;
@@ -118,20 +118,20 @@ private:
    float mHeight;
    
    IDrawableModule* mDisplayModule;
-   vector<IUIControl*> mSliderControls;
-   vector<IUIControl*> mButtonControls;
-   vector<IUIControl*> mDisplayedControls;
+   std::vector<IUIControl*> mSliderControls;
+   std::vector<IUIControl*> mButtonControls;
+   std::vector<IUIControl*> mDisplayedControls;
    int mModuleColumnOffset;
    float mModuleColumnOffsetSmoothed;
    
-   vector<IDrawableModule*> mModules;
+   std::vector<IDrawableModule*> mModules;
    float mModuleListOffset;
    float mModuleListOffsetSmoothed;
    IDrawableModule* mModuleGrid[8*8];
    ofRectangle mModuleGridRect;
    
-   vector<IUIControl*> mFavoriteControls;
-   vector<IUIControl*> mSpawnModuleControls;
+   std::vector<IUIControl*> mFavoriteControls;
+   std::vector<IUIControl*> mSpawnModuleControls;
    bool mNewButtonHeld;
    bool mDeleteButtonHeld;
    bool mModulationButtonHeld;
@@ -139,9 +139,9 @@ private:
    std::array<bool,128> mNoteHeldState;
    IDrawableModule* mHeldModule;
    bool mAllowRepatch;
-   vector<IDrawableModule*> mModuleHistory;
+   std::vector<IDrawableModule*> mModuleHistory;
    int mModuleHistoryPosition;
-   vector<IDrawableModule*> mBookmarkSlots;
+   std::vector<IDrawableModule*> mBookmarkSlots;
    bool mInMidiControllerBindMode;
    
    enum class ScreenDisplayMode

--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -142,7 +142,7 @@ void QuickSpawnMenu::OnClicked(int x, int y, bool right)
    if (right)
       return;
    
-   string moduleTypeName = GetModuleTypeNameAt(x, y);
+   std::string moduleTypeName = GetModuleTypeNameAt(x, y);
    if (moduleTypeName != "")
    {
       IDrawableModule* module = TheSynth->SpawnModuleOnTheFly(moduleTypeName, TheSynth->GetMouseX(GetOwningContainer()) + moduleGrabOffset.x, TheSynth->GetMouseY(GetOwningContainer()) + moduleGrabOffset.y);
@@ -152,12 +152,12 @@ void QuickSpawnMenu::OnClicked(int x, int y, bool right)
    SetShowing(false);
 }
 
-string QuickSpawnMenu::GetHoveredModuleTypeName()
+std::string QuickSpawnMenu::GetHoveredModuleTypeName()
 {
    return GetModuleTypeNameAt(mLastHoverX, mLastHoverY);
 }
 
-string QuickSpawnMenu::GetModuleTypeNameAt(int x, int y)
+std::string QuickSpawnMenu::GetModuleTypeNameAt(int x, int y)
 {
    int index = y / itemSpacing;
    if (index >= 0 && index < mElements.size())

--- a/Source/QuickSpawnMenu.h
+++ b/Source/QuickSpawnMenu.h
@@ -39,9 +39,9 @@ public:
    void DrawModule() override;
    void SetDimensions(int w, int h) { mWidth = w; mHeight = h; }
    bool HasTitleBar() const override { return false; }
-   string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() override { return ""; }
    bool IsSaveable() override { return false; }
-   string GetHoveredModuleTypeName();
+   std::string GetHoveredModuleTypeName();
    
    void KeyPressed(int key, bool isRepeat) override;
    void KeyReleased(int key) override;
@@ -50,13 +50,13 @@ public:
    bool IsSingleton() const override { return true; }
    
 private:
-   string GetModuleTypeNameAt(int x, int y);
+   std::string GetModuleTypeNameAt(int x, int y);
    void OnClicked(int x, int y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void GetDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    float mWidth;
    float mHeight;
-   std::vector<string> mElements;
+   std::vector<std::string> mElements;
    char mCurrentMenuChar;
    int mLastHoverX;
    int mLastHoverY;

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -311,7 +311,7 @@ float RadioButton::GetMidiValue() const
    return mSliderVal;
 }
 
-string RadioButton::GetDisplayValue(float val) const
+std::string RadioButton::GetDisplayValue(float val) const
 {
    if (mMultiSelect)
       return "multiselect";

--- a/Source/RadioButton.h
+++ b/Source/RadioButton.h
@@ -30,7 +30,7 @@
 
 struct RadioButtonElement
 {
-   string mLabel;
+   std::string mLabel;
    int mValue;
 };
 
@@ -75,7 +75,7 @@ public:
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    bool IsBitmask() override { return mMultiSelect; }
    bool InvertScrollDirection() override { return mDirection == kRadioVertical; }
    void Increment(float amount) override;
@@ -100,7 +100,7 @@ private:
    int mWidth;
    int mHeight;
    float mElementWidth;
-   vector<RadioButtonElement> mElements;
+   std::vector<RadioButtonElement> mElements;
    int* mVar;
    IRadioButtonListener* mOwner;
    bool mMultiSelect; //makes this... not a radio button. mVar becomes a bitmask

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -204,7 +204,7 @@ void RadioSequencer::SetNumSteps(int numSteps, bool stretch)
    assert(oldNumSteps != 0);
    if (stretch)   //updated interval, stretch old pattern out to make identical pattern at higher res
    {              // abcd becomes aabbccdd
-      vector<float> pattern;
+      std::vector<float> pattern;
       pattern.resize(oldNumSteps);
       for (int i=0; i<oldNumSteps; ++i)
          pattern[i] = mGrid->GetVal(i,0);
@@ -342,7 +342,7 @@ void RadioSequencer::SaveState(FileStreamOut& out)
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
    {
-      string path = "";
+      std::string path = "";
       if (cable->GetTarget())
          path = cable->GetTarget()->Path();
       out << path;
@@ -364,7 +364,7 @@ void RadioSequencer::LoadState(FileStreamIn& in)
    mControlCables.resize(size);
    for (auto cable : mControlCables)
    {
-      string path;
+      std::string path;
       in >> path;
       cable->SetTarget(TheSynth->FindUIControl(path));
    }

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -45,7 +45,7 @@ public:
    ~RadioSequencer();
    static IDrawableModule* Create() { return new RadioSequencer(); }
    
-   string GetTitleLabel() override { return "radio sequencer"; }
+   std::string GetTitleLabel() override { return "radio sequencer"; }
    void CreateUIControls() override;
    
    //IGridListener
@@ -97,7 +97,7 @@ private:
    DropdownList* mIntervalSelector;
    int mLength;
    DropdownList* mLengthSelector;
-   vector<PatchCableSource*> mControlCables;
+   std::vector<PatchCableSource*> mControlCables;
    GridControlTarget* mGridControlTarget;
 
    TransportListenerInfo* mTransportListenerInfo;

--- a/Source/Ramper.cpp
+++ b/Source/Ramper.cpp
@@ -186,7 +186,7 @@ void Ramper::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void Ramper::SetUpFromSaveData()
 {
-   string controlPath = mModuleSaveData.GetString("uicontrol");
+   std::string controlPath = mModuleSaveData.GetString("uicontrol");
    if (!controlPath.empty())
    {
       mUIControl = TheSynth->FindUIControl(controlPath);

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -44,7 +44,7 @@ public:
    ~Ramper();
    static IDrawableModule* Create() { return new Ramper(); }
    
-   string GetTitleLabel() override { return "ramper"; }
+   std::string GetTitleLabel() override { return "ramper"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/RandomNoteGenerator.h
+++ b/Source/RandomNoteGenerator.h
@@ -40,7 +40,7 @@ public:
    ~RandomNoteGenerator();
    static IDrawableModule* Create() { return new RandomNoteGenerator(); }
    
-   string GetTitleLabel() override { return "random note"; }
+   std::string GetTitleLabel() override { return "random note"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -55,7 +55,7 @@ public:
    ~Razor();
    static IDrawableModule* Create() { return new Razor(); }
    
-   string GetTitleLabel() override { return "razor"; }
+   std::string GetTitleLabel() override { return "razor"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Rewriter.cpp
+++ b/Source/Rewriter.cpp
@@ -217,7 +217,7 @@ void Rewriter::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
 
-   string targetPath = "";
+   std::string targetPath = "";
    if (mConnectedLooper)
       targetPath = mConnectedLooper->Path();
 

--- a/Source/Rewriter.h
+++ b/Source/Rewriter.h
@@ -43,7 +43,7 @@ public:
    virtual ~Rewriter();
    static IDrawableModule* Create() { return new Rewriter(); }
    
-   string GetTitleLabel() override { return "looper rewriter"; }
+   std::string GetTitleLabel() override { return "looper rewriter"; }
    void CreateUIControls() override;
 
    void Go();

--- a/Source/RingModulator.h
+++ b/Source/RingModulator.h
@@ -43,7 +43,7 @@ public:
    virtual ~RingModulator();
    static IDrawableModule* Create() { return new RingModulator(); }
    
-   string GetTitleLabel() override { return "ring modulator"; }
+   std::string GetTitleLabel() override { return "ring modulator"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -56,7 +56,7 @@ bool Sample::Read(const char* path, bool mono, ReadType readType)
 {
    mReadPath = path;
    ofStringReplace(mReadPath, GetPathSeparator(), "/");
-   vector<string> tokens = ofSplitString(mReadPath, "/");
+   std::vector<std::string> tokens = ofSplitString(mReadPath, "/");
    mName = tokens[tokens.size()-1].c_str();
    
    juce::File file(ofToDataPath(mReadPath));
@@ -76,7 +76,7 @@ bool Sample::Read(const char* path, bool mono, ReadType readType)
       mOffset = mNumSamples;
       mSampleRateRatio = float(mReader->sampleRate) / gSampleRate;
       
-      mReadBuffer = make_unique<juce::AudioSampleBuffer>();
+      mReadBuffer = std::make_unique<juce::AudioSampleBuffer>();
       mReadBuffer->setSize(mReader->numChannels, mNumSamples);
       
       if (readType == ReadType::Sync)

--- a/Source/Sample.h
+++ b/Source/Sample.h
@@ -56,8 +56,8 @@ public:
    bool ConsumeData(double time, ChannelBuffer* out, int size, bool replace);
    void Play(double time, float rate, int offset, int stopPoint=-1);
    void SetRate(float rate) { mRate = rate; }
-   string Name() const { return mName; }
-   void SetName(string name) { mName = name; }
+   std::string Name() const { return mName; }
+   void SetName(std::string name) { mName = name; }
    int LengthInSamples() const { return mNumSamples; }
    int NumChannels() const { return mData.NumActiveChannels(); }
    ChannelBuffer* Data() { return &mData; }
@@ -70,7 +70,7 @@ public:
    void PadBack(int amount);
    void ClipTo(int start, int end);
    void ShiftWrap(int numSamples);
-   string GetReadPath() const { return mReadPath; }
+   std::string GetReadPath() const { return mReadPath; }
    static bool WriteDataToFile(const char* path, float** data, int numSamples, int channels = 1);
    static bool WriteDataToFile(const char* path, ChannelBuffer* data, int numSamples);
    bool IsPlaying() { return mOffset < mNumSamples; }
@@ -100,8 +100,8 @@ private:
    float mRate;
    float mSampleRateRatio;
    int mStopPoint;
-   string mName;
-   string mReadPath;
+   std::string mName;
+   std::string mReadPath;
    ofMutex mDataMutex;
    ofMutex mPlayMutex;
    bool mLooping;
@@ -109,7 +109,7 @@ private:
    float mVolume;
 
    juce::AudioFormatReader* mReader;
-   unique_ptr<juce::AudioSampleBuffer> mReadBuffer;
+   std::unique_ptr<juce::AudioSampleBuffer> mReadBuffer;
    int mSamplesLeftToRead;
 };
 

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -259,7 +259,7 @@ void SampleBrowser::LoadState(FileStreamIn& in)
    in >> rev;
    LoadStateValidate(rev == kSaveStateRev);
    
-   string currentDirectory;
+   std::string currentDirectory;
    in >> currentDirectory;
    SetDirectory(currentDirectory);
 }

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -39,7 +39,7 @@ public:
    ~SampleBrowser();
    static IDrawableModule* Create() { return new SampleBrowser(); }
    
-   string GetTitleLabel() override { return "sample browser"; }
+   std::string GetTitleLabel() override { return "sample browser"; }
    
    void CreateUIControls() override;
    

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -105,7 +105,7 @@ void SampleCanvas::Process(double time)
    
    gWorkChannelBuffer.Clear();
    
-   const vector<CanvasElement*>& elements = mCanvas->GetElements();
+   const std::vector<CanvasElement*>& elements = mCanvas->GetElements();
    for (int elemIdx = 0; elemIdx < elements.size(); ++elemIdx)
    {
       SampleCanvasElement* element = static_cast<SampleCanvasElement*>(elements[elemIdx]);
@@ -191,7 +191,7 @@ void SampleCanvas::GetModuleDimensions(float& width, float& height)
    height = mCanvas->GetHeight() + extraH;
 }
 
-void SampleCanvas::FilesDropped(vector<string> files, int x, int y)
+void SampleCanvas::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample sample;
    sample.Read(files[0].c_str());

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -45,7 +45,7 @@ public:
    ~SampleCanvas();
    static IDrawableModule* Create() { return new SampleCanvas(); }
    
-   string GetTitleLabel() override { return "sample canvas"; }
+   std::string GetTitleLabel() override { return "sample canvas"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -59,7 +59,7 @@ public:
    
    void OnClicked(int x, int y, bool right) override;
    
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -39,7 +39,7 @@ public:
    virtual ~SampleCapturer();
    static IDrawableModule* Create() { return new SampleCapturer(); }
 
-   string GetTitleLabel() override { return "sample capturer"; }
+   std::string GetTitleLabel() override { return "sample capturer"; }
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/SampleFinder.cpp
+++ b/Source/SampleFinder.cpp
@@ -218,7 +218,7 @@ bool SampleFinder::MouseScrolled(int x, int y, float scrollX, float scrollY)
    return false;
 }
 
-void SampleFinder::FilesDropped(vector<string> files, int x, int y)
+void SampleFinder::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mSample->Reset();
    

--- a/Source/SampleFinder.h
+++ b/Source/SampleFinder.h
@@ -47,7 +47,7 @@ public:
    ~SampleFinder();
    static IDrawableModule* Create() { return new SampleFinder(); }
    
-   string GetTitleLabel() override { return "sample finder"; }
+   std::string GetTitleLabel() override { return "sample finder"; }
    void CreateUIControls() override;
    
    //INoteReceiver
@@ -59,7 +59,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
    

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -189,7 +189,7 @@ void SamplePlayer::Poll()
    }
    else if (clipboard.contains("youtu.be"))
    {
-      vector<string> tokens = ofSplitString(clipboard.toStdString(), "/");
+      std::vector<std::string> tokens = ofSplitString(clipboard.toStdString(), "/");
       if (tokens.size() > 0)
       {
          mYoutubeId = tokens[tokens.size() - 1];
@@ -219,7 +219,7 @@ void SamplePlayer::Poll()
 
       if (mRunningProcessType == RunningProcessType::SearchYoutube)
       {
-         string tempPath = ofToDataPath("youtube_temp");
+         std::string tempPath = ofToDataPath("youtube_temp");
          auto dir = juce::File(tempPath);
          if (dir.exists())
          {
@@ -229,14 +229,14 @@ void SamplePlayer::Poll()
             {
                for (auto& result : results)
                {
-                  string file = result.getFileName().toStdString();
+                  std::string file = result.getFileName().toStdString();
                   ofStringReplace(file, ".info.json", "");
-                  vector<string> tokens = ofSplitString(file, "#");
+                  std::vector<std::string> tokens = ofSplitString(file, "#");
                   if (tokens.size() >= 3)
                   {
-                     string lengthStr = tokens[tokens.size() - 3];
-                     string id = tokens[tokens.size() - 2];
-                     string channel = tokens[tokens.size() - 1];
+                     std::string lengthStr = tokens[tokens.size() - 3];
+                     std::string id = tokens[tokens.size() - 2];
+                     std::string channel = tokens[tokens.size() - 1];
                      bool found = false;
                      for (auto& existing : mYoutubeSearchResults)
                      {
@@ -246,7 +246,7 @@ void SamplePlayer::Poll()
                      if (!found)
                      {
                         YoutubeSearchResult resultToAdd;
-                        string name = "";
+                        std::string name = "";
                         for (size_t i = 0; i < tokens.size() - 3; ++i)
                            name += tokens[i];
                         resultToAdd.name = name;
@@ -503,7 +503,7 @@ void SamplePlayer::AutoSlice(int slices)
    }
 }
 
-void SamplePlayer::FilesDropped(vector<string> files, int x, int y)
+void SamplePlayer::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample* sample = new Sample();
    sample->Read(files[0].c_str());
@@ -648,9 +648,9 @@ void SamplePlayer::TextEntryComplete(TextEntry* entry)
 
 namespace
 {
-   string GetYoutubeDlPath()
+   std::string GetYoutubeDlPath()
    {
-      static string sPath = "";
+      static std::string sPath = "";
       if (sPath == "")
       {
          if (TheSynth->GetUserPrefs()["youtube-dl_path"].isNull())
@@ -669,9 +669,9 @@ namespace
       return sPath;
    }
 
-   string GetFfmpegPath()
+   std::string GetFfmpegPath()
    {
-      static string sPath = "";
+      static std::string sPath = "";
       if (sPath == "")
       {
          if (TheSynth->GetUserPrefs()["ffmpeg_path"].isNull())
@@ -691,7 +691,7 @@ namespace
    }
 }
 
-void SamplePlayer::DownloadYoutube(string url, string title)
+void SamplePlayer::DownloadYoutube(std::string url, std::string title)
 {
    mPlay = false;
    if (mSample)
@@ -732,7 +732,7 @@ void SamplePlayer::DownloadYoutube(string url, string title)
    RunProcess(args);
 }
 
-void SamplePlayer::OnYoutubeDownloadComplete(string filename, string title)
+void SamplePlayer::OnYoutubeDownloadComplete(std::string filename, std::string title)
 {
    if (juce::File(ofToDataPath(filename)).existsAsFile())
    {
@@ -750,7 +750,7 @@ void SamplePlayer::OnYoutubeDownloadComplete(string filename, string title)
 
 void SamplePlayer::RunProcess(const StringArray& args)
 {
-   string command = "";
+   std::string command = "";
    for (auto& arg : args)
       command += arg.toStdString() + " ";
    ofLog() << "running " << command;
@@ -763,9 +763,9 @@ void SamplePlayer::RunProcess(const StringArray& args)
       ofLog() << "error running process from bespoke";
 }
 
-void SamplePlayer::SearchYoutube(string searchTerm)
+void SamplePlayer::SearchYoutube(std::string searchTerm)
 {
-   string tempPath = ofToDataPath("youtube_temp");
+   std::string tempPath = ofToDataPath("youtube_temp");
    auto dir = juce::File(tempPath);
    if (dir.exists())
       dir.deleteRecursively();
@@ -789,7 +789,7 @@ void SamplePlayer::SearchYoutube(string searchTerm)
    RunProcess(args);
 }
 
-void SamplePlayer::OnYoutubeSearchComplete(string searchTerm, double searchTime)
+void SamplePlayer::OnYoutubeSearchComplete(std::string searchTerm, double searchTime)
 {
    if (mYoutubeSearchResults.size() == 0)
    {
@@ -830,7 +830,7 @@ void SamplePlayer::SaveFile()
    }
 }
 
-void SamplePlayer::FillData(vector<float> data)
+void SamplePlayer::FillData(std::vector<float> data)
 {
    Sample* sample = new Sample();
    sample->Create((int)data.size());
@@ -1039,7 +1039,7 @@ void SamplePlayer::DrawModule()
          mSearchResultButtons[i]->SetShowing(true);
          int minutes = int(mYoutubeSearchResults[i].lengthSeconds / 60);
          int secondsRemainder = int(mYoutubeSearchResults[i].lengthSeconds) % 60;
-         string lengthStr = ofToString(minutes) + ":";
+         std::string lengthStr = ofToString(minutes) + ":";
          if (secondsRemainder < 10)
             lengthStr += "0";
          lengthStr += ofToString(secondsRemainder);
@@ -1518,9 +1518,9 @@ void SamplePlayer::LoadState(FileStreamIn& in)
    }
 }
 
-vector<IUIControl*> SamplePlayer::ControlsToIgnoreInSaveState() const
+std::vector<IUIControl*> SamplePlayer::ControlsToIgnoreInSaveState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mDownloadYoutubeSearch);
    ignore.push_back(mLoadFileButton);
    ignore.push_back(mSaveFileButton);

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -51,7 +51,7 @@ public:
    ~SamplePlayer();
    static IDrawableModule* Create() { return new SamplePlayer(); }
    
-   string GetTitleLabel() override { return "sampleplayer"; }
+   std::string GetTitleLabel() override { return "sampleplayer"; }
    void CreateUIControls() override;
    void Init() override;
    void Poll() override;
@@ -63,14 +63,14 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    bool IsResizable() const override { return true; }
    void Resize(float width, float height) override { mWidth = ofClamp(width, 210, 9999); mHeight = ofClamp(height, 125, 9999); }
    
    void SetCuePoint(int pitch, float startSeconds, float lengthSeconds, float speed);
-   void FillData(vector<float> data);
+   void FillData(std::vector<float> data);
    ChannelBuffer* GetCueSampleData(int cueIndex);
    float GetLengthInSeconds() const;
    
@@ -91,19 +91,19 @@ public:
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
-   vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
+   std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
    
 private:
    void UpdateSample(Sample* sample, bool ownsSample);
    float GetPlayPositionForMouse(float mouseX) const;
    float GetSecondsForMouse(float mouseX) const;
    void GetPlayInfoForPitch(int pitch, float& startSeconds, float& lengthSeconds, float& speed) const;
-   void DownloadYoutube(string url, string titles);
-   void SearchYoutube(string searchTerm);
+   void DownloadYoutube(std::string url, std::string titles);
+   void SearchYoutube(std::string searchTerm);
    void LoadFile();
    void SaveFile();
-   void OnYoutubeSearchComplete(string searchTerm, double searchStartTime);
-   void OnYoutubeDownloadComplete(string filename, string title);
+   void OnYoutubeSearchComplete(std::string searchTerm, double searchStartTime);
+   void OnYoutubeDownloadComplete(std::string filename, std::string title);
    void SwitchAndRamp();
    void SetCuePointForX(float mouseX);
    int GetZoomStartSample() const;
@@ -146,7 +146,7 @@ private:
    Checkbox* mLoopCheckbox;
    Checkbox* mRecordCheckbox;
    bool mScrubbingSample;
-   string mYoutubeId;
+   std::string mYoutubeId;
    ClickButton* mDownloadYoutubeButton;
    TextEntry* mDownloadYoutubeSearch;
    char mYoutubeSearch[MAX_TEXTENTRY_LENGTH];
@@ -173,7 +173,7 @@ private:
       float lengthSeconds;
       float speed; 
    };
-   vector<SampleCuePoint> mSampleCuePoints{128};
+   std::vector<SampleCuePoint> mSampleCuePoints{128};
    DropdownList* mCuePointSelector;
    FloatSlider* mCuePointStartSlider;
    FloatSlider* mCuePointLengthSlider;
@@ -195,7 +195,7 @@ private:
    ClickButton* mPlayHoveredClipButton;
    ClickButton* mGrabHoveredClipButton;
 
-   string mErrorString;
+   std::string mErrorString;
 
 #define kMaxYoutubeSearchResults 10
    enum class RunningProcessType
@@ -206,21 +206,21 @@ private:
    };
    struct YoutubeSearchResult
    {
-      string name;
-      string channel;
+      std::string name;
+      std::string channel;
       float lengthSeconds;
-      string youtubeId;
+      std::string youtubeId;
    };
    RunningProcessType mRunningProcessType;
    juce::ChildProcess* mRunningProcess;
    std::function<void()> mOnRunningProcessComplete;
-   vector<YoutubeSearchResult> mYoutubeSearchResults;
+   std::vector<YoutubeSearchResult> mYoutubeSearchResults;
    std::array<ClickButton*, kMaxYoutubeSearchResults> mSearchResultButtons;
 
    ChannelBuffer mLastOutputSample;
    ChannelBuffer mSwitchAndRampVal;
    
-   vector<ChannelBuffer*> mRecordChunks;
+   std::vector<ChannelBuffer*> mRecordChunks;
    bool mDoRecording;   //separate this out from mRecord to allow setup in main thread before audio thread starts recording
    int mRecordingLength;
    bool mRecordingAppendMode;

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -237,7 +237,7 @@ void Sampler::GetModuleDimensions(float& width, float& height)
    height = 90;
 }
 
-void Sampler::FilesDropped(vector<string> files, int x, int y)
+void Sampler::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample sample;
    sample.Read(files[0].c_str());

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -50,7 +50,7 @@ public:
    ~Sampler();
    static IDrawableModule* Create() { return new Sampler(); }
    
-   string GetTitleLabel() override { return "sampler"; }
+   std::string GetTitleLabel() override { return "sampler"; }
    void CreateUIControls() override;
    
    void Poll() override;
@@ -66,7 +66,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
    
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -404,7 +404,7 @@ void SamplerGrid::MouseReleased()
    mGrid->MouseReleased();
 }
 
-void SamplerGrid::FilesDropped(vector<string> files, int x, int y)
+void SamplerGrid::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    Sample sample;
    sample.Read(files[0].c_str());

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -50,7 +50,7 @@ public:
    ~SamplerGrid();
    static IDrawableModule* Create() { return new SamplerGrid(); }
    
-   string GetTitleLabel() override { return "sampler grid"; }
+   std::string GetTitleLabel() override { return "sampler grid"; }
    void CreateUIControls() override;
    
    void Init() override;
@@ -74,7 +74,7 @@ public:
    //UIGridListener
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
    
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -138,7 +138,7 @@ void Scale::Init()
       mScaleSelector->AddLabel("ionian", 0);
       mScales.resize(1);
       mScales[0].mName = "ionian";
-      mScales[0].mPitches = vector<int>{0,2,4,5,7,9,11};
+      mScales[0].mPitches = std::vector<int>{0,2,4,5,7,9,11};
    }
    
    SetRoot(gRandom()%TheScale->GetTet());
@@ -270,7 +270,7 @@ int Scale::GetToneFromPitch(int pitch)
    return mScale.GetToneFromPitch(pitch);
 }
 
-void Scale::SetScale(int root, string type)
+void Scale::SetScale(int root, std::string type)
 {
    SetRoot(root);
    SetScaleType(type);
@@ -286,7 +286,7 @@ void Scale::SetRoot(int root, bool force)
    NotifyListeners();
 }
 
-void Scale::SetScaleType(string type, bool force)
+void Scale::SetScaleType(std::string type, bool force)
 {
    int oldScaleIndex = mScaleIndex;
    
@@ -350,7 +350,7 @@ void Scale::RemoveListener(IScaleListener* listener)
 
 void Scale::NotifyListeners()
 {
-   for (list<IScaleListener*>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
+   for (std::list<IScaleListener*>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
    {
       (*i)->OnScaleChanged();
    }
@@ -380,7 +380,7 @@ void Scale::DrawModule()
    mLoadKBM->Draw();
 }
 
-vector<int> Scale::GetPitchesForScale(string type)
+std::vector<int> Scale::GetPitchesForScale(std::string type)
 {
    for (int i=0; i<mScales.size(); ++i)
    {
@@ -388,7 +388,7 @@ vector<int> Scale::GetPitchesForScale(string type)
          return mScales[i].mPitches;
    }
    assert(false);
-   return vector<int>();
+   return std::vector<int>();
 }
 
 void Scale::Poll()
@@ -695,7 +695,7 @@ void ScalePitches::SetRoot(int root)
    mScaleRoot = root % TheScale->GetTet();
 }
 
-void ScalePitches::SetScaleType(string type)
+void ScalePitches::SetScaleType(std::string type)
 {
    mScaleType = type;
    int newFlip = (mScalePitchesFlip == 0) ? 1 : 0;

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -57,18 +57,18 @@ inline bool operator==(const Accidental& lhs, const Accidental& rhs)
 struct ScalePitches
 {
    int mScaleRoot;
-   string mScaleType;
-   vector<int> mScalePitches[2]; //double-buffered to avoid thread safety issues when modifying
+   std::string mScaleType;
+   std::vector<int> mScalePitches[2]; //double-buffered to avoid thread safety issues when modifying
    int mScalePitchesFlip{0};
    std::vector<Accidental> mAccidentals;
    
    void SetRoot(int root);
-   void SetScaleType(string type);
+   void SetScaleType(std::string type);
    void SetAccidentals(const std::vector<Accidental>& accidentals);
    
-   const vector<int>& GetPitches() const { return mScalePitches[mScalePitchesFlip]; }
+   const std::vector<int>& GetPitches() const { return mScalePitches[mScalePitchesFlip]; }
    int ScaleRoot() const { return mScaleRoot; }
-   string GetType() const { return mScaleType; }
+   std::string GetType() const { return mScaleType; }
    void GetChordDegreeAndAccidentals(const Chord& chord, int& degree, std::vector<Accidental>& accidentals) const;
    int GetScalePitch(int index) const;
    
@@ -92,7 +92,7 @@ public:
    ~Scale();
    void Init() override;
    
-   string GetTitleLabel() override { return "scale"; }
+   std::string GetTitleLabel() override { return "scale"; }
    void CreateUIControls() override;
    
    bool IsSingleton() const override { return true; }
@@ -103,11 +103,11 @@ public:
    bool IsInScale(int pitch);
    int GetPitchFromTone(int n);
    int GetToneFromPitch(int pitch);
-   void SetScale(int root, string type);
+   void SetScale(int root, std::string type);
    int ScaleRoot() { return mScale.mScaleRoot; }
-   string GetType() { return mScale.mScaleType; }
+   std::string GetType() { return mScale.mScaleType; }
    void SetRoot(int root, bool force = true);
-   void SetScaleType(string type, bool force = true);
+   void SetScaleType(std::string type, bool force = true);
    void AddListener(IScaleListener* listener);
    void RemoveListener(IScaleListener* listener);
    void Poll() override;
@@ -116,10 +116,10 @@ public:
    void SetAccidentals(const std::vector<Accidental>& accidentals);
    void GetChordDegreeAndAccidentals(const Chord& chord, int& degree, std::vector<Accidental>& accidentals);
    ScalePitches& GetScalePitches() { return mScale; }
-   vector<int> GetPitchesForScale(string type);
+   std::vector<int> GetPitchesForScale(std::string type);
    void SetRandomSeptatonicScale();
    int GetNumScaleTypes() { return (int)mScales.size(); }
-   string GetScaleName(int index) { return mScales[index].mName; }
+   std::string GetScaleName(int index) { return mScales[index].mName; }
    int NumPitchesInScale() const { return mScale.NumPitchesInScale(); }
    int GetTet() const { return mTet; }
 
@@ -142,8 +142,8 @@ public:
 private:
    struct ScaleInfo
    {
-      string mName;
-      vector<int> mPitches;
+      std::string mName;
+      std::vector<int> mPitches;
    };
    
    //IDrawableModule
@@ -169,7 +169,7 @@ private:
    };
    
    ScalePitches mScale;
-   list<IScaleListener*> mListeners;
+   std::list<IScaleListener*> mListeners;
    DropdownList* mRootSelector;
    DropdownList* mScaleSelector;
    IntSlider* mScaleDegreeSlider;
@@ -178,7 +178,7 @@ private:
    ClickButton* mLoadSCL{nullptr};
    ClickButton* mLoadKBM{nullptr};
    
-   vector<ScaleInfo> mScales;
+   std::vector<ScaleInfo> mScales;
    int mNumSeptatonicScales;
    int mScaleIndex;
    

--- a/Source/ScaleDegree.h
+++ b/Source/ScaleDegree.h
@@ -37,7 +37,7 @@ public:
    ScaleDegree();
    static IDrawableModule* Create() { return new ScaleDegree(); }
    
-   string GetTitleLabel() override { return "scale degree"; }
+   std::string GetTitleLabel() override { return "scale degree"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ScaleDetect.cpp
+++ b/Source/ScaleDetect.cpp
@@ -74,8 +74,8 @@ void ScaleDetect::DrawModule()
    }
    
    {
-      string pitchString;
-      vector<int> rootRelative;
+      std::string pitchString;
+      std::vector<int> rootRelative;
       for (int i=0; i<128; ++i)
       {
          if (mPitchOn[i])
@@ -104,7 +104,7 @@ void ScaleDetect::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    }
 }
 
-bool ScaleDetect::ScaleSatisfied(int root, string type)
+bool ScaleDetect::ScaleSatisfied(int root, std::string type)
 {
    ScalePitches scale;
    scale.SetRoot(root);

--- a/Source/ScaleDetect.h
+++ b/Source/ScaleDetect.h
@@ -35,9 +35,9 @@
 
 struct MatchingScale
 {
-   MatchingScale(int root, string type) : mRoot(root), mType(type) {}
+   MatchingScale(int root, std::string type) : mRoot(root), mType(type) {}
    int mRoot;
-   string mType;
+   std::string mType;
 };
 
 class ScaleDetect : public NoteEffectBase, public IDrawableModule, public IButtonListener, public IDropdownListener
@@ -46,7 +46,7 @@ public:
    ScaleDetect();
    static IDrawableModule* Create() { return new ScaleDetect(); }
    
-   string GetTitleLabel() override { return "detect"; }
+   std::string GetTitleLabel() override { return "detect"; }
    void CreateUIControls() override;
 
    //INoteReceiver
@@ -60,7 +60,7 @@ public:
    
    
 private:
-   bool ScaleSatisfied(int root, string type);
+   bool ScaleSatisfied(int root, std::string type);
 
    //IDrawableModule
    void DrawModule() override;

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -62,7 +62,7 @@ ScriptModule* ScriptModule::sPriorExecutedModule = nullptr;
 //static
 double ScriptModule::sMostRecentRunTime = 0;
 //static
-string ScriptModule::sBackgroundTextString = "";
+std::string ScriptModule::sBackgroundTextString = "";
 //static
 float ScriptModule::sBackgroundTextSize = 30;
 //static
@@ -141,7 +141,7 @@ void ScriptModule::UninitializePython()
 
 namespace
 {
-   string kPythonIsInstalledMarkerFile = "python_installed";
+   std::string kPythonIsInstalledMarkerFile = "python_installed";
 }
 
 //static
@@ -311,7 +311,7 @@ void ScriptModule::DrawModuleUnclipped()
    ofPushStyle();
    if (mDrawDebug)
    {
-      string debugText = mLastRunLiteralCode;
+      std::string debugText = mLastRunLiteralCode;
       
       for (size_t i=0; i<mScheduledNoteOutput.size(); ++i)
       {
@@ -331,11 +331,11 @@ void ScriptModule::DrawModuleUnclipped()
       {
          if (mScheduledUIControlValue[i].time != -1 &&
              gTime + 50 < mScheduledUIControlValue[i].time)
-            debugText += "\n"+ string(mScheduledUIControlValue[i].control->Name()) + ": " + ofToString(mScheduledUIControlValue[i].value) + ", " + ofToString(mScheduledUIControlValue[i].time) + " " + ofToString(mScheduledUIControlValue[i].startTime) + " " + ofToString(mScheduledUIControlValue[i].lineNum);
+            debugText += "\n"+ std::string(mScheduledUIControlValue[i].control->Name()) + ": " + ofToString(mScheduledUIControlValue[i].value) + ", " + ofToString(mScheduledUIControlValue[i].time) + " " + ofToString(mScheduledUIControlValue[i].startTime) + " " + ofToString(mScheduledUIControlValue[i].lineNum);
       }
       
-      string lineNumbers = "";
-      vector<string> lines = ofSplitString(mLastRunLiteralCode, "\n");
+      std::string lineNumbers = "";
+      std::vector<std::string> lines = ofSplitString(mLastRunLiteralCode, "\n");
       for (size_t i=0; i<lines.size(); ++i)
       {
          lineNumbers += ofToString(i+1)+"\n";
@@ -538,7 +538,7 @@ void ScriptModule::Poll()
    if (mMidiMessageQueue.size() > 0)
    {
       mMidiMessageQueueMutex.lock();
-      for (string& methodCall : mMidiMessageQueue)
+      for (std::string& methodCall : mMidiMessageQueue)
          RunCode(gTime, methodCall);
       mMidiMessageQueue.clear();
       mMidiMessageQueueMutex.unlock();
@@ -605,7 +605,7 @@ void ScriptModule::ScheduleNote(double time, float pitch, float velocity, float 
    }
 }
 
-void ScriptModule::ScheduleMethod(string method, double delayMeasureTime)
+void ScriptModule::ScheduleMethod(std::string method, double delayMeasureTime)
 {
    for (size_t i=0; i<mScheduledMethodCall.size(); ++i)
    {
@@ -652,7 +652,7 @@ void ScriptModule::HighlightLine(int lineNum, int scriptModuleIndex)
    sScriptModules[scriptModuleIndex]->mLineExecuteTracker.AddEvent(lineNum);
 }
 
-void ScriptModule::PrintText(string text)
+void ScriptModule::PrintText(std::string text)
 {
    for (size_t i=0; i<mPrintDisplay.size(); ++i)
    {
@@ -666,7 +666,7 @@ void ScriptModule::PrintText(string text)
    }
 }
 
-IUIControl* ScriptModule::GetUIControl(string path)
+IUIControl* ScriptModule::GetUIControl(std::string path)
 {
    IUIControl* control;
    if (ofIsStringInString(path, "~"))
@@ -768,8 +768,8 @@ void ScriptModule::ConnectOscInput(int port)
 
 void ScriptModule::oscMessageReceived(const OSCMessage& msg)
 {
-   string address = msg.getAddressPattern().toString().toStdString();
-   string messageString = address;
+   std::string address = msg.getAddressPattern().toString().toStdString();
+   std::string messageString = address;
 
    for (int i = 0; i < msg.size(); ++i)
    {
@@ -807,7 +807,7 @@ void ScriptModule::ButtonClicked(ClickButton* button)
       FileChooser chooser("Save script as...", File(ofToDataPath("scripts/script.py")), "*.py", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
       if (chooser.browseForFileToSave(true))
       {
-         string path = chooser.getResult().getFullPathName().toStdString();
+         std::string path = chooser.getResult().getFullPathName().toStdString();
          
          File resourceFile (path);
          TemporaryFile tempFile (resourceFile);
@@ -863,7 +863,7 @@ void ScriptModule::ButtonClicked(ClickButton* button)
             return;
          }
 
-         unique_ptr<FileInputStream> input(resourceFile.createInputStream());
+         std::unique_ptr<FileInputStream> input(resourceFile.createInputStream());
 
          if (!input->openedOk())
          {
@@ -935,7 +935,7 @@ void ScriptModule::ExecuteCode()
    RunScript(gTime+gBufferSizeMs);
 }
 
-pair<int,int> ScriptModule::ExecuteBlock(int lineStart, int lineEnd)
+std::pair<int,int> ScriptModule::ExecuteBlock(int lineStart, int lineEnd)
 {
    return RunScript(gTime, lineStart, lineEnd);
 }
@@ -944,7 +944,7 @@ void ScriptModule::OnCodeUpdated()
 {
    if (mBoundModuleConnections.size() > 0)
    {
-      vector<string> lines = mCodeEntry->GetLines(false);
+      std::vector<std::string> lines = mCodeEntry->GetLines(false);
 
       for (size_t i = 0; i < mBoundModuleConnections.size(); ++i)
       {
@@ -994,12 +994,12 @@ void ScriptModule::PlayNote(double time, int pitch, int velocity, int voiceIdx /
    }
 }
 
-string ScriptModule::GetThisName()
+std::string ScriptModule::GetThisName()
 {
    return "me__"+ofToString(mScriptModuleIndex);
 }
 
-pair<int,int> ScriptModule::RunScript(double time, int lineStart/*=-1*/, int lineEnd/*=-1*/)
+std::pair<int,int> ScriptModule::RunScript(double time, int lineStart/*=-1*/, int lineEnd/*=-1*/)
 {
    //should only be called from main thread
 
@@ -1010,8 +1010,8 @@ pair<int,int> ScriptModule::RunScript(double time, int lineStart/*=-1*/, int lin
    }
 
    py::exec(GetThisName()+" = scriptmodule.get_me("+ofToString(mScriptModuleIndex)+")", py::globals());
-   string code = mCodeEntry->GetText(true);
-   vector<string> lines = ofSplitString(code, "\n");
+   std::string code = mCodeEntry->GetText(true);
+   std::vector<std::string> lines = ofSplitString(code, "\n");
    
    size_t executionStartLine = 0;
    size_t executionEndLine = (int)lines.size();
@@ -1039,7 +1039,7 @@ pair<int,int> ScriptModule::RunScript(double time, int lineStart/*=-1*/, int lin
    code = "";
    for (size_t i=0; i<lines.size(); ++i)
    {
-      string prefix = "";
+      std::string prefix = "";
       if (i < executionStartLine || i > executionEndLine)
          prefix = "#";
       if (ShouldDisplayLineExecutionPre(i > 0 ? lines[i-1] : "", lines[i]))
@@ -1054,7 +1054,7 @@ pair<int,int> ScriptModule::RunScript(double time, int lineStart/*=-1*/, int lin
    return std::make_pair(executionStartLine, executionEndLine);
 }
 
-void ScriptModule::RunCode(double time, string code)
+void ScriptModule::RunCode(double time, std::string code)
 {
    //should only be called from main thread
    
@@ -1091,13 +1091,13 @@ void ScriptModule::RunCode(double time, string code)
       if (mNextLineToExecute == -1) //this script hasn't executed yet
          sMostRecentLineExecutedModule = this;
       
-      sMostRecentLineExecutedModule->mLastError = (string)py::str(e.type()) + ": "+ (string)py::str(e.value());
+      sMostRecentLineExecutedModule->mLastError = (std::string)py::str(e.type()) + ": "+ (std::string)py::str(e.value());
       
       int lineNumber = sMostRecentLineExecutedModule->mNextLineToExecute;
       if (lineNumber == -1)
       {
-         string errorString = (string)py::str(e.value());
-         const string lineTextLabel = " line ";
+         std::string errorString = (std::string)py::str(e.value());
+         const std::string lineTextLabel = " line ";
          const char* lineTextPos = strstr(errorString.c_str(), lineTextLabel.c_str());
          if (lineTextPos != nullptr)
          {
@@ -1105,11 +1105,11 @@ void ScriptModule::RunCode(double time, string code)
             {
                size_t start = lineTextPos + lineTextLabel.length() - errorString.c_str();
                size_t len = errorString.size() - 1 - start;
-               string lineNumberText = errorString.substr(start, len);
+               std::string lineNumberText = errorString.substr(start, len);
                int rawLineNumber = stoi(lineNumberText);
                int realLineNumber = rawLineNumber - 1;
                
-               vector<string> lines = ofSplitString(sMostRecentLineExecutedModule->mLastRunLiteralCode, "\n");
+               std::vector<std::string> lines = ofSplitString(sMostRecentLineExecutedModule->mLastRunLiteralCode, "\n");
                for (size_t i=0; i<lines.size() && i < rawLineNumber; ++i)
                {
                   if (ofIsStringInString(lines[i], "###instrumentation###"))
@@ -1165,16 +1165,16 @@ void ScriptModule::RunCode(double time, string code)
    }
 }
 
-string ScriptModule::GetMethodPrefix()
+std::string ScriptModule::GetMethodPrefix()
 {
-   string prefix = Path();
+   std::string prefix = Path();
    ofStringReplace(prefix, "~", "");
    return prefix;
 }
 
-void ScriptModule::FixUpCode(string& code)
+void ScriptModule::FixUpCode(std::string& code)
 {
-   string prefix = GetMethodPrefix();
+   std::string prefix = GetMethodPrefix();
    ofStringReplace(code, "on_pulse(", "on_pulse__"+ prefix +"(");
    ofStringReplace(code, "on_note(", "on_note__"+ prefix +"(");
    ofStringReplace(code, "on_grid_button(", "on_grid_button__"+ prefix +"(");
@@ -1184,7 +1184,7 @@ void ScriptModule::FixUpCode(string& code)
    ofStringReplace(code, "me.", GetThisName() + ".");
 }
 
-void ScriptModule::GetFirstAndLastCharacter(string line, char& first, char& last)
+void ScriptModule::GetFirstAndLastCharacter(std::string line, char& first, char& last)
 {
    bool hasFirstCharacter = false;
    first = 0;
@@ -1204,7 +1204,7 @@ void ScriptModule::GetFirstAndLastCharacter(string line, char& first, char& last
    }
 }
 
-bool ScriptModule::ShouldDisplayLineExecutionPre(string priorLine, string line)
+bool ScriptModule::ShouldDisplayLineExecutionPre(std::string priorLine, std::string line)
 {
    if (!IsNonWhitespace(line))
       return false;
@@ -1228,9 +1228,9 @@ bool ScriptModule::ShouldDisplayLineExecutionPre(string priorLine, string line)
    return true;
 }
 
-string ScriptModule::GetIndentation(string line)
+std::string ScriptModule::GetIndentation(std::string line)
 {
-   string ret;
+   std::string ret;
    for (size_t i = 0; i < line.length(); ++i)
    {
       if (line[i] == ' ')
@@ -1241,7 +1241,7 @@ string ScriptModule::GetIndentation(string line)
    return ret;
 }
 
-bool ScriptModule::IsNonWhitespace(string line)
+bool ScriptModule::IsNonWhitespace(std::string line)
 {
    for (size_t i = 0; i < line.length(); ++i)
    {
@@ -1251,7 +1251,7 @@ bool ScriptModule::IsNonWhitespace(string line)
    return false;
 }
 
-static string sContextToRestore = "";
+static std::string sContextToRestore = "";
 void ScriptModule::SetContext()
 {
    sContextToRestore = IClickable::sLoadContext;
@@ -1274,8 +1274,8 @@ void ScriptModule::OnModuleReferenceBound(IDrawableModule* target)
             return;
       }
 
-      string code = mCodeEntry->GetText(true);
-      vector<string> lines = ofSplitString(code, "\n");
+      std::string code = mCodeEntry->GetText(true);
+      std::vector<std::string> lines = ofSplitString(code, "\n");
       if (mNextLineToExecute >= 0 && mNextLineToExecute < lines.size())
       {
          BoundModuleConnection connection;
@@ -1459,7 +1459,7 @@ void ScriptReferenceDisplay::LoadText()
    File file(ofToResourcePath("scripting_reference.txt").c_str());
    if (file.existsAsFile())
    {
-      string text = file.loadFileAsString().toStdString();
+      std::string text = file.loadFileAsString().toStdString();
       ofStringReplace(text, "\r", "");
       mText = ofSplitString(text, "\n");
    }

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -53,18 +53,18 @@ public:
    static void InitializePythonIfNecessary();
    static void CheckIfPythonEverSuccessfullyInitialized();
    
-   string GetTitleLabel() override { return "script"; }
+   std::string GetTitleLabel() override { return "script"; }
    void CreateUIControls() override;
    
    void Poll() override;
    
    void PlayNoteFromScript(float pitch, float velocity, float pan, int noteOutputIndex);
    void PlayNoteFromScriptAfterDelay(float pitch, float velocity, double delayMeasureTime, float pan, int noteOutputIndex);
-   void ScheduleMethod(string method, double delayMeasureTime);
+   void ScheduleMethod(std::string method, double delayMeasureTime);
    void ScheduleUIControlValue(IUIControl* control, float value, double delayMeasureTime);
    void HighlightLine(int lineNum, int scriptModuleIndex);
-   void PrintText(string text);
-   IUIControl* GetUIControl(string path);
+   void PrintText(std::string text);
+   IUIControl* GetUIControl(std::string path);
    void Stop();
    double GetScheduledTime(double delayMeasureTime);
    void SetNumNoteOutputs(int num);
@@ -74,7 +74,7 @@ public:
    void SetContext();
    void ClearContext();
    
-   void RunCode(double time, string code);
+   void RunCode(double time, std::string code);
    
    void OnPulse(double time, float velocity, int flags) override;
    void ButtonClicked(ClickButton* button) override;
@@ -84,7 +84,7 @@ public:
  
    //ICodeEntryListener
    void ExecuteCode() override;
-   pair<int,int> ExecuteBlock(int lineStart, int lineEnd) override;
+   std::pair<int,int> ExecuteBlock(int lineStart, int lineEnd) override;
    void OnCodeUpdated() override;
    
    //INoteReceiver
@@ -107,7 +107,7 @@ public:
    static ScriptModule* sPriorExecutedModule;
    static float GetScriptMeasureTime();
    static float GetTimeSigRatio();
-   static string sBackgroundTextString;
+   static std::string sBackgroundTextString;
    static float sBackgroundTextSize;
    static ofVec2f sBackgroundTextPos;
    static ofColor sBackgroundTextColor;
@@ -118,21 +118,21 @@ public:
    ModulationChain* GetModWheel(int pitch) { return &mModWheels[pitch]; }
    ModulationChain* GetPressure(int pitch) { return &mPressures[pitch]; }
 
-   static string GetBootstrapImportString() { return "import bespoke; import module; import scriptmodule; import random; import math"; }
+   static std::string GetBootstrapImportString() { return "import bespoke; import module; import scriptmodule; import random; import math"; }
    
 private:
    void PlayNote(double time, float pitch, float velocity, float pan, int noteOutputIndex, int lineNum);
    void AdjustUIControl(IUIControl* control, float value, int lineNum);
-   pair<int,int> RunScript(double time, int lineStart = -1, int lineEnd = -1);
-   void FixUpCode(string& code);
+   std::pair<int,int> RunScript(double time, int lineStart = -1, int lineEnd = -1);
+   void FixUpCode(std::string& code);
    void ScheduleNote(double time, float pitch, float velocity, float pan, int noteOutputIndex);
    void SendNoteToIndex(int index, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation);
-   string GetThisName();
-   string GetIndentation(string line);
-   string GetMethodPrefix();
-   bool ShouldDisplayLineExecutionPre(string priorLine, string line);
-   void GetFirstAndLastCharacter(string line, char& first, char& last);
-   bool IsNonWhitespace(string line);
+   std::string GetThisName();
+   std::string GetIndentation(std::string line);
+   std::string GetMethodPrefix();
+   bool ShouldDisplayLineExecutionPre(std::string priorLine, std::string line);
+   void GetFirstAndLastCharacter(std::string line, char& first, char& last);
+   bool IsNonWhitespace(std::string line);
    void DrawTimer(int lineNum, double startTime, double endTime, ofColor color, bool filled);
    void RefreshScriptFiles();
    void RefreshStyleFiles();
@@ -172,9 +172,9 @@ private:
    float mHeight;
    std::array<double, 20> mScheduledPulseTimes;
    static double sMostRecentRunTime;
-   string mLastError;
+   std::string mLastError;
    size_t mScriptModuleIndex;
-   string mLastRunLiteralCode;
+   std::string mLastRunLiteralCode;
    int mNextLineToExecute;
    int mInitExecutePriority;
    int mOscInputPort;
@@ -195,7 +195,7 @@ private:
    {
       double startTime;
       double time;
-      string method;
+      std::string method;
       int lineNum;
    };
    std::array<ScheduledMethodCall, 50> mScheduledMethodCall;
@@ -221,7 +221,7 @@ private:
    struct PrintDisplay
    {
       double time;
-      string text;
+      std::string text;
       int lineNum;
    };
    std::array<PrintDisplay, 10> mPrintDisplay;
@@ -244,7 +244,7 @@ private:
             mTimes[i] = -999;
       }
       
-      void AddEvent(int lineNum, string text = "")
+      void AddEvent(int lineNum, std::string text = "")
       {
          if (lineNum >= 0 && lineNum < (int)mTimes.size())
          {
@@ -256,7 +256,7 @@ private:
       void Draw(CodeEntry* codeEntry, int style, ofColor color);
    private:
       std::array<double, 256> mTimes;
-      std::array<string, 256> mText;
+      std::array<std::string, 256> mText;
    };
    
    LineEventTracker mLineExecuteTracker;
@@ -267,18 +267,18 @@ private:
    struct BoundModuleConnection
    {
       int mLineIndex;
-      string mLineText;
+      std::string mLineText;
       IDrawableModule* mTarget;
    };
    std::vector<BoundModuleConnection> mBoundModuleConnections;
    
-   std::vector<string> mScriptFilePaths;
+   std::vector<std::string> mScriptFilePaths;
    
    std::vector<AdditionalNoteCable*> mExtraNoteOutputs;
    std::array<ModulationChain, 128> mPitchBends;
    std::array<ModulationChain, 128> mModWheels;
    std::array<ModulationChain, 128> mPressures;
-   std::list<string> mMidiMessageQueue;
+   std::list<std::string> mMidiMessageQueue;
    ofMutex mMidiMessageQueueMutex;
    
    bool mShowJediWarning;
@@ -291,7 +291,7 @@ public:
    virtual ~ScriptReferenceDisplay();
    static IDrawableModule* Create() { return new ScriptReferenceDisplay(); }
 
-   string GetTitleLabel() override { return "script reference"; }
+   std::string GetTitleLabel() override { return "script reference"; }
    void CreateUIControls() override;
 
    void ButtonClicked(ClickButton* button) override;
@@ -307,7 +307,7 @@ private:
 
    void LoadText();
 
-   vector<string> mText;
+   std::vector<std::string> mText;
    ClickButton* mCloseButton;
    float mWidth;
    float mHeight;

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -98,7 +98,7 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
       int root = TheScale->ScaleRoot();
       auto scalePitches = TheScale->GetScalePitches().GetPitches();
       size_t numPitches = scalePitches.size();
-      vector<int> ret(count);
+      std::vector<int> ret(count);
       for (int i=0; i<count; ++i)
          ret[i] = scalePitches[i % numPitches] + TheScale->GetTet() * (octave + i / numPitches) + root;
       return ret;
@@ -107,7 +107,7 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
    {
       return TheScale->GetPitchFromTone(index);
    });
-   m.def("name_to_pitch", [](string noteName)
+   m.def("name_to_pitch", [](std::string noteName)
    {
       return PitchFromNoteName(noteName);
    });
@@ -123,7 +123,7 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
    {
       return TheTransport->GetTempo();
    });
-   m.def("set_background_text", [](string str, float size, float xPos, float yPos, float red, float green, float blue)
+   m.def("set_background_text", [](std::string str, float size, float xPos, float yPos, float red, float green, float blue)
    {
       ScriptModule::sBackgroundTextString = str;
       ScriptModule::sBackgroundTextSize = size;
@@ -155,7 +155,7 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
       {
          module.PlayNoteFromScriptAfterDelay(pitch, velocity, delay, pan, output_index);
       }, "delay"_a, "pitch"_a, "velocity"_a, "pan"_a = 0, "output_index"_a = 0)
-      .def("schedule_call", [](ScriptModule& module, float delay, string method)
+      .def("schedule_call", [](ScriptModule& module, float delay, std::string method)
       {
          module.ScheduleMethod(method, delay);
       })
@@ -164,20 +164,20 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
       {
          module.PlayNoteFromScript(pitch, velocity, pan, output_index);
       }, "pitch"_a, "velocity"_a, "pan"_a = 0, "output_index"_a = 0)
-      .def("set", [](ScriptModule& module, string path, float value)
+      .def("set", [](ScriptModule& module, std::string path, float value)
       {
          IUIControl* control = module.GetUIControl(path);
          if (control != nullptr)
             module.ScheduleUIControlValue(control, value, 0);
       })
       ///example: me.set("oscillator~pw", .2)
-      .def("schedule_set", [](ScriptModule& module, float delay, string path, float value)
+      .def("schedule_set", [](ScriptModule& module, float delay, std::string path, float value)
       {
          IUIControl* control = module.GetUIControl(path);
          if (control != nullptr)
             module.ScheduleUIControlValue(control, value, delay);
       })
-      .def("get", [](ScriptModule& module, string path)
+      .def("get", [](ScriptModule& module, std::string path)
       {
          IUIControl* control = module.GetUIControl(path);
          if (control != nullptr)
@@ -185,7 +185,7 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
          return 0.0f;
       })
       ///example: pulsewidth = me.get("oscillator~pulsewidth")
-      .def("adjust", [](ScriptModule& module, string path, float amount)
+      .def("adjust", [](ScriptModule& module, std::string path, float amount)
       {
          IUIControl* control = module.GetUIControl(path);
          if (control != nullptr)
@@ -230,7 +230,7 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
 
 PYBIND11_EMBEDDED_MODULE(notesequencer, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<NoteStepSequencer*>(TheSynth->FindModule(path));
@@ -247,7 +247,7 @@ PYBIND11_EMBEDDED_MODULE(notesequencer, m)
 
 PYBIND11_EMBEDDED_MODULE(drumsequencer, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<StepSequencer*>(TheSynth->FindModule(path));
@@ -268,7 +268,7 @@ PYBIND11_EMBEDDED_MODULE(drumsequencer, m)
 
 PYBIND11_EMBEDDED_MODULE(grid, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<GridModule*>(TheSynth->FindModule(path));
@@ -290,7 +290,7 @@ PYBIND11_EMBEDDED_MODULE(grid, m)
       {
          grid.SetGrid(cols, rows);
       })
-      .def("set_label", [](GridModule& grid, int row, string label)
+      .def("set_label", [](GridModule& grid, int row, std::string label)
       {
          grid.SetLabel(row, label);
       })
@@ -332,7 +332,7 @@ PYBIND11_EMBEDDED_MODULE(grid, m)
 
 PYBIND11_EMBEDDED_MODULE(notecanvas, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<NoteCanvas*>(TheSynth->FindModule(path));
@@ -353,7 +353,7 @@ PYBIND11_EMBEDDED_MODULE(notecanvas, m)
 
 PYBIND11_EMBEDDED_MODULE(sampleplayer, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<SamplePlayer*>(TheSynth->FindModule(path));
@@ -366,7 +366,7 @@ PYBIND11_EMBEDDED_MODULE(sampleplayer, m)
       {
          player.SetCuePoint(pitch, startSeconds, lengthSeconds, speed);
       })
-      .def("fill", [](SamplePlayer& player, vector<float> data)
+      .def("fill", [](SamplePlayer& player, std::vector<float> data)
       {
          player.FillData(data);
       })
@@ -389,7 +389,7 @@ PYBIND11_EMBEDDED_MODULE(sampleplayer, m)
 
 PYBIND11_EMBEDDED_MODULE(midicontroller, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<MidiController*>(TheSynth->FindModule(path));
@@ -413,7 +413,7 @@ PYBIND11_EMBEDDED_MODULE(midicontroller, m)
       .value("Default", ControlType::kControlType_Default)
       .export_values();
    midiControllerClass
-      .def("set_connection", [](MidiController& midicontroller, MidiMessageType messageType, int control, string controlPath, ControlType controlType, int value, int channel, int page)
+      .def("set_connection", [](MidiController& midicontroller, MidiMessageType messageType, int control, std::string controlPath, ControlType controlType, int value, int channel, int page)
       {
          ScriptModule::sMostRecentLineExecutedModule->SetContext();
          IUIControl* uicontrol = TheSynth->FindUIControl(controlPath.c_str());
@@ -456,7 +456,7 @@ PYBIND11_EMBEDDED_MODULE(midicontroller, m)
 
 PYBIND11_EMBEDDED_MODULE(linnstrument, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<LinnstrumentControl*>(TheSynth->FindModule(path));
@@ -488,7 +488,7 @@ PYBIND11_EMBEDDED_MODULE(linnstrument, m)
 
 PYBIND11_EMBEDDED_MODULE(osccontroller, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       MidiController* midicontroller = dynamic_cast<MidiController*>(TheSynth->FindModule(path));
@@ -507,7 +507,7 @@ PYBIND11_EMBEDDED_MODULE(osccontroller, m)
       }
    }, py::return_value_policy::reference);
    py::class_<OscController>(m, "osccontroller")
-      .def("add_control", [](OscController& osccontroller, string address, bool isFloat)
+      .def("add_control", [](OscController& osccontroller, std::string address, bool isFloat)
       {
          osccontroller.AddControl(address, isFloat);
       });
@@ -515,7 +515,7 @@ PYBIND11_EMBEDDED_MODULE(osccontroller, m)
 
 PYBIND11_EMBEDDED_MODULE(oscoutput, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<OSCOutput*>(TheSynth->FindModule(path));
@@ -524,15 +524,15 @@ PYBIND11_EMBEDDED_MODULE(oscoutput, m)
       return ret;
    }, py::return_value_policy::reference);
    py::class_<OSCOutput, IDrawableModule>(m, "oscoutput")
-      .def("send_float", [](OSCOutput& oscoutput, string address, float val)
+      .def("send_float", [](OSCOutput& oscoutput, std::string address, float val)
       {
          oscoutput.SendFloat(address, val);
       })
-      .def("send_int", [](OSCOutput& oscoutput, string address, int val)
+      .def("send_int", [](OSCOutput& oscoutput, std::string address, int val)
       {
          oscoutput.SendInt(address, val);
       })
-      .def("send_string", [](OSCOutput& oscoutput, string address, string val)
+      .def("send_string", [](OSCOutput& oscoutput, std::string address, std::string val)
       {
          oscoutput.SendString(address, val);
       });
@@ -540,15 +540,15 @@ PYBIND11_EMBEDDED_MODULE(oscoutput, m)
 
 namespace
 {
-   void StartEnvelope(EnvelopeModulator& envelope, double time, const vector< tuple<float,float> >& stages)
+   void StartEnvelope(EnvelopeModulator& envelope, double time, const std::vector< std::tuple<float,float> >& stages)
    {
       ::ADSR adsr;
       adsr.SetNumStages((int)stages.size());
       adsr.GetHasSustainStage() = false;
       for (int i=0; i<adsr.GetNumStages() && i<(int)stages.size(); ++i)
       {
-         adsr.GetStageData(i).time = get<0>(stages[i]);
-         adsr.GetStageData(i).target = get<1>(stages[i]);
+         adsr.GetStageData(i).time = std::get<0>(stages[i]);
+         adsr.GetStageData(i).target = std::get<1>(stages[i]);
       }
       envelope.Start(time, adsr);
    }
@@ -556,7 +556,7 @@ namespace
 
 PYBIND11_EMBEDDED_MODULE(envelope, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<EnvelopeModulator*>(TheSynth->FindModule(path));
@@ -565,12 +565,12 @@ PYBIND11_EMBEDDED_MODULE(envelope, m)
       return ret;
    }, py::return_value_policy::reference);
    py::class_<EnvelopeModulator, IDrawableModule>(m, "envelope")
-      .def("start", [](EnvelopeModulator& envelope, vector< tuple<float,float> > stages)
+      .def("start", [](EnvelopeModulator& envelope, std::vector< std::tuple<float,float> > stages)
       {
          double time = ScriptModule::sMostRecentLineExecutedModule->GetScheduledTime(0);
          StartEnvelope(envelope, time, stages);
       })
-      .def("schedule", [](EnvelopeModulator& envelope, float delay, vector< tuple<float,float> > stages)
+      .def("schedule", [](EnvelopeModulator& envelope, float delay, std::vector< std::tuple<float,float> > stages)
       {
          double time = ScriptModule::sMostRecentLineExecutedModule->GetScheduledTime(delay);
          StartEnvelope(envelope, time, stages);
@@ -579,7 +579,7 @@ PYBIND11_EMBEDDED_MODULE(envelope, m)
 
 PYBIND11_EMBEDDED_MODULE(drumplayer, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = dynamic_cast<DrumPlayer*>(TheSynth->FindModule(path));
@@ -596,7 +596,7 @@ PYBIND11_EMBEDDED_MODULE(drumplayer, m)
 
 PYBIND11_EMBEDDED_MODULE(module, m)
 {
-   m.def("get", [](string path)
+   m.def("get", [](std::string path)
    {
       ScriptModule::sMostRecentLineExecutedModule->SetContext();
       auto* ret = TheSynth->FindModule(path);
@@ -604,7 +604,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
       ScriptModule::sMostRecentLineExecutedModule->ClearContext();
       return ret;
    }, py::return_value_policy::reference);
-   m.def("create", [](string moduleType, int x, int y)
+   m.def("create", [](std::string moduleType, int x, int y)
    {
       return TheSynth->SpawnModuleOnTheFly(moduleType, x, y);
    }, py::return_value_policy::reference);
@@ -621,7 +621,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
       {
          module.GetOwningContainer()->DeleteModule(&module);
       })
-      .def("set", [](IDrawableModule& module, string path, float value)
+      .def("set", [](IDrawableModule& module, std::string path, float value)
       {
          ScriptModule::sMostRecentLineExecutedModule->SetContext();
          IUIControl* control = module.FindUIControl(path.c_str(), false);
@@ -631,7 +631,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
             control->SetValue(value);
          }
       })
-      .def("get", [](IDrawableModule& module, string path)
+      .def("get", [](IDrawableModule& module, std::string path)
       {
          ScriptModule::sMostRecentLineExecutedModule->SetContext();
          IUIControl* control = module.FindUIControl(path.c_str(), false);
@@ -640,7 +640,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
             return control->GetValue();
          return 0.0f;
       })
-      .def("adjust", [](IDrawableModule& module, string path, float amount)
+      .def("adjust", [](IDrawableModule& module, std::string path, float amount)
       {
          ScriptModule::sMostRecentLineExecutedModule->SetContext();
          IUIControl* control = module.FindUIControl(path.c_str(), false);

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -41,7 +41,7 @@ public:
    
    void Poll() override;
    
-   string GetTitleLabel() override { return "script status"; }
+   std::string GetTitleLabel() override { return "script status"; }
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;
@@ -63,7 +63,7 @@ private:
    
    ClickButton* mResetAll;
    
-   string mStatus;
+   std::string mStatus;
    double mNextUpdateTime;
    
    float mWidth;

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -254,7 +254,7 @@ float SeaOfGrain::GetSourceBufferOffset()
       return 0;
 }
 
-void SeaOfGrain::FilesDropped(vector<string> files, int x, int y)
+void SeaOfGrain::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mLoading = true;
    
@@ -314,7 +314,7 @@ void SeaOfGrain::LoadFile()
    {
       auto file = chooser.getResult();
 
-      vector<string> fileArray;
+      std::vector<std::string> fileArray;
       fileArray.push_back(file.getFullPathName().toStdString());
       FilesDropped(fileArray, 0, 0);
    }

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -47,7 +47,7 @@ public:
    ~SeaOfGrain();
    static IDrawableModule* Create() { return new SeaOfGrain(); }
    
-   string GetTitleLabel() override { return "sea of grain"; }
+   std::string GetTitleLabel() override { return "sea of grain"; }
    void CreateUIControls() override;
    
    //INoteReceiver
@@ -59,7 +59,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //IDrawableModule
-   void FilesDropped(vector<string> files, int x, int y) override;
+   void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
    void Poll() override;

--- a/Source/Selector.cpp
+++ b/Source/Selector.cpp
@@ -90,7 +90,7 @@ void Selector::SyncList()
    mSelector->Clear();
    for (int i=0; i<mControlCables.size()-1; ++i)
    {
-      string controlName = "";
+      std::string controlName = "";
       if (mControlCables[i]->GetTarget())
          controlName = mControlCables[i]->GetTarget()->Path();
       mSelector->AddLabel(controlName.c_str(), i);
@@ -151,7 +151,7 @@ void Selector::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["uicontrols"].resize((unsigned int)mControlCables.size()-1);
    for (int i=0; i<mControlCables.size()-1; ++i)
    {
-      string controlName = "";
+      std::string controlName = "";
       if (mControlCables[i]->GetTarget())
          controlName = mControlCables[i]->GetTarget()->Path();
       moduleInfo["uicontrols"][i] = controlName;
@@ -164,7 +164,7 @@ void Selector::LoadLayout(const ofxJSONElement& moduleInfo)
    
    for (int i=0; i<controls.size(); ++i)
    {
-      string controlPath = controls[i].asString();
+      std::string controlPath = controls[i].asString();
       IUIControl* control = nullptr;
       if (!controlPath.empty())
          control = TheSynth->FindUIControl(controlPath);

--- a/Source/Selector.h
+++ b/Source/Selector.h
@@ -39,7 +39,7 @@ public:
    ~Selector();
    static IDrawableModule* Create() { return new Selector(); }
    
-   string GetTitleLabel() override { return "selector"; }
+   std::string GetTitleLabel() override { return "selector"; }
    void CreateUIControls() override;
    
    void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
@@ -67,7 +67,7 @@ private:
    RadioButton* mSelector;
    int mCurrentValue;
    
-   vector<PatchCableSource*> mControlCables;
+   std::vector<PatchCableSource*> mControlCables;
 };
 
 

--- a/Source/SignalClamp.h
+++ b/Source/SignalClamp.h
@@ -39,7 +39,7 @@ public:
    virtual ~SignalClamp();
    static IDrawableModule* Create() { return new SignalClamp(); }
    
-   string GetTitleLabel() override { return "signal clamp"; }
+   std::string GetTitleLabel() override { return "signal clamp"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/SignalGenerator.h
+++ b/Source/SignalGenerator.h
@@ -45,7 +45,7 @@ public:
    ~SignalGenerator();
    static IDrawableModule* Create() { return new SignalGenerator(); }
    
-   string GetTitleLabel() override { return "sig gen"; }
+   std::string GetTitleLabel() override { return "sig gen"; }
    void CreateUIControls() override;
    
    void SetVol(float vol) { mVol = vol; }

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -217,7 +217,7 @@ void SingleOscillator::PlayNote(double time, int pitch, int velocity, int voiceI
    
    if (mDrawDebug)
    {
-      vector<string> lines = ofSplitString(mDebugLines, "\n");
+      std::vector<std::string> lines = ofSplitString(mDebugLines, "\n");
       mDebugLines = "";
       const int kNumDisplayLines = 10;
       for (int i=0; i<kNumDisplayLines-1; ++i)
@@ -226,7 +226,7 @@ void SingleOscillator::PlayNote(double time, int pitch, int velocity, int voiceI
          if (lineIndex >= 0)
             mDebugLines += lines[lineIndex] + "\n";
       }
-      string debugLine = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
+      std::string debugLine = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
       mDebugLines += debugLine;
       ofLog() << debugLine;
    }
@@ -327,7 +327,7 @@ void SingleOscillator::DrawModuleUnclipped()
    }
 }
 
-void SingleOscillator::UpdateOldControlName(string& oldName)
+void SingleOscillator::UpdateOldControlName(std::string& oldName)
 {
    IDrawableModule::UpdateOldControlName(oldName);
 

--- a/Source/SingleOscillator.h
+++ b/Source/SingleOscillator.h
@@ -49,7 +49,7 @@ public:
    ~SingleOscillator();
    static IDrawableModule* Create() { return new SingleOscillator(); }
    
-   string GetTitleLabel() override { return "oscillator"; }
+   std::string GetTitleLabel() override { return "oscillator"; }
    void CreateUIControls() override;
    
    void SetType(OscillatorType type) { mVoiceParams.mOscType = type; }
@@ -80,7 +80,7 @@ private:
    void DrawModuleUnclipped() override;
    void GetModuleDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    bool Enabled() const override { return mEnabled; }
-   void UpdateOldControlName(string& oldName) override;
+   void UpdateOldControlName(std::string& oldName) override;
    
    float mWidth;
    float mHeight;
@@ -116,7 +116,7 @@ private:
    
    Oscillator mDrawOsc;
    
-   string mDebugLines;
+   std::string mDebugLines;
 };
 
 

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -203,7 +203,7 @@ void FloatSlider::Render()
    
    DrawHover(mX,mY,mWidth,mHeight);
 
-   string display;
+   std::string display;
    float textSize = 15;
    if (AdjustSmooth())
    {
@@ -213,7 +213,7 @@ void FloatSlider::Render()
    else
    {
       if (mShowName)
-         display = string(Name());
+         display = std::string(Name());
       if (display.length() > 0) //only show a colon if there's a label
          display += ":";
       if (mFloatEntry)
@@ -592,7 +592,7 @@ float FloatSlider::GetMidiValue() const
    return ValToPos(*mVar, true);
 }
 
-string FloatSlider::GetDisplayValue(float val) const
+std::string FloatSlider::GetDisplayValue(float val) const
 {
    if (val == mMin && mMinValueDisplay != "")
       return mMinValueDisplay;
@@ -962,9 +962,9 @@ void IntSlider::Render()
    
    DrawHover(mX,mY,mWidth,mHeight);
 
-   string display;
+   std::string display;
    if (mShowName)
-      display = string(Name());
+      display = std::string(Name());
    if (display.length() > 0) //only show a colon if there's a label
       display += ":";
    if (mIntEntry)
@@ -1128,7 +1128,7 @@ float IntSlider::GetMidiValue() const
    return mSliderVal;
 }
 
-string IntSlider::GetDisplayValue(float val) const
+std::string IntSlider::GetDisplayValue(float val) const
 {
    return ofToString(val,0);
 }

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -64,8 +64,8 @@ public:
    void SetClamped(bool clamped) { mClamped = clamped; }
    float GetMin() const { return mMin; }
    float GetMax() const { return mMax; }
-   void SetMaxValueDisplay(string display) { mMaxValueDisplay = display; }
-   void SetMinValueDisplay(string display) { mMinValueDisplay = display; }
+   void SetMaxValueDisplay(std::string display) { mMaxValueDisplay = display; }
+   void SetMinValueDisplay(std::string display) { mMinValueDisplay = display; }
    void SetLFO(FloatSliderLFOControl* lfo);
    void SetShowName(bool show) { mShowName = show; }
    void SetDimensions(int w, int h) { mWidth = w; mHeight = h; }
@@ -89,7 +89,7 @@ public:
    float GetValueForMidiCC(float slider) const override;
    void SetValue(float value) override;
    float GetValue() const override;
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    float GetMidiValue() const override;
    void GetRange(float& min, float& max) override { min = mMin; max = mMax; }
    void Double() override;
@@ -140,8 +140,8 @@ private:
    bool mClamped;
    Mode mMode;
    float mOriginalValue;
-   string mMinValueDisplay;
-   string mMaxValueDisplay;
+   std::string mMinValueDisplay;
+   std::string mMaxValueDisplay;
    bool mShowName;
    float mBezierControl;
    float mSmooth;
@@ -198,7 +198,7 @@ public:
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return mMax - mMin + 1; }
-   string GetDisplayValue(float val) const override;
+   std::string GetDisplayValue(float val) const override;
    void GetRange(int& min, int& max) { min = mMin; max = mMax; }
    void Double() override;
    void Halve() override;

--- a/Source/SliderSequencer.h
+++ b/Source/SliderSequencer.h
@@ -67,7 +67,7 @@ public:
    ~SliderSequencer();
    static IDrawableModule* Create() { return new SliderSequencer(); }
    
-   string GetTitleLabel() override { return "slider sequencer"; }
+   std::string GetTitleLabel() override { return "slider sequencer"; }
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/SlowLayers.h
+++ b/Source/SlowLayers.h
@@ -43,7 +43,7 @@ public:
    virtual ~SlowLayers();
    static IDrawableModule* Create() { return new SlowLayers(); }
    
-   string GetTitleLabel() override { return "slow layers"; }
+   std::string GetTitleLabel() override { return "slow layers"; }
    void CreateUIControls() override;
    
    void Clear();

--- a/Source/SpectralDisplay.h
+++ b/Source/SpectralDisplay.h
@@ -41,7 +41,7 @@ public:
    virtual ~SpectralDisplay();
    static IDrawableModule* Create() { return new SpectralDisplay(); }
    
-   string GetTitleLabel() override { return "spectrum"; }
+   std::string GetTitleLabel() override { return "spectrum"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Splitter.h
+++ b/Source/Splitter.h
@@ -41,7 +41,7 @@ public:
    virtual ~Splitter();
    static IDrawableModule* Create() { return new Splitter(); }
    
-   string GetTitleLabel() override { return "splitter"; }
+   std::string GetTitleLabel() override { return "splitter"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -110,7 +110,7 @@ public:
    ~StepSequencer();
    static IDrawableModule* Create() { return new StepSequencer(); }
    
-   string GetTitleLabel() override { return "drum sequencer"; }
+   std::string GetTitleLabel() override { return "drum sequencer"; }
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/Stutter.h
+++ b/Source/Stutter.h
@@ -111,7 +111,7 @@ private:
    IntSlider* mSubdivideSlider;
    JumpBlender mJumpBlender[ChannelBuffer::kMaxNumChannels];
    int mNanopadScene;
-   list<StutterParams> mStutterStack;
+   std::list<StutterParams> mStutterStack;
    Ramp mStutterLengthRamp;
    bool mFadeStutter;
    Checkbox* mFadeCheckbox;

--- a/Source/StutterControl.h
+++ b/Source/StutterControl.h
@@ -43,7 +43,7 @@ public:
    ~StutterControl();
    static IDrawableModule* Create() { return new StutterControl(); }
    
-   string GetTitleLabel() override { return "stutter"; }
+   std::string GetTitleLabel() override { return "stutter"; }
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -37,7 +37,7 @@ public:
    SustainPedal();
    static IDrawableModule* Create() { return new SustainPedal(); }
    
-   string GetTitleLabel() override { return "sustain"; }
+   std::string GetTitleLabel() override { return "sustain"; }
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -276,11 +276,11 @@ void BufferCopy(float* dst, const float* src, int bufferSize)
 #endif
 }
 
-string NoteName(int pitch, bool flat, bool includeOctave)
+std::string NoteName(int pitch, bool flat, bool includeOctave)
 {
    int octave = pitch / 12;
    pitch %= 12;
-   string ret = "x";
+   std::string ret = "x";
    switch (pitch)
    {
       case 0:
@@ -332,7 +332,7 @@ string NoteName(int pitch, bool flat, bool includeOctave)
    return ret;
 }
 
-int PitchFromNoteName(string noteName)
+int PitchFromNoteName(std::string noteName)
 {
    int octave = -2;
    if (isdigit(noteName[noteName.length()-1]))
@@ -381,29 +381,29 @@ void FloatWrap(double& num, float space)
    num -= space * floor(num/space);
 }
 
-void DrawTextNormal(string text, int x, int y, float size)
+void DrawTextNormal(std::string text, int x, int y, float size)
 {
    gFont.DrawString(text, size, x, y);
 }
 
-void DrawTextLeftJustify(string text, int x, int y, float size)
+void DrawTextLeftJustify(std::string text, int x, int y, float size)
 {
    gFont.DrawString(text, size, x - gFont.GetStringWidth(text,size), y);
 }
 
-void DrawTextBold(string text, int x, int y, float size)
+void DrawTextBold(std::string text, int x, int y, float size)
 {
    gFontBold.DrawString(text, size, x, y);
 }
 
-float GetStringWidth(string text, float size)
+float GetStringWidth(std::string text, float size)
 {
    return gFont.GetStringWidth(text, size);
 }
 
 void AssertIfDenormal(float input)
 {
-   assert(input == 0 || input != input || fabsf(input) > numeric_limits<float>::min());
+   assert(input == 0 || input != input || fabsf(input) > std::numeric_limits<float>::min());
 }
 
 float GetInterpolatedSample(double offset, const float* buffer, int bufferSize)
@@ -448,9 +448,9 @@ void WriteInterpolatedSample(double offset, float* buffer, int bufferSize, float
    buffer[posNext] += a*sample;
 }
 
-string GetRomanNumeralForDegree(int degree)
+std::string GetRomanNumeralForDegree(int degree)
 {
-   string roman;
+   std::string roman;
    switch ((degree + 700) % 7)
    {
       case 0: roman = "I"; break;
@@ -470,7 +470,7 @@ void UpdateTarget(IDrawableModule* module)
    INoteSource* noteSource = dynamic_cast<INoteSource*>(module);
    IGridController* grid = dynamic_cast<IGridController*>(module);
    IPulseSource* pulseSource = dynamic_cast<IPulseSource*>(module);
-   string targetName = "";
+   std::string targetName = "";
    if (audioSource)
    {
       for (int i=0; i<audioSource->GetNumTargets(); ++i)
@@ -485,7 +485,7 @@ void UpdateTarget(IDrawableModule* module)
    {
       if (module->GetPatchCableSource())
       {
-         const vector<PatchCable*>& cables = module->GetPatchCableSource()->GetPatchCables();
+         const std::vector<PatchCable*>& cables = module->GetPatchCableSource()->GetPatchCables();
          for (int i=0; i<cables.size(); ++i)
          {
             PatchCable* cable = cables[i];
@@ -655,9 +655,9 @@ bool IsInUnitBox(ofVec2f pos)
    return pos.x >= 0 && pos.x < 1 && pos.y >= 0 && pos.y < 1;
 }
 
-string GetUniqueName(string name, vector<IDrawableModule*> existing)
+std::string GetUniqueName(std::string name, std::vector<IDrawableModule*> existing)
 {
-   string origName = name;
+   std::string origName = name;
    while (origName.length() > 1 && CharacterFunctions::isDigit((char)origName[origName.length()-1]))
       origName.resize(origName.length()-1);
    int suffix = 1;
@@ -681,9 +681,9 @@ string GetUniqueName(string name, vector<IDrawableModule*> existing)
    return name;
 }
 
-string GetUniqueName(string name, vector<string> existing)
+std::string GetUniqueName(std::string name, std::vector<std::string> existing)
 {
-   string origName = name;
+   std::string origName = name;
    int suffix = 1;
    while (true)
    {
@@ -1364,7 +1364,7 @@ void DrawFallbackText(const char* text, float posX, float posY)
    }
 }
 
-bool EvaluateExpression(string expressionStr, float currentValue, float& output)
+bool EvaluateExpression(std::string expressionStr, float currentValue, float& output)
 {
    exprtk::symbol_table<float> symbolTable;
    exprtk::expression<float> expression;
@@ -1394,7 +1394,7 @@ bool EvaluateExpression(string expressionStr, float currentValue, float& output)
 
 ofLog::~ofLog()
 {
-   string output = ofToString(gTime / 1000) + ": " + mMessage;
+   std::string output = ofToString(gTime / 1000) + ": " + mMessage;
    DBG(output);
    if (mSendToBespokeConsole)
       TheSynth->LogEvent(output, kLogEventType_Verbose);

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -70,14 +70,12 @@ void* operator new[](std::size_t size, const char *file, int line) throw(std::ba
 //avoid "unused variable" warnings
 #define UNUSED(x) ((void) x)
 
-using namespace std;
-
 class IUIControl;
 class IDrawableModule;
 class RollingBuffer;
 class ChannelBuffer;
 
-typedef map<string,int> EnumMap;
+typedef std::map<std::string,int> EnumMap;
 
 const int kWorkBufferSize = 1024*8; //larger than the audio buffer size would ever be (even oversampled)
 
@@ -133,20 +131,20 @@ enum KeyModifiers
    kModifier_Command = 8
 };
 
-class LoadingJSONException : public exception {};
-class UnknownModuleException : public exception
+class LoadingJSONException : public std::exception {};
+class UnknownModuleException : public std::exception
 {
 public:
-   UnknownModuleException(string searchName)
+   UnknownModuleException(std::string searchName)
    : mSearchName(searchName) {}
    ~UnknownModuleException() throw() {}
-   string mSearchName;
+   std::string mSearchName;
 };
-class UnknownEffectTypeException : public exception {};
-class BadUIControlPathException : public exception {};
-class UnknownUIControlException : public exception {};
-class WrongModuleTypeException : public exception {};
-class LoadStateException : public exception {};
+class UnknownEffectTypeException : public std::exception {};
+class BadUIControlPathException : public std::exception {};
+class UnknownUIControlException : public std::exception {};
+class WrongModuleTypeException : public std::exception {};
+class LoadStateException : public std::exception {};
 
 void SynthInit();
 void LoadGlobalResources();
@@ -160,21 +158,21 @@ void Mult(float* buff, float val, int bufferSize);
 void Mult(float* buff1, const float* buff2, int bufferSize);
 void Clear(float* buffer, int bufferSize);
 void BufferCopy(float* dst, const float* src, int bufferSize);
-string NoteName(int pitch, bool flat=false, bool includeOctave = false);
-int PitchFromNoteName(string noteName);
+std::string NoteName(int pitch, bool flat=false, bool includeOctave = false);
+int PitchFromNoteName(std::string noteName);
 float Interp(float a, float start, float end);
 double GetPhaseInc(float freq);
 void FloatWrap(float& num, float space);
 void FloatWrap(double& num, float space);
-void DrawTextNormal(string text, int x, int y, float size = 15);
-void DrawTextLeftJustify(string text, int x, int y, float size = 15);
-void DrawTextBold(string text, int x, int y, float size = 15);
-float GetStringWidth(string text, float size = 15);
+void DrawTextNormal(std::string text, int x, int y, float size = 15);
+void DrawTextLeftJustify(std::string text, int x, int y, float size = 15);
+void DrawTextBold(std::string text, int x, int y, float size = 15);
+float GetStringWidth(std::string text, float size = 15);
 void AssertIfDenormal(float input);
 float GetInterpolatedSample(double offset, const float* buffer, int bufferSize);
 float GetInterpolatedSample(double offset, ChannelBuffer* buffer, int bufferSize, float channelBlend);
 void WriteInterpolatedSample(double offset, float* buffer, int bufferSize, float sample);
-string GetRomanNumeralForDegree(int degree);
+std::string GetRomanNumeralForDegree(int degree);
 void UpdateTarget(IDrawableModule* module);
 void DrawLissajous(RollingBuffer* buffer, float x, float y, float w, float h, float r = .2f, float g = .7f, float b = .2f);
 void StringCopy(char* dest, const char* source, int destLength);
@@ -187,8 +185,8 @@ float Bias(float value, float bias);
 float Pow2(float in);
 void PrintCallstack();
 bool IsInUnitBox(ofVec2f pos);
-string GetUniqueName(string name, vector<IDrawableModule*> existing);
-string GetUniqueName(string name, vector<string> existing);
+std::string GetUniqueName(std::string name, std::vector<IDrawableModule*> existing);
+std::string GetUniqueName(std::string name, std::vector<std::string> existing);
 void SetMemoryTrackingEnabled(bool enabled);
 void DumpUnfreedMemory();
 float DistSqToLine(ofVec2f point, ofVec2f a, ofVec2f b);
@@ -197,14 +195,14 @@ void LoadStateValidate(bool assertion);
 float GetLeftPanGain(float pan);
 float GetRightPanGain(float pan);
 void DrawFallbackText(const char* text, float posX, float posY);
-bool EvaluateExpression(string expression, float currentValue, float& output);
+bool EvaluateExpression(std::string expression, float currentValue, float& output);
 
 inline static float RandomSample()
 {
    return (float(gRandom())/gRandom.max()) * 2.0f - 1.0f;
 }
 
-inline static string GetPathSeparator()
+inline static std::string GetPathSeparator()
 {
 #if BESPOKE_WINDOWS
    return "\\";
@@ -275,6 +273,6 @@ public:
       return *this;
    }
 private:
-   string mMessage;
+   std::string mMessage;
    bool mSendToBespokeConsole;
 };

--- a/Source/TakeRecorder.h
+++ b/Source/TakeRecorder.h
@@ -41,7 +41,7 @@ public:
    virtual ~TakeRecorder();
    static IDrawableModule* Create() { return new TakeRecorder(); }
    
-   string GetTitleLabel() override { return "take recorder"; }
+   std::string GetTitleLabel() override { return "take recorder"; }
    void CreateUIControls() override;
    
    //IAudioProcessor

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -53,7 +53,7 @@ TextEntry::TextEntry(ITextEntryListener* owner, const char* name, int x, int y, 
    Construct(owner, name, x, y, charWidth);
 }
 
-TextEntry::TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, string* var)
+TextEntry::TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, std::string* var)
 : mVarCString(nullptr)
 , mVarString(var)
 , mVarInt(nullptr)
@@ -302,7 +302,7 @@ void TextEntry::RemoveSelectedText()
 {
    int caretStart = MAX(0, MIN(mCaretPosition, mCaretPosition2));
    int caretEnd = MIN(strlen(mString), MAX(mCaretPosition, mCaretPosition2));
-   string newString = mString;
+   std::string newString = mString;
    strcpy(mString, (newString.substr(0, caretStart) + newString.substr(caretEnd)).c_str());
    MoveCaret(caretStart, false);
 }
@@ -432,7 +432,7 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
          RemoveSelectedText();
       juce::String clipboard = TheSynth->GetTextFromClipboard();
       
-      string newString = mString;
+      std::string newString = mString;
       strcpy(mString, (newString.substr(0, mCaretPosition) + clipboard.toStdString() + newString.substr(mCaretPosition)).c_str());
       MoveCaret(mCaretPosition + clipboard.length());
    }
@@ -442,7 +442,7 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
       {
          int caretStart = MIN(mCaretPosition, mCaretPosition2);
          int caretEnd = MAX(mCaretPosition, mCaretPosition2);
-         string tmpString(mString);
+         std::string tmpString(mString);
          TheSynth->CopyTextToClipboard(tmpString.substr(caretStart,caretEnd-caretStart));
          
          if (toupper(key) == 'X')
@@ -622,7 +622,7 @@ void TextEntry::SaveState(FileStreamOut& out)
 {
    out << kSaveStateRev;
    
-   out << string(mString);
+   out << std::string(mString);
 }
 
 void TextEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
@@ -631,7 +631,7 @@ void TextEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
    in >> rev;
    LoadStateValidate(rev == kSaveStateRev);
    
-   string var;
+   std::string var;
    in >> var;
    StringCopy(mString, var.c_str(), MAX_TEXTENTRY_LENGTH);
    AcceptEntry(false);

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -70,7 +70,7 @@ class TextEntry : public IUIControl, public IKeyboardFocusListener
 {
 public:
    TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, char* var);
-   TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, string* var);
+   TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, std::string* var);
    TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, int* var, int min, int max);
    TextEntry(ITextEntryListener* owner, const char* name, int x, int y, int charWidth, float* var, float min, float max);
    void OnKeyPressed(int key, bool isRepeat) override;
@@ -118,7 +118,7 @@ private:
    ITextEntryListener* mListener;
    char mString[MAX_TEXTENTRY_LENGTH];
    char* mVarCString;
-   string* mVarString;
+   std::string* mVarString;
    int* mVarInt;
    float* mVarFloat;
    int mIntMin;

--- a/Source/TimelineControl.h
+++ b/Source/TimelineControl.h
@@ -37,7 +37,7 @@ public:
    ~TimelineControl();
    static IDrawableModule* Create() { return new TimelineControl(); }
    
-   string GetTitleLabel() override { return "timeline control"; }
+   std::string GetTitleLabel() override { return "timeline control"; }
    void CreateUIControls() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/TimerDisplay.cpp
+++ b/Source/TimerDisplay.cpp
@@ -60,11 +60,11 @@ void TimerDisplay::DrawModule()
    int mins = secs / 60;
    secs %= 60;
    
-   string zeroPadMins = "";
+   std::string zeroPadMins = "";
    if (mins < 10)
       zeroPadMins = "0";
    
-   string zeroPadSecs = "";
+   std::string zeroPadSecs = "";
    if (secs < 10)
       zeroPadSecs = "0";
    

--- a/Source/TimerDisplay.h
+++ b/Source/TimerDisplay.h
@@ -38,7 +38,7 @@ public:
    ~TimerDisplay();
    static IDrawableModule* Create() { return new TimerDisplay(); }
    
-   string GetTitleLabel() override { return "timer"; }
+   std::string GetTitleLabel() override { return "timer"; }
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -44,10 +44,10 @@ bool TitleBar::sShowInitialHelpOverlay = true;
 
 namespace
 {
-   const string kRescanPluginsLabel = "rescan VSTs...";
+   const std::string kRescanPluginsLabel = "rescan VSTs...";
 }
 
-SpawnList::SpawnList(IDropdownListener* owner, SpawnListManager* listManager, int x, int y, string label)
+SpawnList::SpawnList(IDropdownListener* owner, SpawnListManager* listManager, int x, int y, std::string label)
 : mLabel(label)
 , mSpawnIndex(-1)
 , mSpawnList(nullptr)
@@ -57,7 +57,7 @@ SpawnList::SpawnList(IDropdownListener* owner, SpawnListManager* listManager, in
 {
 }
 
-void SpawnList::SetList(vector<string> spawnables, string overrideModuleType)
+void SpawnList::SetList(std::vector<std::string> spawnables, std::string overrideModuleType)
 {
    mOverrideModuleType = overrideModuleType;
    if (mSpawnList == nullptr)
@@ -69,7 +69,7 @@ void SpawnList::SetList(vector<string> spawnables, string overrideModuleType)
    mSpawnables = spawnables;
    for (int i=0; i<mSpawnables.size(); ++i)
    {
-      string name = mSpawnables[i].c_str();
+      std::string name = mSpawnables[i].c_str();
       if (mOverrideModuleType == "" && TheSynth->GetModuleFactory()->IsExperimental(name))
          name += " (exp.)";
       if (mOverrideModuleType == "vstplugin" && name != kRescanPluginsLabel)
@@ -96,7 +96,7 @@ void SpawnList::OnSelection(DropdownList* list)
 
 IDrawableModule* SpawnList::Spawn()
 {
-   string moduleType = mSpawnables[mSpawnIndex];
+   std::string moduleType = mSpawnables[mSpawnIndex];
    if (mOverrideModuleType != "")
       moduleType = mOverrideModuleType;
 
@@ -238,7 +238,7 @@ void SpawnListManager::SetModuleFactory(ModuleFactory* factory)
    
    SetUpVstDropdown(false);
    
-   vector<string> prefabs;
+   std::vector<std::string> prefabs;
    ModuleFactory::GetPrefabs(prefabs);
    mPrefabs.SetList(prefabs, "prefab");
    
@@ -255,7 +255,7 @@ void SpawnListManager::SetModuleFactory(ModuleFactory* factory)
 
 void SpawnListManager::SetUpVstDropdown(bool rescan)
 {
-   vector<string> vsts;
+   std::vector<std::string> vsts;
    VSTLookup::GetAvailableVSTs(vsts, rescan);
    vsts.push_back(kRescanPluginsLabel);
    mVstPlugins.SetList(vsts, "vstplugin");
@@ -323,9 +323,9 @@ void TitleBar::DrawModule()
    DrawTextBold("bespoke", 2, 28, 36);
    ofPopStyle();
    
-   string info;
+   std::string info;
    if (TheSynth->GetMoveModule())
-      info += " (moving module \"" + string(TheSynth->GetMoveModule()->Name()) + "\")";
+      info += " (moving module \"" + std::string(TheSynth->GetMoveModule()->Name()) + "\")";
    if (IKeyboardFocusListener::GetActiveKeyboardFocus())
       info += " (entering text)";
 
@@ -357,7 +357,7 @@ void TitleBar::DrawModule()
 
    float x = startX;
    float y = startY;
-   array<SpawnList*, 9> lists = { &mSpawnLists.mInstrumentModules,
+   std::array<SpawnList*, 9> lists = { &mSpawnLists.mInstrumentModules,
                                   &mSpawnLists.mNoteModules,
                                   &mSpawnLists.mSynthModules,
                                   &mSpawnLists.mAudioModules,
@@ -404,7 +404,7 @@ void TitleBar::DrawModule()
    mModuleType = type;
    
    float usage = TheSynth->GetAudioDeviceManager().getCpuUsage();
-   string stats;
+   std::string stats;
    stats += "fps:" + ofToString(ofGetFrameRate(),0);
    stats += "  audio cpu:" + ofToString(usage * 100,1);
    if (usage > 1)
@@ -444,7 +444,7 @@ void TitleBar::DrawModuleUnclipped()
       TheTitleBar->GetDimensions(titleBarWidth, titleBarHeight);
       float x = 100;
       float y = 40 + titleBarHeight;
-      string filename = juce::File(TheSynth->GetLastSavePath()).getFileName().toStdString();
+      std::string filename = juce::File(TheSynth->GetLastSavePath()).getFileName().toStdString();
       gFontBold.DrawString("saved "+filename, 50, x, y);
       ofPopStyle();
    }
@@ -456,7 +456,7 @@ void TitleBar::DrawModuleUnclipped()
    {
       ofPushStyle();
       ofSetColor(255, 255, 255);
-      string text = "click ? to view help and toggle tooltips";
+      std::string text = "click ? to view help and toggle tooltips";
       float size = 28;
       float titleBarWidth, titleBarHeight;
       TheTitleBar->GetDimensions(titleBarWidth, titleBarHeight);
@@ -503,7 +503,7 @@ void TitleBar::DropdownUpdated(DropdownList* list, int oldVal)
 {
    if (list == mLoadLayoutDropdown)
    {
-      string layout = mLoadLayoutDropdown->GetLabel(mLoadLayoutIndex);
+      std::string layout = mLoadLayoutDropdown->GetLabel(mLoadLayoutIndex);
       TheSynth->LoadLayoutFromFile(ofToDataPath("layouts/"+layout+".json"));
       return;
    }

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -40,8 +40,8 @@ struct SpawnListManager;
 class SpawnList
 {
 public:
-   SpawnList(IDropdownListener* owner, SpawnListManager* listManager, int x, int y, string label);
-   void SetList(vector<string> spawnables, string overrideModuleType);
+   SpawnList(IDropdownListener* owner, SpawnListManager* listManager, int x, int y, std::string label);
+   void SetList(std::vector<std::string> spawnables, std::string overrideModuleType);
    void OnSelection(DropdownList* list);
    void SetPosition(int x, int y);
    void SetPositionRelativeTo(SpawnList* list);
@@ -50,14 +50,14 @@ public:
    IDrawableModule* Spawn();
    
 private:
-   string mLabel;
-   std::vector<string> mSpawnables;
+   std::string mLabel;
+   std::vector<std::string> mSpawnables;
    int mSpawnIndex;
    DropdownList* mSpawnList;
    IDropdownListener* mOwner;
    SpawnListManager* mListManager;
    ofVec2f mPos;
-   string mOverrideModuleType;
+   std::string mOverrideModuleType;
 };
 
 struct SpawnListManager
@@ -66,7 +66,7 @@ struct SpawnListManager
    
    void SetModuleFactory(ModuleFactory* factory);
    void SetUpVstDropdown(bool rescan);
-   vector<SpawnList*> GetDropdowns() { return mDropdowns; }
+   std::vector<SpawnList*> GetDropdowns() { return mDropdowns; }
    
    SpawnList mInstrumentModules;
    SpawnList mNoteModules;
@@ -79,7 +79,7 @@ struct SpawnListManager
    SpawnList mPrefabs;
    
 private:
-   vector<SpawnList*> mDropdowns;
+   std::vector<SpawnList*> mDropdowns;
 };
 
 class TitleBar : public IDrawableModule, public IDropdownListener, public IButtonListener, public IFloatSliderListener
@@ -88,7 +88,7 @@ public:
    TitleBar();
    ~TitleBar();
    
-   string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() override { return ""; }
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
    bool AlwaysOnTop() override { return true; }

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -139,7 +139,7 @@ void Transport::Advance(double ms)
 
    UpdateListeners(ms);
 
-   for (list<IAudioPoller*>::iterator i = mAudioPollers.begin(); i != mAudioPollers.end(); ++i)
+   for (std::list<IAudioPoller*>::iterator i = mAudioPollers.begin(); i != mAudioPollers.end(); ++i)
    {
       IAudioPoller* poller = *i;
       poller->OnTransportAdvanced(amount);
@@ -200,7 +200,7 @@ void Transport::DrawModule()
    double measurePos = GetMeasurePos(gTime);
    
    int count = int(fmod(mMeasureTime,1)*mTimeSigTop) + 1;
-   string display;
+   std::string display;
    display += ofToString(measurePos,2)+" "+ofToString(GetMeasure(gTime))+"\n";
    display += ofToString(count);
    DrawTextNormal(display,5,52);
@@ -288,7 +288,7 @@ TransportListenerInfo* Transport::AddListener(ITimeListener* listener, NoteInter
 
 TransportListenerInfo* Transport::GetListenerInfo(ITimeListener* listener)
 {
-   for (list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
+   for (std::list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
    {
       TransportListenerInfo& info = *i;
       if (info.mListener == listener)
@@ -299,7 +299,7 @@ TransportListenerInfo* Transport::GetListenerInfo(ITimeListener* listener)
 
 void Transport::RemoveListener(ITimeListener* listener)
 {
-   for (list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end();)
+   for (std::list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end();)
    {
       TransportListenerInfo& info = *i;
       if (info.mListener == listener)
@@ -546,7 +546,7 @@ double Transport::GetMeasureFraction(NoteInterval interval)
 
 void Transport::UpdateListeners(double jumpMs)
 {
-   for (list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
+   for (std::list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
    {
       const TransportListenerInfo& info = *i;
       if (info.mInterval != kInterval_None &&
@@ -582,7 +582,7 @@ void Transport::UpdateListeners(double jumpMs)
 
 void Transport::OnDrumEvent(NoteInterval drumEvent)
 {
-   for (list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
+   for (std::list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
    {
       const TransportListenerInfo& info = *i;
       if (info.mInterval == drumEvent)

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -95,7 +95,7 @@ class Transport : public IDrawableModule, public IButtonListener, public IFloatS
 public:
    Transport();
    
-   string GetTitleLabel() override { return "transport"; }
+   std::string GetTitleLabel() override { return "transport"; }
    void CreateUIControls() override;
 
    float GetTempo() { return mTempo; }
@@ -185,8 +185,8 @@ private:
    int mLoopStartMeasure;
    int mLoopEndMeasure;
 
-   list<TransportListenerInfo> mListeners;
-   list<IAudioPoller*> mAudioPollers;
+   std::list<TransportListenerInfo> mListeners;
+   std::list<IAudioPoller*> mAudioPollers;
 };
 
 extern Transport* TheTransport;

--- a/Source/TransposeFrom.h
+++ b/Source/TransposeFrom.h
@@ -41,7 +41,7 @@ public:
    virtual ~TransposeFrom();
    static IDrawableModule* Create() { return new TransposeFrom(); }
    
-   string GetTitleLabel() override { return "transpose from"; }
+   std::string GetTitleLabel() override { return "transpose from"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -40,14 +40,14 @@ public:
    
    static IAudioEffect* Create() { return new TremoloEffect(); }
    
-   string GetTitleLabel() override { return "tremolo"; }
+   std::string GetTitleLabel() override { return "tremolo"; }
    void CreateUIControls() override;
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    float GetEffectAmount() override;
-   string GetType() override { return "tremolo"; }
+   std::string GetType() override { return "tremolo"; }
 
    //IDropdownListener
    void DropdownUpdated(DropdownList* list, int oldVal) override;

--- a/Source/UnstableModWheel.h
+++ b/Source/UnstableModWheel.h
@@ -41,7 +41,7 @@ public:
    virtual ~UnstableModWheel();
    static IDrawableModule* Create() { return new UnstableModWheel(); }
 
-   string GetTitleLabel() override { return "unstable modwheel"; }
+   std::string GetTitleLabel() override { return "unstable modwheel"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UnstablePitch.h
+++ b/Source/UnstablePitch.h
@@ -63,7 +63,7 @@ public:
    virtual ~UnstablePitch();
    static IDrawableModule* Create() { return new UnstablePitch(); }
 
-   string GetTitleLabel() override { return "unstable pitch"; }
+   std::string GetTitleLabel() override { return "unstable pitch"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UnstablePressure.h
+++ b/Source/UnstablePressure.h
@@ -41,7 +41,7 @@ public:
    virtual ~UnstablePressure();
    static IDrawableModule* Create() { return new UnstablePressure(); }
 
-   string GetTitleLabel() override { return "unstable pressure"; }
+   std::string GetTitleLabel() override { return "unstable pressure"; }
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UserData.cpp
+++ b/Source/UserData.cpp
@@ -3,7 +3,7 @@
 
 #include "juce_core/juce_core.h"
 
-void UpdateUserData(string destDirPath)
+void UpdateUserData(std::string destDirPath)
 {
    juce::File bundledDataDir(ofToResourcePath("userdata_original"));
    juce::File destDataDir(destDirPath);

--- a/Source/UserData.h
+++ b/Source/UserData.h
@@ -2,4 +2,4 @@
 
 #include "SynthGlobals.h"
 
-void UpdateUserData(string destDirPath);
+void UpdateUserData(std::string destDirPath);

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -210,7 +210,7 @@ void UserPrefsEditor::Show()
    UpdateDropdowns({});
 }
 
-void UserPrefsEditor::UpdateDropdowns(vector<DropdownList*> toUpdate)
+void UserPrefsEditor::UpdateDropdowns(std::vector<DropdownList*> toUpdate)
 {
    auto& deviceManager = TheSynth->GetAudioDeviceManager();
 
@@ -393,7 +393,7 @@ void UserPrefsEditor::DrawModule()
    DrawRightLabel(mRecordingsPathEntry, "(default: recordings/)", ofColor::white);
 }
 
-void UserPrefsEditor::DrawRightLabel(IUIControl* control, string text, ofColor color)
+void UserPrefsEditor::DrawRightLabel(IUIControl* control, std::string text, ofColor color)
 {
    ofRectangle rect = control->GetRect(true);
    ofPushStyle();
@@ -409,52 +409,52 @@ void UserPrefsEditor::PrepareForSave()
 
 namespace
 {
-   string ToStringLeadingZeroes(int number) {
+   std::string ToStringLeadingZeroes(int number) {
       char buffer[9];
       snprintf(buffer, sizeof(buffer), "%08d", number);
       return buffer;
    }
 }
 
-void UserPrefsEditor::UpdatePrefStr(ofxJSONElement& userPrefs, string prefName, string value)
+void UserPrefsEditor::UpdatePrefStr(ofxJSONElement& userPrefs, std::string prefName, std::string value)
 {
    userPrefs.removeMember(prefName);
    userPrefs["**"+ ToStringLeadingZeroes(mSavePrefIndex) + "**"+prefName] = value;
    ++mSavePrefIndex;
 }
 
-void UserPrefsEditor::UpdatePrefStrArray(ofxJSONElement& userPrefs, string prefName, vector<string> value)
+void UserPrefsEditor::UpdatePrefStrArray(ofxJSONElement& userPrefs, std::string prefName, std::vector<std::string> value)
 {
    userPrefs.removeMember(prefName);
    ofxJSONElement strArray;
-   for (string str : value)
+   for (std::string str : value)
       strArray.append(str);
    userPrefs["**"+ ToStringLeadingZeroes(mSavePrefIndex) + "**"+prefName] = strArray;
    ++mSavePrefIndex;
 }
 
-void UserPrefsEditor::UpdatePrefInt(ofxJSONElement& userPrefs, string prefName, int value)
+void UserPrefsEditor::UpdatePrefInt(ofxJSONElement& userPrefs, std::string prefName, int value)
 {
    userPrefs.removeMember(prefName);
    userPrefs["**" + ToStringLeadingZeroes(mSavePrefIndex) + "**" + prefName] = value;
    ++mSavePrefIndex;
 }
 
-void UserPrefsEditor::UpdatePrefFloat(ofxJSONElement& userPrefs, string prefName, float value)
+void UserPrefsEditor::UpdatePrefFloat(ofxJSONElement& userPrefs, std::string prefName, float value)
 {
    userPrefs.removeMember(prefName);
    userPrefs["**" + ToStringLeadingZeroes(mSavePrefIndex) + "**" + prefName] = value;
    ++mSavePrefIndex;
 }
 
-void UserPrefsEditor::UpdatePrefBool(ofxJSONElement& userPrefs, string prefName, bool value)
+void UserPrefsEditor::UpdatePrefBool(ofxJSONElement& userPrefs, std::string prefName, bool value)
 {
    userPrefs.removeMember(prefName);
    userPrefs["**" + ToStringLeadingZeroes(mSavePrefIndex) + "**" + prefName] = value;
    ++mSavePrefIndex;
 }
 
-void UserPrefsEditor::CleanUpSave(string& json)
+void UserPrefsEditor::CleanUpSave(std::string& json)
 {
    for (int i = 0; i < mSavePrefIndex; ++i)
    {
@@ -500,12 +500,12 @@ void UserPrefsEditor::ButtonClicked(ClickButton* button)
       UpdatePrefStr(userPrefs, "layout", mDefaultLayoutPath);
       UpdatePrefStr(userPrefs, "youtube-dl_path", mYoutubeDlPath);
       UpdatePrefStr(userPrefs, "ffmpeg_path", mFfmpegPath);
-      string vstSearchDirs = mVstSearchDirs;
+      std::string vstSearchDirs = mVstSearchDirs;
       ofStringReplace(vstSearchDirs, ", ", ",");
       UpdatePrefStrArray(userPrefs, "vstsearchdirs", ofSplitString(vstSearchDirs, ","));
       UpdatePrefBool(userPrefs, "show_tooltips_on_load", mShowTooltipsOnLoad);
 
-      string output = userPrefs.getRawString(true);
+      std::string output = userPrefs.getRawString(true);
       CleanUpSave(output);
 
       juce::File file(TheSynth->GetUserPrefsPath(false));

--- a/Source/UserPrefsEditor.h
+++ b/Source/UserPrefsEditor.h
@@ -41,7 +41,7 @@ public:
    static IDrawableModule* Create() { return new UserPrefsEditor(); }
 
    void CreateUIControls() override;
-   string GetTitleLabel() override { return "settings"; }
+   std::string GetTitleLabel() override { return "settings"; }
    bool AlwaysOnTop() override { return true; }
    bool CanMinimize() override { return false; }
    bool IsSingleton() const override { return true; }
@@ -63,15 +63,15 @@ private:
    bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
 
-   void UpdateDropdowns(vector<DropdownList*> toUpdate);
-   void DrawRightLabel(IUIControl* control, string text, ofColor color);
+   void UpdateDropdowns(std::vector<DropdownList*> toUpdate);
+   void DrawRightLabel(IUIControl* control, std::string text, ofColor color);
    void PrepareForSave();
-   void UpdatePrefStr(ofxJSONElement& userPrefs, string prefName, string value);
-   void UpdatePrefStrArray(ofxJSONElement& userPrefs, string prefName, vector<string> value);
-   void UpdatePrefInt(ofxJSONElement& userPrefs, string prefName, int value);
-   void UpdatePrefFloat(ofxJSONElement& userPrefs, string prefName, float value);
-   void UpdatePrefBool(ofxJSONElement& userPrefs, string prefName, bool value);
-   void CleanUpSave(string& json);
+   void UpdatePrefStr(ofxJSONElement& userPrefs, std::string prefName, std::string value);
+   void UpdatePrefStrArray(ofxJSONElement& userPrefs, std::string prefName, std::vector<std::string> value);
+   void UpdatePrefInt(ofxJSONElement& userPrefs, std::string prefName, int value);
+   void UpdatePrefFloat(ofxJSONElement& userPrefs, std::string prefName, float value);
+   void UpdatePrefBool(ofxJSONElement& userPrefs, std::string prefName, bool value);
+   void CleanUpSave(std::string& json);
 
    DropdownList* mDeviceTypeDropdown;
    int mDeviceTypeIndex;
@@ -104,19 +104,19 @@ private:
    Checkbox* mAutosaveCheckbox;
    bool mAutosave;
    TextEntry* mRecordingsPathEntry;
-   string mRecordingsPath;
+   std::string mRecordingsPath;
    TextEntry* mRecordBufferLengthEntry;
    float mRecordBufferLengthMinutes;
    TextEntry* mTooltipsFilePathEntry;
-   string mTooltipsFilePath;
+   std::string mTooltipsFilePath;
    TextEntry* mDefaultLayoutPathEntry;
-   string mDefaultLayoutPath;
+   std::string mDefaultLayoutPath;
    TextEntry* mYoutubeDlPathEntry;
-   string mYoutubeDlPath;
+   std::string mYoutubeDlPath;
    TextEntry* mFfmpegPathEntry;
-   string mFfmpegPath;
+   std::string mFfmpegPath;
    TextEntry* mVstSearchDirsEntry;
-   string mVstSearchDirs;
+   std::string mVstSearchDirs;
    Checkbox* mShowTooltipsOnLoadCheckbox;
    bool mShowTooltipsOnLoad;
    ClickButton* mSaveButton;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -61,7 +61,7 @@ namespace VSTLookup
    static juce::AudioPluginFormatManager sFormatManager;
    static juce::KnownPluginList sPluginList;
    
-   void GetAvailableVSTs(vector<string>& vsts, bool rescan)
+   void GetAvailableVSTs(std::vector<std::string>& vsts, bool rescan)
    {
       static bool sFirstTime = true;
       if (sFirstTime)
@@ -102,7 +102,7 @@ namespace VSTLookup
          vsts.push_back(types[i].fileOrIdentifier.toStdString());
       }
       
-      std::map<string, double> lastUsedTimes;
+      std::map<std::string, double> lastUsedTimes;
       
       if (juce::File(ofToDataPath("vst/used_vsts.json")).existsAsFile())
       {
@@ -112,12 +112,12 @@ namespace VSTLookup
 
          for (auto it = jsonList.begin(); it != jsonList.end(); ++it)
          {
-            string key = it.key().asString();
+            std::string key = it.key().asString();
             lastUsedTimes[key] = jsonList[key].asDouble();
          }
       }
       
-      std::sort(vsts.begin(), vsts.end(), [lastUsedTimes](string a, string b) {
+      std::sort(vsts.begin(), vsts.end(), [lastUsedTimes](std::string a, std::string b) {
          auto itA = lastUsedTimes.find(a);
          auto itB = lastUsedTimes.find(b);
          if (itA == lastUsedTimes.end() && itB == lastUsedTimes.end())
@@ -137,13 +137,13 @@ namespace VSTLookup
    void FillVSTList(DropdownList* list)
    {
       assert(list);
-      vector<string> vsts;
+      std::vector<std::string> vsts;
       GetAvailableVSTs(vsts, false);
       for (int i=0; i<vsts.size(); ++i)
          list->AddLabel(vsts[i].c_str(), i);
    }
    
-   string GetVSTPath(string vstName)
+   std::string GetVSTPath(std::string vstName)
    {
       if (juce::String(vstName).contains("/") || juce::String(vstName).contains("\\"))  //already a path
          return vstName;
@@ -223,12 +223,12 @@ void VSTPlugin::Exit()
    }
 }
 
-string VSTPlugin::GetTitleLabel()
+std::string VSTPlugin::GetTitleLabel()
 {
    return "vst: "+GetPluginName();
 }
 
-string VSTPlugin::GetPluginName()
+std::string VSTPlugin::GetPluginName()
 {
    if (mPlugin)
       return mPluginName;
@@ -237,7 +237,7 @@ string VSTPlugin::GetPluginName()
    return "no plugin loaded";
 }
 
-string VSTPlugin::GetPluginId()
+std::string VSTPlugin::GetPluginId()
 {
    if (mPlugin)
    {
@@ -247,12 +247,12 @@ string VSTPlugin::GetPluginId()
    return "no plugin loaded";
 }
 
-void VSTPlugin::SetVST(string vstName)
+void VSTPlugin::SetVST(std::string vstName)
 {
    ofLog() << "loading VST: " << vstName;
    
    mModuleSaveData.SetString("vst", vstName);
-   string path = VSTLookup::GetVSTPath(vstName);
+   std::string path = VSTLookup::GetVSTPath(vstName);
    
    //mark VST as used
    {
@@ -394,7 +394,7 @@ void VSTPlugin::CreateParameterSliders()
    {
       mParameterSliders[i].mValue = parameters[i]->getValue();
       juce::String name = parameters[i]->getName(32);
-      string label(name.getCharPointer());
+      std::string label(name.getCharPointer());
       try
       {
          int append = 0;
@@ -713,9 +713,9 @@ void VSTPlugin::OnVSTWindowClosed()
    mWindow.release();
 }
 
-vector<IUIControl*> VSTPlugin::ControlsToIgnoreInSaveState() const
+std::vector<IUIControl*> VSTPlugin::ControlsToIgnoreInSaveState() const
 {
-   vector<IUIControl*> ignore;
+   std::vector<IUIControl*> ignore;
    ignore.push_back(mPresetFileSelector);
    return ignore;
 }
@@ -739,7 +739,7 @@ void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal)
             return;
          }
 
-         unique_ptr<FileInputStream> input(resourceFile.createInputStream());
+         std::unique_ptr<FileInputStream> input(resourceFile.createInputStream());
 
          if (!input->openedOk())
          {
@@ -827,7 +827,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
       FileChooser chooser("Save preset as...", File(ofToDataPath("vst/presets/"+ GetPluginId()+"/preset.vstp")), "*.vstp", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
       if (chooser.browseForFileToSave(true))
       {
-         string path = chooser.getResult().getFullPathName().toStdString();
+         std::string path = chooser.getResult().getFullPathName().toStdString();
          
          File resourceFile (path);
          TemporaryFile tempFile (resourceFile);
@@ -853,7 +853,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
             if (vstProgramState.getSize() > 0)
                output.write(vstProgramState.getData(), vstProgramState.getSize());
             
-            vector<int> exposedParams;
+            std::vector<int> exposedParams;
             for (int i=0; i<(int)mParameterSliders.size(); ++i)
             {
                if (mParameterSliders[i].mShowing)
@@ -932,7 +932,7 @@ void VSTPlugin::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void VSTPlugin::SetUpFromSaveData()
 {
-   string vstName = mModuleSaveData.GetString("vst");
+   std::string vstName = mModuleSaveData.GetString("vst");
    if (vstName != "")
       SetVST(vstName);
    
@@ -964,7 +964,7 @@ void VSTPlugin::SaveState(FileStreamOut& out)
       if (vstProgramState.getSize() > 0)
          out.WriteGeneric(vstProgramState.getData(), (int)vstProgramState.getSize());
       
-      vector<int> exposedParams;
+      std::vector<int> exposedParams;
       for (int i=0; i<(int)mParameterSliders.size(); ++i)
       {
          if (mParameterSliders[i].mShowing)

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -46,9 +46,9 @@ class ofxJSONElement;
 
 namespace VSTLookup
 {
-   void GetAvailableVSTs(vector<string>& vsts, bool rescan);
+   void GetAvailableVSTs(std::vector<std::string>& vsts, bool rescan);
    void FillVSTList(DropdownList* list);
-   string GetVSTPath(string vstName);
+   std::string GetVSTPath(std::string vstName);
 }
 
 class VSTPlugin : public IAudioProcessor, public INoteReceiver, public IDrawableModule, public IDropdownListener, public IFloatSliderListener, public IIntSliderListener, public IButtonListener
@@ -58,7 +58,7 @@ public:
    virtual ~VSTPlugin() override;
    static IDrawableModule* Create() { return new VSTPlugin(); }
    
-   string GetTitleLabel() override;
+   std::string GetTitleLabel() override;
    void CreateUIControls() override;
    
    void SetVol(float vol) { mVol = vol; }
@@ -68,7 +68,7 @@ public:
    
    juce::AudioProcessor* GetAudioProcessor() { return mPlugin.get(); }
    
-   void SetVST(string vstName);
+   void SetVST(std::string vstName);
    void OnVSTWindowClosed();
    
    //IAudioSource
@@ -90,7 +90,7 @@ public:
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
-   vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
+   std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
    
    static bool sIsRescanningVsts;
    
@@ -102,8 +102,8 @@ private:
    bool Enabled() const override { return mEnabled; }
    void LoadVST(juce::PluginDescription desc);
    
-   string GetPluginName();
-   string GetPluginId();
+   std::string GetPluginName();
+   std::string GetPluginId();
    void CreateParameterSliders();
    void RefreshPresetFiles();
    
@@ -112,14 +112,14 @@ private:
    int mPresetFileIndex;
    DropdownList* mPresetFileSelector;
    ClickButton* mSavePresetFileButton;
-   vector<string> mPresetFilePaths;
+   std::vector<std::string> mPresetFilePaths;
    ClickButton* mOpenEditorButton;
    int mOverlayWidth;
    int mOverlayHeight;
    
    bool mPluginReady;
    std::unique_ptr<juce::AudioProcessor> mPlugin;
-   string mPluginName;
+   std::string mPluginName;
    std::unique_ptr<VSTWindow> mWindow;
    juce::MidiBuffer mMidiBuffer;
    juce::MidiBuffer mFutureMidiBuffer;
@@ -136,7 +136,7 @@ private:
       bool mInSelectorList;
    };
    
-   vector<ParameterSlider> mParameterSliders;
+   std::vector<ParameterSlider> mParameterSliders;
    
    int mChannel;
    bool mUseVoiceAsChannel;
@@ -151,7 +151,7 @@ private:
       float mLastPressure;
    };
    
-   vector<ChannelModulations> mChannelModulations;
+   std::vector<ChannelModulations> mChannelModulations;
    
    ofMutex mVSTMutex;
    VSTPlayhead mPlayhead;

--- a/Source/ValueSetter.cpp
+++ b/Source/ValueSetter.cpp
@@ -97,7 +97,7 @@ void ValueSetter::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -41,7 +41,7 @@ public:
    virtual ~ValueSetter();
    static IDrawableModule* Create() { return new ValueSetter(); }
    
-   string GetTitleLabel() override { return "value setter"; }
+   std::string GetTitleLabel() override { return "value setter"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ValueStream.cpp
+++ b/Source/ValueStream.cpp
@@ -150,7 +150,7 @@ void ValueStream::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void ValueStream::SetUpFromSaveData()
 {
-   string controlPath = mModuleSaveData.GetString("uicontrol");
+   std::string controlPath = mModuleSaveData.GetString("uicontrol");
    if (!controlPath.empty())
    {
       mUIControl = TheSynth->FindUIControl(controlPath);

--- a/Source/ValueStream.h
+++ b/Source/ValueStream.h
@@ -41,7 +41,7 @@ public:
    ~ValueStream();
    static IDrawableModule* Create() { return new ValueStream(); }
 
-   string GetTitleLabel() override { return "value stream"; }
+   std::string GetTitleLabel() override { return "value stream"; }
    void CreateUIControls() override;
 
    IUIControl* GetUIControl() const { return mUIControl; }
@@ -80,6 +80,6 @@ private:
    float mHeight;
    float mSpeed;
    FloatSlider* mSpeedSlider;
-   array<float, 100000> mValues;
+   std::array<float, 100000> mValues;
    int mValueDisplayPointer;
 };

--- a/Source/VelocityScaler.h
+++ b/Source/VelocityScaler.h
@@ -38,7 +38,7 @@ public:
    VelocityScaler();
    static IDrawableModule* Create() { return new VelocityScaler(); }
    
-   string GetTitleLabel() override { return "velocity scaler"; }
+   std::string GetTitleLabel() override { return "velocity scaler"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VelocitySetter.h
+++ b/Source/VelocitySetter.h
@@ -38,7 +38,7 @@ public:
    VelocitySetter();
    static IDrawableModule* Create() { return new VelocitySetter(); }
    
-   string GetTitleLabel() override { return "velocity"; }
+   std::string GetTitleLabel() override { return "velocity"; }
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VelocityStepSequencer.cpp
+++ b/Source/VelocityStepSequencer.cpp
@@ -86,7 +86,7 @@ VelocityStepSequencer::~VelocityStepSequencer()
    TheTransport->RemoveListener(this);
 }
 
-void VelocityStepSequencer::SetMidiController(string name)
+void VelocityStepSequencer::SetMidiController(std::string name)
 {
    if (mController)
       mController->RemoveListener(this);

--- a/Source/VelocityStepSequencer.h
+++ b/Source/VelocityStepSequencer.h
@@ -48,11 +48,11 @@ public:
    ~VelocityStepSequencer();
    static IDrawableModule* Create() { return new VelocityStepSequencer(); }
    
-   string GetTitleLabel() override { return "velocity seq"; }
+   std::string GetTitleLabel() override { return "velocity seq"; }
    void CreateUIControls() override;
    void Init() override;
    
-   void SetMidiController(string name);
+   void SetMidiController(std::string name);
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/VelocityToCV.cpp
+++ b/Source/VelocityToCV.cpp
@@ -83,7 +83,7 @@ void VelocityToCV::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
    
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
    

--- a/Source/VelocityToCV.h
+++ b/Source/VelocityToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~VelocityToCV();
    static IDrawableModule* Create() { return new VelocityToCV(); }
    
-   string GetTitleLabel() override { return "velocity to cv"; }
+   std::string GetTitleLabel() override { return "velocity to cv"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VinylTempoControl.cpp
+++ b/Source/VinylTempoControl.cpp
@@ -131,7 +131,7 @@ void VinylTempoControl::SaveLayout(ofxJSONElement& moduleInfo)
 {
    IDrawableModule::SaveLayout(moduleInfo);
 
-   string targetPath = "";
+   std::string targetPath = "";
    if (mTarget)
       targetPath = mTarget->Path();
 

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -61,7 +61,7 @@ public:
    ~VinylTempoControl();
    static IDrawableModule* Create() { return new VinylTempoControl(); }
    
-   string GetTitleLabel() override { return "vinylcontrol"; }
+   std::string GetTitleLabel() override { return "vinylcontrol"; }
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void CreateUIControls() override;

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -44,7 +44,7 @@ public:
    virtual ~Vocoder();
    static IDrawableModule* Create() { return new Vocoder(); }
    
-   string GetTitleLabel() override { return "fft vocoder"; }
+   std::string GetTitleLabel() override { return "fft vocoder"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VocoderCarrierInput.h
+++ b/Source/VocoderCarrierInput.h
@@ -44,7 +44,7 @@ public:
    virtual ~VocoderCarrierInput();
    static IDrawableModule* Create() { return new VocoderCarrierInput(); }
    
-   string GetTitleLabel() override { return "carrier"; }
+   std::string GetTitleLabel() override { return "carrier"; }
    void CreateUIControls() override;
 
    //IAudioProcessor

--- a/Source/VolcaBeatsControl.h
+++ b/Source/VolcaBeatsControl.h
@@ -43,7 +43,7 @@ public:
    virtual ~VolcaBeatsControl();
    static IDrawableModule* Create() { return new VolcaBeatsControl(); }
    
-   string GetTitleLabel() override { return "volca beats control"; }
+   std::string GetTitleLabel() override { return "volca beats control"; }
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/WaveformViewer.h
+++ b/Source/WaveformViewer.h
@@ -42,7 +42,7 @@ public:
    virtual ~WaveformViewer();
    static IDrawableModule* Create() { return new WaveformViewer(); }
    
-   string GetTitleLabel() override { return "waveform viewer"; }
+   std::string GetTitleLabel() override { return "waveform viewer"; }
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Waveshaper.h
+++ b/Source/Waveshaper.h
@@ -41,7 +41,7 @@ public:
    virtual ~Waveshaper();
    static IDrawableModule* Create() { return new Waveshaper(); }
    
-   string GetTitleLabel() override { return "waveshaper"; }
+   std::string GetTitleLabel() override { return "waveshaper"; }
    void CreateUIControls() override;
    
    //IAudioSource
@@ -76,7 +76,7 @@ private:
    float mE;
    FloatSlider* mESlider;
    
-   string mEntryString;
+   std::string mEntryString;
    TextEntry* mTextEntry;
    exprtk::symbol_table<float> mSymbolTable;
    exprtk::expression<float> mExpression;

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -37,7 +37,7 @@ public:
    WhiteKeys();
    static IDrawableModule* Create() { return new WhiteKeys(); }
    
-   string GetTitleLabel() override { return "white keys"; }
+   std::string GetTitleLabel() override { return "white keys"; }
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 

--- a/Source/ofxJSONElement.cpp
+++ b/Source/ofxJSONElement.cpp
@@ -23,14 +23,14 @@ ofxJSONElement::ofxJSONElement(const Json::Value& v) : Value(v)
 
 
 //--------------------------------------------------------------
-ofxJSONElement::ofxJSONElement(string jsonString)
+ofxJSONElement::ofxJSONElement(std::string jsonString)
 {
    parse(jsonString);
 }
 
 
 //--------------------------------------------------------------
-bool ofxJSONElement::parse(string jsonString)
+bool ofxJSONElement::parse(std::string jsonString)
 {
    Reader reader;
    if(!reader.parse( jsonString, *this )) {
@@ -42,7 +42,7 @@ bool ofxJSONElement::parse(string jsonString)
 
 
 //--------------------------------------------------------------
-bool ofxJSONElement::open(string filename)
+bool ofxJSONElement::open(std::string filename)
 {
    juce::File file(filename);
    
@@ -66,7 +66,7 @@ bool ofxJSONElement::open(string filename)
 
 
 //--------------------------------------------------------------
-bool ofxJSONElement::save(string filename, bool pretty)
+bool ofxJSONElement::save(std::string filename, bool pretty)
 {
    filename = ofToDataPath(filename, true);
    juce::File file(filename);
@@ -90,9 +90,9 @@ bool ofxJSONElement::save(string filename, bool pretty)
 
 
 //--------------------------------------------------------------
-string ofxJSONElement::getRawString(bool pretty)
+std::string ofxJSONElement::getRawString(bool pretty)
 {
-   string raw;
+   std::string raw;
    if(pretty) {
       StyledWriter writer;
       raw = writer.write(*this);
@@ -104,9 +104,9 @@ string ofxJSONElement::getRawString(bool pretty)
 }
 
 //--------------------------------------------------------------
-string ofxJSONElement::decodeURL(string &SRC)
+std::string ofxJSONElement::decodeURL(std::string &SRC)
 {
-   string ret;
+   std::string ret;
    char ch;
    int i, ii;
    for (i=0; i<SRC.length(); i++) {

--- a/Source/ofxJSONElement.h
+++ b/Source/ofxJSONElement.h
@@ -20,17 +20,17 @@ extern "C" size_t decode_html_entities_utf8(char *dest, const char *src);
 class ofxJSONElement: public Json::Value {
 public:
    ofxJSONElement() {};
-   ofxJSONElement(string jsonString);
+   ofxJSONElement(std::string jsonString);
    ofxJSONElement(const Json::Value& v);
    
-   bool parse(string jsonString);
-   bool open(string filename);
-   bool save(string filename, bool pretty=false);
-   string getRawString(bool pretty=true);
+   bool parse(std::string jsonString);
+   bool open(std::string filename);
+   bool save(std::string filename, bool pretty=false);
+   std::string getRawString(bool pretty=true);
    
    
    // static
-   static string decodeURL(string& str);
+   static std::string decodeURL(std::string& str);
    /*static string decodeEntities(string& str) {
       char dest[ str.length() ];
       decode_html_entities_utf8(dest, str.c_str());

--- a/Source/psmove/PSMoveMgr.cpp
+++ b/Source/psmove/PSMoveMgr.cpp
@@ -204,9 +204,9 @@ void PSMoveMgr::Update()
    }
 }
 
-void PSMoveMgr::SendButtonMessage(int id, string button, int val)
+void PSMoveMgr::SendButtonMessage(int id, std::string button, int val)
 {
-   string address = "/" + ofToString(id) + "/button/" + button;
+   std::string address = "/" + ofToString(id) + "/button/" + button;
    //TheMessenger->SendIntMessage(address,val);
    
    if (mListener)

--- a/Source/psmove/PSMoveMgr.h
+++ b/Source/psmove/PSMoveMgr.h
@@ -11,7 +11,7 @@ class PSMoveListener
 {
 public:
    virtual ~PSMoveListener() {}
-   virtual void OnPSMoveButton(int id, string button, int val) = 0;
+   virtual void OnPSMoveButton(int id, std::string button, int val) = 0;
 };
 
 class PSMoveMgr
@@ -36,7 +36,7 @@ public:
    
 private:
    _PSMove* SetUpMove(int id);
-   void SendButtonMessage(int id, string button, int val);
+   void SendButtonMessage(int id, std::string button, int val);
 
    _PSMove* mMove[MAX_NUM_PS_MOVES];
    int mButtons[MAX_NUM_PS_MOVES];

--- a/Source/push2/modules/libusb/os/haiku_usb.h
+++ b/Source/push2/modules/libusb/os/haiku_usb.h
@@ -25,8 +25,6 @@
 #include "libusbi.h"
 #include "haiku_usb_raw.h"
 
-using namespace std;
-
 class USBDevice;
 class USBDeviceHandle;
 class USBTransfer;


### PR DESCRIPTION
When setting the C++ standard to C++17, all hell breaks loose on Windows due to ambiguity between `std` and the global namespace. (see #307)

This change removes `using namespace std` and tacks `std::` in front of everything that needs it. No more, no less.