### PR TITLE
123 Window seemingly softlocks/disables input at random

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -105,6 +105,7 @@ public:
       setSize(width, height);
       setWantsKeyboardFocus(true);
       Desktop::setScreenSaverEnabled(false);
+      mGlobalManagers.mDeviceManager.getAvailableDeviceTypes();   //scans for device types ("Windows Audio", "DirectSound", etc)
    }
    
    ~MainContentComponent()
@@ -212,8 +213,6 @@ public:
          for (auto output : deviceType->getDeviceNames(false))
             ofLog() << output.toStdString();
       }*/
-
-      mGlobalManagers.mDeviceManager.getAvailableDeviceTypes();   //scans for device types ("Windows Audio", "DirectSound", etc)
 
       ofxJSONElement userPrefs;
       const string kAutoDevice = "auto";


### PR DESCRIPTION
fixes #123
in windows, when certain events happened (plugging in a monitor, unplugging a monitor, etc), bespoke would stop receiving messages from windows, such as mouse clicks. this seems to have been caused by the juce audio device scanner spawning up a hidden window, but that window was not spawned up by the main thread, which seems to have caused issues. the fix is to ensure that that window is spawned by the main thread. thank you to @gamingrobot for the incredible work in investigating this.