### PR TITLE
Use Enabled checkbox for prefabs

### DIFF
--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -233,6 +233,17 @@ void Prefab::ButtonClicked(ClickButton* button)
    }
 }
 
+void Prefab::CheckboxUpdated(Checkbox* checkbox)
+{
+   if (checkbox == mEnabledCheckbox)
+   {
+      bool enabled = mEnabledCheckbox->GetValue() >= 0.5;
+      auto modules = mModuleContainer.GetModules();
+      for (auto* module : modules)
+         module->SetEnabled(enabled);
+   }
+}
+
 void Prefab::SavePrefab(std::string savePath)
 {
    ofxJSONElement root;

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -57,6 +57,8 @@ public:
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
 
+   void SetEnabled(bool enabled) override { mEnabled = enabled; }
+
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
    
@@ -72,6 +74,7 @@ private:
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(int x, int y, bool right) override;
+   void CheckboxUpdated(Checkbox* checkbox) override;
    void MouseReleased() override;
 
    bool CanAddDropModules();


### PR DESCRIPTION
This allows enabling/disabling all modules within a prefab with one checkbox on prefab level.

More like a proof of concept, as I don't know about any possible side effects, and if this has been discussed and dismissed already.