### PR TITLE
Python Startup Crash Avoidance on .bsk load

### DIFF
--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -50,7 +50,8 @@ namespace py = pybind11;
 
 //static
 bool CodeEntry::sWarnJediNotInstalled = false;
-
+bool CodeEntry::sDoPythonAutocomplete = false;
+bool CodeEntry::sDoSyntaxHighlighting = false;
 
 CodeEntry::CodeEntry(ICodeEntryListener* owner, const char* name, int x, int y, float w, float h)
 : mListener(owner)
@@ -64,8 +65,7 @@ CodeEntry::CodeEntry(ICodeEntryListener* owner, const char* name, int x, int y, 
 , mLastPublishTime(-999)
 , mHasError(false)
 , mErrorLine(-1)
-, mDoSyntaxHighlighting(true)
-, mDoPythonAutocomplete(true)
+, mDoSyntaxHighlighting(false)
 , mAutocompleteUpdateTimer(0)
 , mWantToShowAutocomplete(false)
 , mAutocompleteHighlightIndex(0)
@@ -93,7 +93,7 @@ void CodeEntry::Poll()
 {
    if (mCodeUpdated)
    {
-      if (mDoSyntaxHighlighting)
+      if (mDoSyntaxHighlighting && sDoSyntaxHighlighting)
       {
          try
          {
@@ -122,7 +122,7 @@ void CodeEntry::Poll()
       mAutocompleteUpdateTimer -= 1.0 / ofGetFrameRate();
       if (mAutocompleteUpdateTimer <= 0)
       {
-         if (mDoPythonAutocomplete)
+         if (sDoPythonAutocomplete)
          {
             mAutocompleteCaretCoords = GetCaretCoords(mCaretPosition);
 
@@ -667,6 +667,7 @@ void CodeEntry::OnPythonInit()
    try
    {
       py::exec(syntaxHighlightCode, py::globals());
+      sDoSyntaxHighlighting = true;
    }
    catch (const std::exception &e)
    {
@@ -686,6 +687,7 @@ void CodeEntry::OnPythonInit()
          py::exec("jediProject.added_sys_path = [\"" + ofToResourcePath("python_stubs") + "\"]", py::globals());
          //py::eval_file(ofToResourcePath("bespoke_stubs.pyi"), py::globals());
          //py::exec("import sys;sys.path.append(\""+ ofToResourcePath("python_stubs")+"\")", py::globals());
+         sDoPythonAutocomplete = true;
       }
       catch (const std::exception &e)
       {

--- a/Source/CodeEntry.h
+++ b/Source/CodeEntry.h
@@ -158,8 +158,15 @@ private:
    int mErrorLine;
    ofVec2f mScroll;
    std::vector<int> mSyntaxHighlightMapping;
+
+   /*
+    * For syntax highlighting we have both a static (system wide) and mDo (per insdtance)
+    * control and then we use and
+    */
+   static bool sDoSyntaxHighlighting;
+   static bool sDoPythonAutocomplete;
    bool mDoSyntaxHighlighting;
-   bool mDoPythonAutocomplete;
+
    double mLastInputTime;
    std::array<AutocompleteSignatureInfo, 10> mAutocompleteSignatures;
    std::array<AutocompleteInfo, 10> mAutocompletes;


### PR DESCRIPTION
In the case where

1. Your system has a valid python
2. But the python_ever_init file marker isn't there and
3. You directly load a BSK with python that was saved from a working session

you would crash. You would crash because the syntax highlighter would run.
You can repro this by save a BSK with python, blow away the sentinel, and then
restart bespoke and load it.

This fixes the problem by

1. Making the code highlight sentinel be static and default to false
   and toggle to true when py is initialized
2. Keep a per-module instance highlighter to unstream onto to preserve
   backwarad capability

Closes #133