### PR TITLE
updated UI of scale module for custom scale loading

### DIFF
--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -583,7 +583,8 @@ void ChaosEngine::ReadSongs()
    
    const ofxJSONElement& songs = root["songs"];
    mSongs.resize(songs.size());
-   for (int i=0; i<songs.size(); ++i)
+   //TODO(Ryan) this is broken. but is it worth reviving?
+   /*for (int i=0; i<songs.size(); ++i)
    {
       const ofxJSONElement& song = songs[i];
       mSongs[i].mName = song["name"].asString();
@@ -624,7 +625,7 @@ void ChaosEngine::ReadSongs()
             mSongs[i].mSections[j].mChords.push_back(ProgressionChord(chordInfo,scale));
          }
       }
-   }
+   }*/
    
    for (int i=0; i<mSongs.size(); ++i)
       mSongDropdown->AddLabel(mSongs[i].mName.c_str(), i);

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -212,10 +212,10 @@ void Chorder::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modul
             {
                outPitch = pitch + gridPosition;
             }
-            else if (gridPosition%TheScale->NumPitchesInScale() == 0) //if this is the pressed note or an octave of it
+            else if (gridPosition%TheScale->NumTonesInScale() == 0) //if this is the pressed note or an octave of it
             {
                //play the pressed note (might not be in scale, so play it directly)
-               int octave = gridPosition/TheScale->NumPitchesInScale();
+               int octave = gridPosition/TheScale->NumTonesInScale();
                outPitch = pitch+TheScale->GetTet()*octave;
             }
             else

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -529,7 +529,7 @@ int LaunchpadKeyboard::GridToPitch(int x, int y)
          }
          else if (x == 3)
          {
-            if (TheScale->NumPitchesInScale() == 7)   //septatonic scales only
+            if (TheScale->NumTonesInScale() == 7)   //septatonic scales only
             {
                if (y%2 == 0)  // 7 or maj7
                {
@@ -554,7 +554,7 @@ int LaunchpadKeyboard::GridToPitch(int x, int y)
          }
       }
       
-      int numPitchesInScale = TheScale->NumPitchesInScale();
+      int numPitchesInScale = TheScale->NumTonesInScale();
       if (numPitchesInScale > 8)
          return INVALID_PITCH;
       
@@ -572,7 +572,7 @@ int LaunchpadKeyboard::GridToPitch(int x, int y)
 
 int LaunchpadKeyboard::GridToPitchChordSection(int x, int y)
 {
-   int numPitchesInScale = TheScale->NumPitchesInScale();
+   int numPitchesInScale = TheScale->NumTonesInScale();
    
    if (y<7 && y<numPitchesInScale)
    {

--- a/Source/NoteSinger.cpp
+++ b/Source/NoteSinger.cpp
@@ -85,7 +85,7 @@ void NoteSinger::OnTransportAdvanced(float amount)
       float peak = mPeaks[i].GetPeak();
       if (peak > bestPeak)
       {
-         int numPitchesInScale = TheScale->NumPitchesInScale();
+         int numPitchesInScale = TheScale->NumTonesInScale();
          if (bestBucket != -1 &&
              peak < 2*bestPeak &&
              i % numPitchesInScale == bestBucket % numPitchesInScale)
@@ -133,7 +133,7 @@ void NoteSinger::DrawModule()
 
 void NoteSinger::OnScaleChanged()
 {
-   mNumBuckets = MIN(TheScale->NumPitchesInScale() * 4, NOTESINGER_MAX_BUCKETS);
+   mNumBuckets = MIN(TheScale->NumTonesInScale() * 4, NOTESINGER_MAX_BUCKETS);
    
    for (int i=0; i<mNumBuckets; ++i)
    {
@@ -149,7 +149,7 @@ void NoteSinger::OnScaleChanged()
 
 int NoteSinger::GetPitchForBucket(int bucket)
 {
-   return TheScale->GetPitchFromTone(bucket+TheScale->NumPitchesInScale()*2);
+   return TheScale->GetPitchFromTone(bucket+TheScale->NumTonesInScale()*2);
 }
 
 void NoteSinger::ButtonClicked(ClickButton* button)

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -305,7 +305,7 @@ void NoteStepSequencer::DrawModule()
    {
       if (RowToPitch(i)%TheScale->GetTet() == TheScale->ScaleRoot()%TheScale->GetTet())
          ofSetColor(0,255,0,80);
-      else if (RowToPitch(i)%TheScale->GetTet() == (TheScale->ScaleRoot()+7)%TheScale->GetTet())
+      else if (TheScale->GetTet() == 12 && RowToPitch(i)%TheScale->GetTet() == (TheScale->ScaleRoot()+7)%TheScale->GetTet())
          ofSetColor(200,150,0,80);
       else if (mNoteMode == kNoteMode_Chromatic && TheScale->IsInScale(RowToPitch(i)))
          ofSetColor(100,75,0,80);
@@ -473,7 +473,7 @@ int NoteStepSequencer::RowToPitch(int row)
 {
    row += mRowOffset;
    
-   int numPitchesInScale = TheScale->NumPitchesInScale();
+   int numPitchesInScale = TheScale->NumTonesInScale();
    switch (mNoteMode)
    {
       case kNoteMode_Scale:

--- a/Source/NoteTransformer.cpp
+++ b/Source/NoteTransformer.cpp
@@ -91,7 +91,7 @@ void NoteTransformer::PlayNote(double time, int pitch, int velocity, int voiceId
       mLastTimeTonePlayed[tone%7] = time;
    int pitchOffset = pitch - TheScale->GetPitchFromTone(tone);
    
-   tone += mToneMod[tone % TheScale->NumPitchesInScale()];
+   tone += mToneMod[tone % TheScale->NumTonesInScale()];
    
    int outPitch = TheScale->GetPitchFromTone(tone) + pitchOffset;
    PlayNoteOutput(time, outPitch, velocity, voiceIdx, modulation);


### PR DESCRIPTION
- hid irrelevant controls when using SCL or oddsound
- make modules that use scale information pay attention to custom scales
- update tuning table when user is using SCL with no KBM and changes reference pitch or frequency