### PR TITLE
Make Ableton Push 2 support optional

### DIFF
--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include "push2/JuceToPush2DisplayBridge.h"
 #include "IDrawableModule.h"
 #include "MidiDevice.h"
 #include "MidiController.h"
@@ -77,7 +76,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    void OnClicked(int x, int y, bool right) override;
    
-   NBase::Result Initialize();
+   bool Initialize();
    void DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float t, float pxRatio);
    void RenderPush2Display();
    
@@ -102,10 +101,6 @@ private:
    ofColor GetSpawnGridColor(int index, ModuleType moduleType) const;
    int GetSpawnGridPadColor(int index, ModuleType moduleType) const;
    
-   bool mDisplayInitialized;
-   
-   static ableton::Push2DisplayBridge* sPush2Bridge;      /* The bridge allowing to use juce::graphics for push */
-   static ableton::Push2Display* sPush2Display;           /* The low-level push2 class */
    unsigned char* mPixels;
    const int kPixelRatio = 1;
    
@@ -161,6 +156,7 @@ private:
    SpawnListManager mSpawnLists;
    int mPendingSpawnPitch;
    int mSelectedGridSpawnListIndex;
+   std::string mPushBridgeInitErrMsg;
 };
 
 //https://raw.githubusercontent.com/Ableton/push-interface/master/doc/MidiMapping.png

--- a/libs/push2/CMakeLists.txt
+++ b/libs/push2/CMakeLists.txt
@@ -1,59 +1,77 @@
 project(push2)
 
+set(DOC_STRING "Enable Ableton Push 2 support. When off, the push2control module is present but non-functional.")
+option(BESPOKE_PUSH2_SUPPORT "${DOC_STRING}" ON)
+
 add_library(${PROJECT_NAME}
     JuceToPush2DisplayBridge.cpp
-    Push2-Usb-Communicator.cpp
+    Push2-Display.cpp
+    Push2-Display.h
+    Push2-UsbCommunicator.h
     Result.cpp
     include/push2/JuceToPush2DisplayBridge.h
     include/push2/Macros.h
     include/push2/Push2-Bitmap.h
-    include/push2/Push2-Display.h
-    include/push2/Push2-UsbCommunicator.h
     include/push2/Result.h
     )
 
-# FIXME: The code currently assumes that WIN32 == MSVC and will fail to build
-# on MinGW, so we use the system libusb on there. This is the best option for
-# native builds anyway, but for cross we should build libusb for convenience.
-if(APPLE OR MSVC)
-    target_sources(${PROJECT_NAME} PRIVATE
-        modules/libusb/core.c
-        modules/libusb/descriptor.c
-        modules/libusb/hotplug.c
-        modules/libusb/io.c
-        modules/libusb/strerror.c
-        modules/libusb/sync.c
-        )
-    target_include_directories(${PROJECT_NAME} PRIVATE
-        libusb
-        modules/libusb
-        )
+if(BESPOKE_PUSH2_SUPPORT)
+    # FIXME: The code currently assumes that WIN32 == MSVC and will fail to build
+    # on MinGW, so we use the system libusb on there. This is the best option for
+    # native builds anyway, but for cross we should build libusb for convenience.
+    if(APPLE OR MSVC)
+        target_sources(${PROJECT_NAME} PRIVATE
+            modules/libusb/core.c
+            modules/libusb/descriptor.c
+            modules/libusb/hotplug.c
+            modules/libusb/io.c
+            modules/libusb/strerror.c
+            modules/libusb/sync.c
+            )
+        target_include_directories(${PROJECT_NAME} PRIVATE
+            libusb
+            modules/libusb
+            )
+    endif()
+
+    if(APPLE)
+        target_sources(${PROJECT_NAME} PRIVATE
+            modules/libusb/os/darwin_usb.c
+            modules/libusb/os/poll_posix.c
+            modules/libusb/os/threads_posix.c
+            )
+        target_compile_definitions(${PROJECT_NAME} PRIVATE OBJC_SILENCE_GC_DEPRECATIONS=1)
+    elseif(MSVC)
+        target_sources(${PROJECT_NAME} PRIVATE
+            modules/libusb/os/poll_windows.c
+            modules/libusb/os/threads_windows.c
+            modules/libusb/os/windows_winusb.c
+            modules/libusb/os/windows_nt_common.c
+            )
+        target_compile_definitions(${PROJECT_NAME} PRIVATE
+            HAVE_STRUCT_TIMESPEC
+            THREADS_WINDOWS
+            )
+    else()
+        find_package(PkgConfig)
+        pkg_check_modules(LIBUSB libusb-1.0)
+        if(NOT LIBUSB_FOUND)
+            message(WARNING "libusb not found, disabling Ableton Push 2 support")
+            set(BESPOKE_PUSH2_SUPPORT OFF CACHE BOOL "${DOC_STRING}" FORCE)
+        endif()
+        target_include_directories(${PROJECT_NAME} PRIVATE ${LIBUSB_INCLUDE_DIRS})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBUSB_LIBRARIES})
+    endif()
 endif()
 
-if(APPLE)
-    target_sources(${PROJECT_NAME} PRIVATE
-        modules/libusb/os/darwin_usb.c
-        modules/libusb/os/poll_posix.c
-        modules/libusb/os/threads_posix.c
-        )
-    target_compile_definitions(${PROJECT_NAME} PRIVATE OBJC_SILENCE_GC_DEPRECATIONS=1)
-elseif(MSVC)
-    target_sources(${PROJECT_NAME} PRIVATE
-        modules/libusb/os/poll_windows.c
-        modules/libusb/os/threads_windows.c
-        modules/libusb/os/windows_winusb.c
-        modules/libusb/os/windows_nt_common.c
-        )
-    target_compile_definitions(${PROJECT_NAME} PRIVATE
-        HAVE_STRUCT_TIMESPEC
-        THREADS_WINDOWS
-        )
+# Gotta recheck in case it was vetoed above
+if(BESPOKE_PUSH2_SUPPORT)
+    target_sources(${PROJECT_NAME} PRIVATE Push2-Usb-Communicator.cpp)
+    message(STATUS "Ableton Push 2 support enabled")
 else()
-    find_package(PkgConfig)
-    pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${LIBUSB_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBUSB_LIBRARIES})
+    message(STATUS "Ableton Push 2 support disabled")
 endif()
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE BESPOKE_PUSH2_SUPPORT=$<BOOL:${BESPOKE_PUSH2_SUPPORT}>)
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 add_library(bespoke::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/libs/push2/JuceToPush2DisplayBridge.cpp
+++ b/libs/push2/JuceToPush2DisplayBridge.cpp
@@ -20,6 +20,8 @@
 
 #include "push2/JuceToPush2DisplayBridge.h"
 #include "push2/Push2-Bitmap.h"
+#include "Push2-Display.h"
+
 #include <assert.h>
 
 using namespace ableton;
@@ -30,13 +32,22 @@ Push2DisplayBridge::Push2DisplayBridge()
    : push2Display_(nullptr)
    {};
 
+//------------------------------------------------------------------------------
+
+Push2DisplayBridge::~Push2DisplayBridge() = default;
 
 //------------------------------------------------------------------------------
 
-NBase::Result Push2DisplayBridge::Init(ableton::Push2Display& display)
+NBase::Result Push2DisplayBridge::Init()
 {
-   push2Display_ = &display;
-   return NBase::Result::NoError;
+   std::unique_ptr<Push2Display> display{Push2Display::create()};
+   if (!display)
+     return {"no push 2 support"};
+   auto result{display->Init()};
+   if (result.Failed())
+     return {"no push 2 found"};
+   push2Display_ = std::move(display);
+   return result;
 }
 
 

--- a/libs/push2/Push2-Display.cpp
+++ b/libs/push2/Push2-Display.cpp
@@ -1,0 +1,23 @@
+#include "Push2-Display.h"
+
+namespace ableton {
+
+Push2Display *Push2Display::create()
+{
+#if BESPOKE_PUSH2_SUPPORT
+  return new Push2Display;
+#else
+  return nullptr;
+#endif
+}
+
+NBase::Result Push2Display::Init()
+{
+#if BESPOKE_PUSH2_SUPPORT
+  return communicator_.Init(dataSource_);
+#else
+  return {""}; // unreachable unless this is nullptr
+#endif
+}
+
+} // namespace ableton

--- a/libs/push2/Push2-Display.h
+++ b/libs/push2/Push2-Display.h
@@ -20,10 +20,9 @@
 
 #pragma once
 
+#include "push2/Push2-Bitmap.h"
 #include "push2/Result.h"
-#include "push2/Push2-UsbCommunicator.h"
-#include <memory>
-#include <atomic>
+#include "Push2-UsbCommunicator.h"
 
 namespace ableton
 {
@@ -34,20 +33,9 @@ namespace ableton
   public:
     using pixel_t = Push2DisplayBitmap::pixel_t;
 
-    Push2Display()
-    {
-      pixel_t* pData = dataSource_;
-      for (uint8_t line = 0; line < kDataSourceHeight; line++)
-      {
-        memset(pData, 0, kDataSourceWidth*sizeof(pixel_t));
-        pData += kDataSourceWidth;
-      }
-    }
+    static Push2Display *create();
 
-    NBase::Result Init()
-    {
-      return communicator_.Init(dataSource_);
-    }
+    NBase::Result Init();
 
     // Transfers the bitmap into the output buffer sent to
     // the push display. The push display buffer has a larger stride
@@ -71,10 +59,14 @@ namespace ableton
     }
 
   private:
+    Push2Display() = default;
+
     static const int kDataSourceWidth = 1024;
     static const int kDataSourceHeight = 160;
 
-    pixel_t dataSource_[kDataSourceWidth * kDataSourceHeight];
+    pixel_t dataSource_[kDataSourceWidth * kDataSourceHeight]{};
+#if BESPOKE_PUSH2_SUPPORT
     UsbCommunicator communicator_;
+#endif
   };
 }

--- a/libs/push2/Push2-Usb-Communicator.cpp
+++ b/libs/push2/Push2-Usb-Communicator.cpp
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-#include "push2/Push2-UsbCommunicator.h"
+#include "Push2-UsbCommunicator.h"
 
 #include <cstdint>
 

--- a/libs/push2/Push2-UsbCommunicator.h
+++ b/libs/push2/Push2-UsbCommunicator.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include "Result.h"
-#include "Push2-Bitmap.h"
+#include "push2/Result.h"
+#include "push2/Push2-Bitmap.h"
 
 #include <thread>
 #include <assert.h>

--- a/libs/push2/include/push2/JuceToPush2DisplayBridge.h
+++ b/libs/push2/include/push2/JuceToPush2DisplayBridge.h
@@ -20,10 +20,14 @@
 
 #pragma once
 
-#include "Push2-Display.h"
+#include "push2/Result.h"
+
+#include <memory>
 
 namespace ableton
 {
+  class Push2Display;
+
   /*!
    *  Implements a bridge between juce::Graphics and push2 display format.
    */
@@ -33,6 +37,7 @@ namespace ableton
   public:
 
     Push2DisplayBridge();
+    ~Push2DisplayBridge();
 
     /*!
      * Initialises the bridge
@@ -40,7 +45,13 @@ namespace ableton
      *  \return the result of the initialisation process
      */
 
-    NBase::Result Init(ableton::Push2Display& display);
+    NBase::Result Init();
+
+    /*!
+     *  \return true if this bridge is initialized
+     */
+
+    bool IsInitialized() const { return bool{push2Display_}; }
 
     /*!
      * Tells the bridge the drawing is done and the bitmap can be sent to
@@ -50,6 +61,6 @@ namespace ableton
     void Flip(unsigned char* pixels);
 
   private:
-    ableton::Push2Display* push2Display_;    /*< The push display the bridge works on */
+    std::unique_ptr<Push2Display> push2Display_;    /*< The push display the bridge works on */
   };
 }


### PR DESCRIPTION
This adds the `BESPOKE_PUSH2_SUPPORT` build option (defaults to `ON`). When disabled, Bespoke builds without `libusb` and the `push2control` module shows a "no push 2 support" message.

![image](https://user-images.githubusercontent.com/304760/135719773-71a313f8-dd83-41f6-8706-525218dca3cb.png)

On anything not macOS or Visual Studio we use the system `libusb`. If it can't be found, warn and gracefully disable Push 2 support.

Also fixes leaking of the Push API objects at shutdown and on every click on a disconnected `push2control`.