### PR TITLE
Make it possible to rescan VSTs with a huge list of VSTs.

### DIFF
--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -257,7 +257,7 @@ void SpawnListManager::SetUpVstDropdown(bool rescan)
 {
    std::vector<std::string> vsts;
    VSTLookup::GetAvailableVSTs(vsts, rescan);
-   vsts.push_back(kRescanPluginsLabel);
+   vsts.insert(vsts.begin(), kRescanPluginsLabel);
    mVstPlugins.SetList(vsts, "vstplugin");
 }
 


### PR DESCRIPTION
Changed the 'rescan vsts' menu entry to be in the front of the list instead of behind potentially hundreds of VSTs.

(I am aware that a better UI solution is in the works but for the time being this seems to be a quick and easy "fix")