### PR TITLE
VST Midi Output in the VSTPlugin module

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -550,13 +550,14 @@ void VSTPlugin::Process(double time)
             while (midiIt != mMidiBuffer.end())
             {
                auto msg = (*midiIt).getMessage();
+               auto tMidi = time + (*midiIt).samplePosition * gInvSampleRateMs;
                if (msg.isNoteOn())
                {
-                  mMidiOutCable->PlayNoteOutput(time, msg.getNoteNumber(), msg.getVelocity());
+                  mMidiOutCable->PlayNoteOutput(tMidi, msg.getNoteNumber(), msg.getVelocity());
                }
                else if (msg.isNoteOff())
                {
-                  mMidiOutCable->PlayNoteOutput(time, msg.getNoteNumber(), 0);
+                  mMidiOutCable->PlayNoteOutput(tMidi, msg.getNoteNumber(), 0);
                }
                else if (msg.isController())
                {

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -32,6 +32,7 @@
 #include "Profiler.h"
 #include "Scale.h"
 #include "ModulationChain.h"
+#include "PatchCableSource.h"
 //#include "NSWindowOverlay.h"
 
 namespace
@@ -201,7 +202,14 @@ void VSTPlugin::CreateUIControls()
    
    mPresetFileSelector->DrawLabel(true);
    mSavePresetFileButton->PositionTo(mPresetFileSelector,kAnchor_Right);
-   
+
+   mMidiOutCable = new AdditionalNoteCable();
+   mMidiOutCable->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
+   mMidiOutCable->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+   AddPatchCableSource(mMidiOutCable->GetPatchCableSource());
+   mMidiOutCable->GetPatchCableSource()->SetManualPosition(206-10, 10);
+
+
    if (mPlugin)
    {
       CreateParameterSliders();
@@ -535,7 +543,30 @@ void VSTPlugin::Process(double time)
          mMidiBuffer.clear(gBufferSize, mMidiBuffer.getLastEventTime() + 1);
          
          mPlugin->processBlock(buffer, mMidiBuffer);
-         
+
+         if (!mMidiBuffer.isEmpty())
+         {
+            auto midiIt = mMidiBuffer.begin();
+            while (midiIt != mMidiBuffer.end())
+            {
+               auto msg = (*midiIt).getMessage();
+               if (msg.isNoteOn())
+               {
+                  mMidiOutCable->PlayNoteOutput(time, msg.getNoteNumber(), msg.getVelocity());
+               }
+               else if (msg.isNoteOff())
+               {
+                  mMidiOutCable->PlayNoteOutput(time, msg.getNoteNumber(), 0);
+               }
+               else if (msg.isController())
+               {
+                  mMidiOutCable->SendCCOutput(msg.getControllerNumber(), msg.getControllerValue());
+               }
+               midiIt ++;
+
+            }
+         }
+
          mMidiBuffer.clear();
       }
       mVSTMutex.unlock();
@@ -655,7 +686,9 @@ void VSTPlugin::DrawModule()
    mSavePresetFileButton->Draw();
    mOpenEditorButton->Draw();
    mShowParameterDropdown->Draw();
-   
+
+   DrawTextLeftJustify("MIDI out", 206-18, 14);
+
    if (mDisplayMode == kDisplayMode_Sliders)
    {
       int sliderCount = 0;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -29,6 +29,7 @@
 #include "IAudioProcessor.h"
 #include "PolyphonyMgr.h"
 #include "INoteReceiver.h"
+#include "INoteSource.h"
 #include "IDrawableModule.h"
 #include "Slider.h"
 #include "DropdownList.h"
@@ -168,6 +169,11 @@ private:
    int mShowParameterIndex;
    DropdownList* mShowParameterDropdown;
    int mTemporarilyDisplayedParamIndex;
+
+   /*
+    * Midi and MultiOut support
+    */
+   AdditionalNoteCable *mMidiOutCable{nullptr};
 };
 
 #endif /* defined(__Bespoke__VSTPlugin__) */


### PR DESCRIPTION
This adds a working VST Output point for VST Midi Output
plugins. There's a couple of problems

1. Independetly of this, it seems tempo and position in VST is
   wrong so stochas (my test case) acts a bit wierd
2. I positioned the midi output on the plugin but we could put it
   elsewhere too. Wasn't sure where to put it. I thoughts
   also about putting it in the bottom of the module maybe?
3. I couldn't figure out how to label the midi output either.

So I'm not entirely sure this is something you just want to merge
rather than sharing comments on 2 and 3, but also i don't think it
is broken and is mergable.