### PR TITLE
Generic event propagation infrastructure.

### DIFF
--- a/Source/Event.h
+++ b/Source/Event.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "juce_opengl/juce_opengl.h"
+
+struct Event{
+    static inline const juce::KeyPress& keycode(const void* data, size_t size){return *(const juce::KeyPress*)data;}
+};

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -796,6 +796,12 @@ ofVec2f IDrawableModule::GetMinimumDimensions()
    return ofVec2f(GetMinimizedWidth() + 10, 10);
 }
 
+void IDrawableModule::SignalEmit(const void *data, size_t size)
+{
+   for (auto control : mUIControls)
+      control->SignalEmit(data, size);
+}
+
 void IDrawableModule::KeyPressed(int key, bool isRepeat)
 {
    for (auto source : mPatchCableSources)

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -79,6 +79,7 @@ public:
    virtual bool AlwaysOnTop() { return false; }
    void ToggleMinimized();
    void SetMinimized(bool minimized) { if (HasTitleBar()) mMinimized = minimized; }
+   virtual void SignalEmit(const void* data, size_t size);
    virtual void KeyPressed(int key, bool isRepeat);
    virtual void KeyReleased(int key);
    void DrawConnection(IClickable* target);

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -59,6 +59,7 @@ public:
    virtual std::string GetDisplayValue(float val) const { return "unimplemented"; }
    virtual void Init() {}
    virtual void Poll() {}
+   virtual void SignalEmit(const void *data, size_t size) {}
    virtual void KeyPressed(int key, bool isRepeat) {}
    void StartBeacon() override;
    bool IsPreset();

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -29,6 +29,8 @@
 #include "ModuleContainer.h"
 #include "FileStream.h"
 
+#include "Event.h"
+
 namespace
 {
    const float kKeyboardYOffset = 0;
@@ -280,6 +282,11 @@ int KeyboardDisplay::GetPitchForTypingKey(int key) const
    if (index != -1)
       return mRootOctave*12+index;
    return -1;
+}
+
+void KeyboardDisplay::SignalEmit(const void* data, size_t size){
+   auto& kp = Event::keycode(data,size);
+   std::cout<<kp.getKeyCode()<<","<<kp.getModifiers().getRawFlags()<<"\n";
 }
 
 void KeyboardDisplay::KeyPressed(int key, bool isRepeat)

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -44,6 +44,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    
    void MouseReleased() override;
+   void SignalEmit(const void* data, size_t size) override;
    void KeyPressed(int key, bool isRepeat) override;
    void KeyReleased(int key) override;
    

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -453,6 +453,7 @@ private:
          isRepeat = false;
       }
       mSynth.KeyPressed(keyCode, isRepeat);
+      mSynth.SignalEmit(&key,sizeof(key));
       return true;
    }
    

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -880,6 +880,12 @@ IDrawableModule* ModularSynth::GetLastClickedModule() const
    return mLastClickedModule;
 }
 
+void ModularSynth::SignalEmit(const void* data, size_t size){
+   mModuleContainer.SignalEmit(data, size);
+   mUILayerModuleContainer.SignalEmit(data, size);
+}
+
+
 void ModularSynth::KeyPressed(int key, bool isRepeat)
 {
    if (gHoveredUIControl &&

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -74,6 +74,7 @@ public:
 
    void Focus();
 
+   void SignalEmit(const void* data, size_t size);
    void KeyPressed(int key, bool isRepeat);
    void KeyReleased(int key);
    void MouseMoved(int x, int y );

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -145,6 +145,16 @@ void ModuleContainer::Exit()
    }
 }
 
+void ModuleContainer::SignalEmit(const void* data, size_t size)
+{
+   for (int i=0; i<mModules.size(); ++i)
+   {
+      if (mModules[i]->GetContainer())
+         mModules[i]->GetContainer()->SignalEmit(data, size);
+      mModules[i]->SignalEmit(data, size);
+   }
+}
+
 void ModuleContainer::KeyPressed(int key, bool isRepeat)
 {
    for (int i=0; i<mModules.size(); ++i)

--- a/Source/ModuleContainer.h
+++ b/Source/ModuleContainer.h
@@ -54,7 +54,7 @@ public:
    void SetDrawOffset(ofVec2f offset) { mDrawOffset = offset; }
    float GetDrawScale() const;
    void SetDrawScale(float scale) { mDrawScale = scale; }
-   
+   void SignalEmit(const void* data, size_t size);
    void KeyPressed(int key, bool isRepeat);
    void KeyReleased(int key);
    void MouseMoved(float x, float y);


### PR DESCRIPTION
This is the first commit to detach keyboard events from assigned ASCII characters, but also to support other types of events in the future.
Keycodes are way better to control instruments, as we can map arbitrary macros from multiple input devices without interfering with the actual control keys for the interface. Macropads, mechanical keyboards, gamepads, they could all be used to interface with our virtual tools.
I implemented a test for the KeyboardDisplay which was a bit broken in how it handled input events in my opinion due to the overlay of actions on the interface and events on the KeyboardDisplay itself.
Next step is to add configurable maps and remove the hardcoded one.

The questionable solution based on the pair const void*, size_t is meant to be made more ideomatic in the future, once the Event class will be fully developed.