### PR TITLE
One last VST Bus Fix

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -582,7 +582,14 @@ void VSTPlugin::Process(double time)
       mVSTMutex.unlock();
    
       GetBuffer()->Clear();
-      for (int ch=0; ch < buffer.getNumChannels() && ch < kSafetyMaxChannels; ++ch)
+      /*
+       * Until we support multi output we end up with this requirement that
+       * the output is at most stereo. This stops mis-behaving plugins which
+       * output the full buffer set from copying that onto the output.
+       * (Ahem: Surge 1.9)
+       */
+      int nChannelsToCopy = MIN(2, buffer.getNumChannels());
+      for (int ch=0; ch < nChannelsToCopy && ch < kSafetyMaxChannels; ++ch)
       {
          int outputChannel = MIN(ch,GetBuffer()->NumActiveChannels()-1);
          for (int sampleIndex=0; sampleIndex < buffer.getNumSamples(); ++sampleIndex)


### PR DESCRIPTION
I was so close with that last commit, I really was! But I
over-copied the output which meant in several cases surge 1.9
would use the extra buffers and you would copy them, which is not
what we wanted.

This fixes it by making sure even if we have a robust number of
output buesses, we only send the first stereo pair out to bespoke

Tested with a bunch of VST3 including surge, pianoteq, surge xt,
arturia jupiter 8.