### PR TITLE
Fixes performance issues on Linux, Run @60fps

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -52,6 +52,7 @@ public:
       
       openGLContext.setOpenGLVersionRequired(juce::OpenGLContext::openGL3_2);
       openGLContext.setContinuousRepainting(false);
+      openGLContext.setComponentPaintingEnabled(false);
 
 #ifndef BESPOKE_WINDOWS //windows crash handler is set up in ModularSynth() constructor
       SystemStats::setApplicationCrashHandler(ModularSynth::CrashHandler);
@@ -121,7 +122,7 @@ public:
       
       mSynth.Poll();
       
-#if DEBUG || BESPOKE_LINUX
+#if DEBUG
       if (sRenderFrame % 2 == 0)
 #else
       if (true)


### PR DESCRIPTION
This should fix #309 which originated from #30. Original issue seems to be caused by how JUCE sends batch render calls to the gpu causing hangs with mesa/dri leading to dropped input events, after fiddling around a bit i found that if you're handling rendering yourself (not using the paint override) like Bespoke does, you should set `ComponentPaintingEnabled` to false to improve performance and avoid redundant call to paint. 
Note: this might also benefit performance on other platforms.

From Juce Docs:
> By default this is set to true. If you're not using any paint() method functionality and are doing all your rendering in an OpenGLRenderer, you should disable it to improve performance.

---

This fixes the issue on my machine and Bespoke runs at 60fps with no issues.