### PR TITLE
Fix and simplify resource directory discovery

### DIFF
--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -311,7 +311,7 @@ void BeatBloks::FilesDropped(std::vector<std::string> files, int x, int y)
    if (!hasCached)   //have to look it up with echonest
    {
       char command[2048];
-      sprintf(command,"export ECHO_NEST_API_KEY=SUZ3W7PAIVQQXZCAW; export PATH=/usr/local/bin:$PATH; python \"%s\" \"%s\"", ofToDataPath("get_echonest_remix_data.py",true).c_str(), files[0].c_str());
+      sprintf(command,"export ECHO_NEST_API_KEY=SUZ3W7PAIVQQXZCAW; export PATH=/usr/local/bin:$PATH; python \"%s\" \"%s\"", ofToDataPath("get_echonest_remix_data.py").c_str(), files[0].c_str());
       output = popen(command, "r");
       cachedFile = fopen(ofToDataPath(cachedFilename).c_str(), "w");
    }
@@ -488,14 +488,14 @@ void BeatBloks::ButtonClicked(ClickButton *button)
    if (button == mGetLuckyButton)
    {
       std::vector<std::string> fake;
-      fake.push_back(ofToDataPath("Daft Punk - Get Lucky.mp3",true));
+      fake.push_back(ofToDataPath("Daft Punk - Get Lucky.mp3"));
       FilesDropped(fake, 0, 0);
       mOffset = -53275;
    }
    if (button == mLoseYourselfButton)
    {
       std::vector<std::string> fake;
-      fake.push_back(ofToDataPath("Daft Punk - Lose Yourself To Dance.mp3",true));
+      fake.push_back(ofToDataPath("Daft Punk - Lose Yourself To Dance.mp3"));
       FilesDropped(fake, 0, 0);
    }
 }

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -29,10 +29,6 @@
 #include <windows.h>
 #endif
 
-#if BESPOKE_MAC
-#include <CoreFoundation/CoreFoundation.h>
-#endif
-
 #include "juce_opengl/juce_opengl.h"
 using namespace juce::gl;
 using namespace juce;
@@ -65,126 +61,53 @@ ofColor ofColor::clear(0, 0, 0, 0);
 NVGcontext* gNanoVG = nullptr;
 NVGcontext* gFontBoundsNanoVG = nullptr;
 
-std::string ofToDataPath(std::string path, bool makeAbsolute)
+std::string ofToDataPath(const std::string& path)
 {
-   if (path.empty() == false && path[0] == '.')
+   if (!path.empty() && (path[0] == '.' || juce::File::isAbsolutePath(path)))
       return path;
-   if (path.empty() == false && path[0] == '/')
-      return path;
-   if (path.empty() == false && path[1] == ':')
-      return path;
-   
-   static juce::File sWorkingDirectory;
-   static bool sFirstTime = true;
-   if (sFirstTime)
-   {
-      sFirstTime = false;
-      sWorkingDirectory = juce::File::getCurrentWorkingDirectory();
-   }
-   sWorkingDirectory.setAsCurrentWorkingDirectory(); //restore working directory, in case a VST plugin changed it (ROLI Studio Drums does this!)
-   
-   static std::string sDataDir = "";
-   if (sDataDir == "")
-   {
-      std::string dataDir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("BespokeSynth").getFullPathName().toStdString();
-      ofStringReplace(dataDir, "\\", "/");
+
+   static const auto sDataDir = [] {
+      auto dataDir = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory).getChildFile("BespokeSynth").getFullPathName().toStdString();
+#if BESPOKE_WINDOWS
+      std::replace(begin(dataDir), end(dataDir), '\\', '/');
+#endif
       UpdateUserData(dataDir);
-      sDataDir = dataDir;
-   }
+      dataDir += '/';
+      return dataDir;
+   }();
    
-   return sDataDir + "/" + path;
+   return sDataDir + path;
 }
 
-std::string ofToResourcePath(std::string path, bool makeAbsolute)
+std::string ofToFactoryPath(const std::string &subdir)
 {
-   if (path.empty() == false && path[0] == '.')
-      return path;
-   if (path.empty() == false && path[0] == '/')
-      return path;
-   if (path.empty() == false && path[1] == ':')
-      return path;
-   
-   static juce::File sWorkingDirectory;
-   static bool sFirstTime = true;
-   if (sFirstTime)
-   {
-      sFirstTime = false;
-      sWorkingDirectory = juce::File::getCurrentWorkingDirectory();
-   }
-   sWorkingDirectory.setAsCurrentWorkingDirectory(); //restore working directory, in case a VST plugin changed it (ROLI Studio Drums does this!)
-   
-   static std::string sResourceDir = "";
-   if (sResourceDir == "")
-   {
-#if JUCE_WINDOWS
-      std::string localResourceDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
-      if (juce::File(localResourceDir).exists())
-         sResourceDir = localResourceDir;
-      else
-         sResourceDir = File::getCurrentWorkingDirectory().getChildFile("../../../resource").getFullPathName().toStdString();   //fall back to looking at OSX dir in dev environment
-      ofStringReplace(sResourceDir, "\\", "/");
-
-#elif JUCE_LINUX
-      std::string localDataDir = File::getCurrentWorkingDirectory().getChildFile("resource").getFullPathName().toStdString();
-      std::string cmakeDataDir = File(Bespoke::CMAKE_INSTALL_PREFIX).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString();
-      std::string installedDataDir = File::getSpecialLocation(File::globalApplicationsDirectory).getChildFile("share/BespokeSynth/resource").getFullPathName().toStdString(); // /usr/share/BespokeSynth/resource
-      if (juce::File(localDataDir).exists())
-         sResourceDir = localDataDir;
-      else if (getenv("BESPOKE_DATA_DIR") && juce::File(getenv("BESPOKE_DATA_DIR")).exists())
-          sResourceDir = getenv("BESPOKE_DATA_DIR");
-      else if (juce::File(cmakeDataDir).exists())
-         sResourceDir = cmakeDataDir;
-      else if (juce::File(installedDataDir).exists())
-         sResourceDir = installedDataDir;
-      ofLog() << "Resources directory is '" << sResourceDir << "'";
-   
-#elif BESPOKE_MAC
-      auto bundle = CFBundleGetMainBundle();
-      bool foundResources = false;
-      if (bundle)
-      {
-
-          auto url = CFBundleCopyResourcesDirectoryURL(bundle);
-
-          if (url)
-          {
-              char bResPath[PATH_MAX];
-              if (CFURLGetFileSystemRepresentation(url, true, (UInt8*)bResPath, PATH_MAX))
-              {
-                  std::string p = bResPath;
-                  p += "/resource";
-                  if (juce::File(p).exists()) {
-                      foundResources = true;
-                      sResourceDir = p;
-                      ofLog() << "macOS: Resource Bundle From [" << p << "]";
-                  }
-              }
-              CFRelease(url);
-          }
-      }
-
-      if (!foundResources) {
-          // Retain the old code for now just in case
-#if DEBUG
-          std::string relative = "../Release/resource";
+   std::string result;
+#if BESPOKE_MAC
+   auto resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentApplicationFile).getChildFile("Contents/Resources").getChildFile(subdir);
 #else
-          std::string relative = "resource";
+   auto resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentExecutableFile).getSiblingFile(subdir);
+#if BESPOKE_LINUX
+   if (!resDir.isDirectory())
+      resDir = juce::File{juce::CharPointer_UTF8{Bespoke::CMAKE_INSTALL_PREFIX}}.getChildFile("share/BespokeSynth").getChildFile(subdir);
 #endif
+#endif
+   if (!resDir.isDirectory())
+      throw std::runtime_error{"Application directory not found. Please reinstall Bespoke."};
 
-          std::string localResourceDir = File::getCurrentWorkingDirectory().getChildFile(
-                  relative).getFullPathName().toStdString();
-          if (juce::File(localResourceDir).exists()) {
-              sResourceDir = localResourceDir;
-          } else {
-              sResourceDir = "/Applications/BespokeSynth/resource";
-          }
-      }
-#else
-#error Mac, Linux or Windows only supported at this time
+   result = resDir.getFullPathName().toStdString();
+#if BESPOKE_WINDOWS
+   std::replace(begin(result), end(result), '\\', '/');
 #endif
-   }
-   
-   return sResourceDir + "/" + path;
+   return result;
+}
+
+std::string ofToResourcePath(const std::string& path)
+{
+   if (!path.empty() && (path[0] == '.' || juce::File::isAbsolutePath(path)))
+      return path;
+
+   static const auto sResourceDir = ofToFactoryPath("resource") + '/';
+   return sResourceDir + path;
 }
 
 struct StyleStack

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -198,8 +198,9 @@ private:
 
 typedef ofVec2f ofPoint;
 
-std::string ofToDataPath(std::string path, bool makeAboslute = false);
-std::string ofToResourcePath(std::string path, bool makeAboslute = false);
+std::string ofToDataPath(const std::string& path);
+std::string ofToFactoryPath(const std::string& path);
+std::string ofToResourcePath(const std::string& path);
 void ofPushStyle();
 void ofPopStyle();
 void ofPushMatrix();

--- a/Source/ofxJSONElement.cpp
+++ b/Source/ofxJSONElement.cpp
@@ -68,7 +68,7 @@ bool ofxJSONElement::open(std::string filename)
 //--------------------------------------------------------------
 bool ofxJSONElement::save(std::string filename, bool pretty)
 {
-   filename = ofToDataPath(filename, true);
+   filename = ofToDataPath(filename);
    juce::File file(filename);
    file.create();
    if (!file.exists()) {


### PR DESCRIPTION
Follow-up of a Discord chat with @baconpaul today. Fixes #354

---
The resource directory was resolved relative to the CWD everywhere
except on macOS, causing resources to not be found in many cases.

This removes reliance on the CWD and only looks in one well-defined path
(two on non-Apple UNIX). If the resource dir ain't there, that's a usage
error and we throw.

The paths are as follows:

macOS: \<Bundle directory\>/Contents/Resources/resource
Windows: <BespokeSynth.exe directory>/resource
UNIX: \<BespokeSynth executable directory\>/resource
      \<prefix\>/share/BespokeSynth/resource (for distros)