### PR TITLE
make vst windows optionally always on top

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -310,7 +310,7 @@ void ModularSynth::LoadResources(void* nanoVG, void* fontBoundsNanoVG)
    LoadGlobalResources();
 
    if (!gFont.IsLoaded())
-      mFatalError = "couldn't load font from " + gFont.GetFontPath();
+      mFatalError = "couldn't load font from " + gFont.GetFontPath() + "\nmaybe bespoke can't find your resources directory?";
 }
 
 void ModularSynth::InitIOBuffers(int inputChannelCount, int outputChannelCount)

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -864,7 +864,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
       {
          if (mWindow == nullptr)
             mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateWindow(this, VSTWindow::Normal));
-         mWindow->toFront (true);
+         mWindow->ShowWindow();
       }
       
       //if (mWindow->GetNSViewComponent())

--- a/Source/VSTWindow.cpp
+++ b/Source/VSTWindow.cpp
@@ -51,8 +51,7 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
                          mainMon.getY() + mainMon.getHeight() / 4);
    }
 
-   setUsingNativeTitleBar(true);
-   setVisible (true);
+   setVisible(true);
    
 #ifdef JUCE_MAC
    if (pluginEditor->getNumChildComponents() > 0)
@@ -96,6 +95,15 @@ VSTWindow* VSTWindow::CreateWindow(VSTPlugin* vst, WindowFormatType type)
 VSTWindow::~VSTWindow()
 {
    clearContentComponent();
+}
+
+void VSTWindow::ShowWindow()
+{
+   bool alwaysOnTop = true;
+   if (!TheSynth->GetUserPrefs()["vst_always_on_top"].isNull())
+      alwaysOnTop = TheSynth->GetUserPrefs()["vst_always_on_top"].asBool();
+   setAlwaysOnTop(alwaysOnTop);
+   toFront(true);
 }
 
 void VSTWindow::moved()

--- a/Source/VSTWindow.h
+++ b/Source/VSTWindow.h
@@ -50,6 +50,8 @@ public:
    
    VSTWindow(VSTPlugin* vst, Component* pluginEditor, WindowFormatType);
    ~VSTWindow();
+
+   void ShowWindow();
    
    static VSTWindow* CreateWindow(VSTPlugin* vst, WindowFormatType);
    


### PR DESCRIPTION
also, undo #341 because it was causing a crash when loading vital on windows
I didn't add an an option in the settings menu to enable/disable vst always-on-top, but I'll be refactoring the settings menu soon and add it then