### PR TITLE
get rid of strange decoupling between module name and module title bar

### DIFF
--- a/Source/Amplifier.h
+++ b/Source/Amplifier.h
@@ -39,7 +39,7 @@ public:
    virtual ~Amplifier();
    static IDrawableModule* Create() { return new Amplifier(); }
    
-   std::string GetTitleLabel() override { return "gain"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -45,7 +45,7 @@ public:
    ~Arpeggiator();
    static IDrawableModule* Create() { return new Arpeggiator(); }
    
-   std::string GetTitleLabel() override { return "arpeggiator"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioLevelToCV();
    static IDrawableModule* Create() { return new AudioLevelToCV(); }
    
-   std::string GetTitleLabel() override { return "level to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -39,7 +39,7 @@ public:
    virtual ~AudioMeter();
    static IDrawableModule* Create() { return new AudioMeter(); }
    
-   std::string GetTitleLabel() override { return "audiometer"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/AudioRouter.h
+++ b/Source/AudioRouter.h
@@ -39,7 +39,7 @@ public:
    virtual ~AudioRouter();
    static IDrawableModule* Create() { return new AudioRouter(); }
    
-   std::string GetTitleLabel() override { return "audio router"; }
+   
    void CreateUIControls() override;
 
    void SetActiveIndex(int index) { mRouteIndex = index; }

--- a/Source/AudioSend.h
+++ b/Source/AudioSend.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioSend();
    static IDrawableModule* Create() { return new AudioSend(); }
    
-   std::string GetTitleLabel() override { return "send"; }
+   
    void CreateUIControls() override;
 
    void SetSend(float amount, bool crossfade) { mAmount = amount; mCrossfade = crossfade; }

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~AudioToCV();
    static IDrawableModule* Create() { return new AudioToCV(); }
    
-   std::string GetTitleLabel() override { return "audio to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/AudioToPulse.h
+++ b/Source/AudioToPulse.h
@@ -41,7 +41,7 @@ public:
    virtual ~AudioToPulse();
    static IDrawableModule* Create() { return new AudioToPulse(); }
 
-   std::string GetTitleLabel() override { return "audio to pulse"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Autotalent.cpp
+++ b/Source/Autotalent.cpp
@@ -933,14 +933,6 @@ void Autotalent::Process(double time)
    mLatency = (N-1);
 }
 
-std::string Autotalent::GetTitleLabel()
-{
-   if (Minimized())
-      return "autotalent";
-   else
-      return "autotalent "+ofToString(mPitch,2)+" "+ofToString(mConfidence,2);
-}
-
 void Autotalent::DrawModule()
 {
    if (Minimized() || IsVisible() == false)

--- a/Source/Autotalent.h
+++ b/Source/Autotalent.h
@@ -44,7 +44,7 @@ public:
    ~Autotalent();
    static IDrawableModule* Create() { return new Autotalent(); }
    
-   std::string GetTitleLabel() override;
+   
    void CreateUIControls() override;
 
    //IAudioReceiver

--- a/Source/BandVocoder.h
+++ b/Source/BandVocoder.h
@@ -45,7 +45,6 @@ public:
    virtual ~BandVocoder();
    static IDrawableModule* Create() { return new BandVocoder(); }
    
-   std::string GetTitleLabel() override { return "vocoder"; }
    void CreateUIControls() override;
    
    void SetCarrierBuffer(float* carrier, int bufferSize) override;

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -50,7 +50,7 @@ public:
    ~BeatBloks();
    static IDrawableModule* Create() { return new BeatBloks(); }
    
-   std::string GetTitleLabel() override { return "BEAT BLOKS by @awwbees"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -98,7 +98,7 @@ public:
    virtual ~Beats();
    static IDrawableModule* Create() { return new Beats(); }
    
-   std::string GetTitleLabel() override { return "beats"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/BiquadFilterEffect.h
+++ b/Source/BiquadFilterEffect.h
@@ -43,7 +43,7 @@ public:
    
    static IAudioEffect* Create() { return new BiquadFilterEffect(); }
    
-   std::string GetTitleLabel() override { return "biquad"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/BitcrushEffect.h
+++ b/Source/BitcrushEffect.h
@@ -38,7 +38,7 @@ public:
    
    static IAudioEffect* Create() { return new BitcrushEffect(); }
    
-   std::string GetTitleLabel() override { return "bitcrush"; }
+   
    void CreateUIControls() override;
    
    //IAudioEffect

--- a/Source/ButterworthFilterEffect.h
+++ b/Source/ButterworthFilterEffect.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new ButterworthFilterEffect(); }
    
-   std::string GetTitleLabel() override { return "butterworth"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/CanvasControls.h
+++ b/Source/CanvasControls.h
@@ -42,7 +42,7 @@ public:
    ~CanvasControls();
    static IDrawableModule* Create() { return new CanvasControls(); }
    
-   std::string GetTitleLabel() override { return ""; }
+   
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
    bool CanMinimize() override { return false; }

--- a/Source/Capo.h
+++ b/Source/Capo.h
@@ -39,7 +39,7 @@ public:
    Capo();
    static IDrawableModule* Create() { return new Capo(); }
    
-   std::string GetTitleLabel() override { return "capo"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -50,7 +50,7 @@ public:
    static IDrawableModule* Create() { return new ChaosEngine(); }
    static bool CanCreate() { return TheChaosEngine == nullptr; }
    
-   std::string GetTitleLabel() override { return "CHAOS ENGINE"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/ChordDisplayer.h
+++ b/Source/ChordDisplayer.h
@@ -36,7 +36,7 @@ public:
    ChordDisplayer();
    static IDrawableModule* Create() { return new ChordDisplayer(); }
    
-   std::string GetTitleLabel() override { return "chord displayer"; }
+   
    
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/ChordHolder.h
+++ b/Source/ChordHolder.h
@@ -39,7 +39,7 @@ public:
    ChordHolder();
    static IDrawableModule* Create() { return new ChordHolder(); }
 
-   std::string GetTitleLabel() override { return "chord holder"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -41,7 +41,7 @@ public:
    Chorder();
    static IDrawableModule* Create() { return new Chorder(); }
    
-   std::string GetTitleLabel() override { return "chorder"; }
+   
    void CreateUIControls() override;
    
    void AddTone(int tone, float velocity=1);

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -77,7 +77,7 @@ public:
    ~CircleSequencer();
    static IDrawableModule* Create() { return new CircleSequencer(); }
    
-   std::string GetTitleLabel() override { return "circle sequencer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ClipLauncher.h
+++ b/Source/ClipLauncher.h
@@ -48,7 +48,7 @@ public:
    ~ClipLauncher();
    static IDrawableModule* Create() { return new ClipLauncher(); }
    
-   std::string GetTitleLabel() override { return "clip launcher"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ComboGridController.cpp
+++ b/Source/ComboGridController.cpp
@@ -40,18 +40,6 @@ void ComboGridController::CreateUIControls()
    IDrawableModule::CreateUIControls();
 }
 
-std::string ComboGridController::GetTitleLabel()
-{
-   std::string title = "combo:";
-   for (int i=0; i<mGrids.size(); ++i)
-   {
-      title += dynamic_cast<IClickable*>(mGrids[i])->Name();
-      if (i < mGrids.size()-1)
-         title += "+";
-   }
-   return title;
-}
-
 void ComboGridController::Init()
 {
    IDrawableModule::Init();

--- a/Source/ComboGridController.h
+++ b/Source/ComboGridController.h
@@ -35,7 +35,7 @@ public:
    ~ComboGridController() {}
    static IDrawableModule* Create() { return new ComboGridController(); }
    
-   std::string GetTitleLabel() override;
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/CommentDisplay.h
+++ b/Source/CommentDisplay.h
@@ -38,7 +38,7 @@ public:
    virtual ~CommentDisplay();
    static IDrawableModule* Create() { return new CommentDisplay(); }
    
-   std::string GetTitleLabel() override { return "comment"; }
+   
    void CreateUIControls() override;
    
    void TextEntryComplete(TextEntry* entry) override;

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -118,7 +118,7 @@ public:
    
    static IAudioEffect* Create() { return new Compressor(); }
    
-   std::string GetTitleLabel() override { return "compressor"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -43,7 +43,7 @@ public:
    ~ControlSequencer();
    static IDrawableModule* Create() { return new ControlSequencer(); }
    
-   std::string GetTitleLabel() override { return "control sequencer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ControlTactileFeedback.h
+++ b/Source/ControlTactileFeedback.h
@@ -39,7 +39,7 @@ public:
    ~ControlTactileFeedback();
    static IDrawableModule* Create() { return new ControlTactileFeedback(); }
    
-   std::string GetTitleLabel() override { return "tactile"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/ControllingSong.h
+++ b/Source/ControllingSong.h
@@ -47,7 +47,7 @@ public:
    ~ControllingSong();
    static IDrawableModule* Create() { return new ControllingSong(); }
    
-   std::string GetTitleLabel() override { return "controlling song"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -43,7 +43,7 @@ public:
    ~CurveLooper();
    static IDrawableModule* Create() { return new CurveLooper(); }
    
-   std::string GetTitleLabel() override { return "curve looper"; }
+   
    void CreateUIControls() override;
    
    IUIControl* GetUIControl() const { return mUIControl; }

--- a/Source/DCOffset.h
+++ b/Source/DCOffset.h
@@ -39,7 +39,7 @@ public:
    virtual ~DCOffset();
    static IDrawableModule* Create() { return new DCOffset(); }
    
-   std::string GetTitleLabel() override { return "dc offset"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/DCRemoverEffect.h
+++ b/Source/DCRemoverEffect.h
@@ -39,7 +39,7 @@ public:
    
    static IAudioEffect* Create() { return new DCRemoverEffect(); }
    
-   std::string GetTitleLabel() override { return "dc remover"; }
+   
    
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer) override;

--- a/Source/DebugAudioSource.h
+++ b/Source/DebugAudioSource.h
@@ -41,7 +41,7 @@ public:
    ~DebugAudioSource();
    static IDrawableModule* Create() { return new DebugAudioSource(); }
    
-   std::string GetTitleLabel() override { return "debug"; }
+   
    
    //IAudioSource
    void Process(double time) override;

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -44,7 +44,7 @@ public:
    
    static IAudioEffect* Create() { return new DelayEffect(); }
    
-   std::string GetTitleLabel() override { return "delay"; }
+   
    void CreateUIControls() override;
    bool Enabled() const override { return mEnabled; }
 

--- a/Source/DistortionEffect.h
+++ b/Source/DistortionEffect.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new DistortionEffect(); }
    
-   std::string GetTitleLabel() override { return "distort"; }
+   
    void CreateUIControls() override;
    
    void SetClip(float amount);

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -53,7 +53,7 @@ public:
    void DrawModule() override;
    void SetDimensions(int w, int h) { mWidth = w; mHeight = h; }
    bool HasTitleBar() const override { return false; }
-   std::string GetTitleLabel() override { return ""; }
+   
    void GetDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
    bool ShouldClipContents() override { return false; }
    DropdownList* GetOwner() const { return mOwner; }

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -56,7 +56,7 @@ public:
    ~DrumPlayer();
    static IDrawableModule* Create() { return new DrumPlayer(); }
    
-   std::string GetTitleLabel() override { return "drumplayer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -59,7 +59,7 @@ public:
    ~DrumSynth();
    static IDrawableModule* Create() { return new DrumSynth(); }
    
-   std::string GetTitleLabel() override { return "drumsynth"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/EQEffect.h
+++ b/Source/EQEffect.h
@@ -46,7 +46,7 @@ public:
    
    static IAudioEffect* Create() { return new EQEffect(); }
    
-   std::string GetTitleLabel() override { return "basiceq"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -42,7 +42,7 @@ public:
    virtual ~EQModule();
    static IDrawableModule* Create() { return new EQModule(); }
 
-   std::string GetTitleLabel() override { return "eq"; }
+   
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -46,7 +46,7 @@ public:
    virtual ~EffectChain();
    static IDrawableModule* Create() { return new EffectChain(); }
    
-   std::string GetTitleLabel() override { return "effect chain"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -84,7 +84,6 @@ public:
    void SetEnabled(bool enabled) override {} //don't use this one
    bool Enabled() const override { return true; }
    bool HasTitleBar() const override { return mPinned; }
-   std::string GetTitleLabel() override { return mPinned ? "envelope editor" : ""; }
    bool IsSaveable() override { return mPinned; }
    void CreateUIControls() override;
    void MouseReleased() override;

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -51,7 +51,7 @@ public:
    void Start(double time, const ::ADSR& adsr);
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    bool Enabled() const override { return mEnabled; }
-   std::string GetTitleLabel() override { return "envelope"; }
+   
    void CreateUIControls() override;
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;

--- a/Source/EventCanvas.h
+++ b/Source/EventCanvas.h
@@ -45,7 +45,7 @@ public:
    ~EventCanvas();
    static IDrawableModule* Create() { return new EventCanvas(); }
    
-   std::string GetTitleLabel() override { return "event canvas"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/FFTtoAdditive.h
+++ b/Source/FFTtoAdditive.h
@@ -46,7 +46,7 @@ public:
    virtual ~FFTtoAdditive();
    static IDrawableModule* Create() { return new FFTtoAdditive(); }
    
-   std::string GetTitleLabel() override { return "fft to additive"; }
+   
    void CreateUIControls() override;
 
    //IAudioReceiver

--- a/Source/FMSynth.h
+++ b/Source/FMSynth.h
@@ -44,7 +44,7 @@ public:
    ~FMSynth();
    static IDrawableModule* Create() { return new FMSynth(); }
    
-   std::string GetTitleLabel() override { return "FM"; }
+   
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/FeedbackModule.h
+++ b/Source/FeedbackModule.h
@@ -40,7 +40,7 @@ public:
    virtual ~FeedbackModule();
    static IDrawableModule* Create() { return new FeedbackModule(); }
    
-   std::string GetTitleLabel() override { return "feedback"; }
+   
    void CreateUIControls() override;
    
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/FilterViz.h
+++ b/Source/FilterViz.h
@@ -42,7 +42,7 @@ public:
    ~FilterViz();
    static IDrawableModule* Create() { return new FilterViz(); }
    
-   std::string GetTitleLabel() override { return "filter viz"; }
+   
    void CreateUIControls() override;
    
    //IDrawableModule

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -88,7 +88,7 @@ public:
    FloatSlider* GetOwner() { return mTarget; }
    bool Enabled() const override { return mEnabled; }
    bool HasTitleBar() const override { return mPinned; }
-   std::string GetTitleLabel() override { return mPinned ? "lfo" : ""; }
+   
    bool IsSaveable() override { return mPinned; }
    void CreateUIControls() override;
    bool IsPinned() const { return mPinned; }

--- a/Source/FollowingSong.h
+++ b/Source/FollowingSong.h
@@ -45,7 +45,7 @@ public:
    ~FollowingSong();
    static IDrawableModule* Create() { return new FollowingSong(); }
    
-   std::string GetTitleLabel() override { return "following song"; }
+   
    void CreateUIControls() override;
    
    void LoadSample(const char* file);

--- a/Source/FormantFilterEffect.h
+++ b/Source/FormantFilterEffect.h
@@ -42,7 +42,7 @@ public:
    
    static IAudioEffect* Create() { return new FormantFilterEffect(); }
    
-   std::string GetTitleLabel() override { return "formant"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/FourOnTheFloor.h
+++ b/Source/FourOnTheFloor.h
@@ -39,7 +39,7 @@ public:
    ~FourOnTheFloor();
    static IDrawableModule* Create() { return new FourOnTheFloor(); }
    
-   std::string GetTitleLabel() override { return "four on the floor"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/FreeverbEffect.h
+++ b/Source/FreeverbEffect.h
@@ -40,7 +40,7 @@ public:
    
    static IAudioEffect* Create() { return new FreeverbEffect(); }
    
-   std::string GetTitleLabel() override { return "freeverb"; }
+   
    void CreateUIControls() override;
    
    //IAudioEffect

--- a/Source/FreqDelay.h
+++ b/Source/FreqDelay.h
@@ -40,7 +40,7 @@ public:
    virtual ~FreqDelay();
    static IDrawableModule* Create() { return new FreqDelay(); }
    
-   std::string GetTitleLabel() override { return "freq delay"; }
+   
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/FreqDomainBoilerplate.h
+++ b/Source/FreqDomainBoilerplate.h
@@ -43,7 +43,7 @@ public:
    virtual ~FreqDomainBoilerplate();
    static IDrawableModule* Create() { return new FreqDomainBoilerplate(); }
    
-   std::string GetTitleLabel() override { return "freq domain"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -47,7 +47,7 @@ public:
    ~FubbleModule();
    static IDrawableModule* Create() { return new FubbleModule(); }
    
-   std::string GetTitleLabel() override { return "fubble"; }
+   
    void CreateUIControls() override;
    
    //IDrawableModule

--- a/Source/GainStageEffect.h
+++ b/Source/GainStageEffect.h
@@ -36,7 +36,7 @@ public:
    GainStageEffect();
    static IAudioEffect* Create() { return new GainStageEffect(); }
    
-   std::string GetTitleLabel() override { return "gain stage"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/GateEffect.h
+++ b/Source/GateEffect.h
@@ -37,7 +37,7 @@ public:
    GateEffect();
    static IAudioEffect* Create() { return new GateEffect(); }
    
-   std::string GetTitleLabel() override { return "gate"; }
+   
    void CreateUIControls() override;
    
    void SetAttack(float ms) { mAttackTime = ms; }

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -38,7 +38,7 @@ public:
    virtual ~GlobalControls();
    static IDrawableModule* Create() { return new GlobalControls(); }
 
-   std::string GetTitleLabel() override { return "global controls"; }
+   
    void CreateUIControls() override;
    void Poll() override;
 

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -46,7 +46,7 @@ public:
    ~GridModule();
    static IDrawableModule* Create() { return new GridModule(); }
    
-   std::string GetTitleLabel() override { return "grid"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -42,7 +42,7 @@ public:
    ~GridSliders();
    static IDrawableModule* Create() { return new GridSliders(); }
 
-   std::string GetTitleLabel() override { return "grid sliders"; }
+   
    void CreateUIControls() override;
 
    //IDrawableModule

--- a/Source/GroupControl.h
+++ b/Source/GroupControl.h
@@ -38,7 +38,7 @@ public:
    ~GroupControl();
    static IDrawableModule* Create() { return new GroupControl(); }
    
-   std::string GetTitleLabel() override { return "group control"; }
+   
    void CreateUIControls() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -37,7 +37,7 @@ public:
    virtual ~HelpDisplay();
    static IDrawableModule* Create() { return new HelpDisplay(); }
    
-   std::string GetTitleLabel() override { return "help"; }
+   
    bool IsSaveable() override { return false; }
    bool HasTitleBar() const override { return false; }
    void CreateUIControls() override;

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -341,8 +341,11 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
       ofPopMatrix();
    }
    
-   ofSetColor(color * (1-GetBeaconAmount()) + ofColor::yellow * GetBeaconAmount(), gModuleDrawAlpha);
-   DrawTextBold(GetTitleLabel(),5+enableToggleOffset,10-titleBarHeight,16);
+   if (HasTitleBar())
+   {
+      ofSetColor(color * (1 - GetBeaconAmount()) + ofColor::yellow * GetBeaconAmount(), gModuleDrawAlpha);
+      DrawTextBold(GetTitleLabel(), 5 + enableToggleOffset, 10 - titleBarHeight, 16);
+   }
    
    if (Enabled() && mShouldDrawOutline)
    {

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -97,7 +97,7 @@ public:
    bool Minimized() const { return mMinimizeAnimation > 0; }
    virtual void MouseReleased() override;
    virtual void FilesDropped(std::vector<std::string> files, int x, int y) {}
-   virtual std::string GetTitleLabel() { return "&&&fixme&&&"; }
+   virtual std::string GetTitleLabel() const { return Name(); }
    virtual bool HasTitleBar() const { return true; }
    static float TitleBarHeight() { return mTitleBarHeight; }
    static ofColor GetColor(ModuleType type);

--- a/Source/InputChannel.h
+++ b/Source/InputChannel.h
@@ -38,7 +38,7 @@ public:
    virtual ~InputChannel();
    static IDrawableModule* Create() { return new InputChannel(); }
    
-   std::string GetTitleLabel() override { return "input"; }
+   
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/Inverter.h
+++ b/Source/Inverter.h
@@ -40,7 +40,7 @@ public:
    virtual ~Inverter();
    static IDrawableModule* Create() { return new Inverter(); }
    
-   std::string GetTitleLabel() override { return "inverter"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/KarplusStrong.h
+++ b/Source/KarplusStrong.h
@@ -46,7 +46,7 @@ public:
    ~KarplusStrong();
    static IDrawableModule* Create() { return new KarplusStrong(); }
    
-   std::string GetTitleLabel() override { return "karplus/strong"; }
+   
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -35,7 +35,7 @@ public:
    KeyboardDisplay();
    static IDrawableModule* Create() { return new KeyboardDisplay(); }
    
-   std::string GetTitleLabel() override { return "keyboard"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Kicker.h
+++ b/Source/Kicker.h
@@ -40,7 +40,7 @@ public:
    Kicker();
    static IDrawableModule* Create() { return new Kicker(); }
    
-   std::string GetTitleLabel() override { return "kicker"; }
+   
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void SetDrumPlayer(DrumPlayer* drumPlayer) { mDrumPlayer = drumPlayer; }

--- a/Source/KompleteKontrol.h
+++ b/Source/KompleteKontrol.h
@@ -46,7 +46,7 @@ public:
    ~KompleteKontrol();
    static IDrawableModule* Create() { return new KompleteKontrol(); }
    
-   std::string GetTitleLabel() override { return "komplete kontrol"; }
+   
    void CreateUIControls() override;
    
    void Poll() override;

--- a/Source/LFOController.h
+++ b/Source/LFOController.h
@@ -45,7 +45,7 @@ public:
    static IDrawableModule* Create() { return new LFOController(); }
    static bool CanCreate() { return TheLFOController == nullptr; }
    
-   std::string GetTitleLabel() override { return "LFO control"; }
+   
    void CreateUIControls() override;
    
    void SetSlider(FloatSlider* slider);

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -48,7 +48,7 @@ public:
    ~LaunchpadKeyboard();
    static IDrawableModule* Create() { return new LaunchpadKeyboard(); }
    
-   std::string GetTitleLabel() override { return "gridkeyboard"; }
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/LaunchpadNoteDisplayer.h
+++ b/Source/LaunchpadNoteDisplayer.h
@@ -39,7 +39,7 @@ public:
    LaunchpadNoteDisplayer();
    static IDrawableModule* Create() { return new LaunchpadNoteDisplayer(); }
    
-   std::string GetTitleLabel() override { return "grid display"; }
+   
 
    void SetLaunchpad(LaunchpadKeyboard* launchpad) { mLaunchpad = launchpad; }
 

--- a/Source/LinnstrumentControl.h
+++ b/Source/LinnstrumentControl.h
@@ -46,7 +46,7 @@ public:
    virtual ~LinnstrumentControl();
    static IDrawableModule* Create() { return new LinnstrumentControl(); }
    
-   std::string GetTitleLabel() override { return "linnstrument control"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/Lissajous.h
+++ b/Source/Lissajous.h
@@ -40,7 +40,7 @@ public:
    virtual ~Lissajous();
    static IDrawableModule* Create() { return new Lissajous(); }
    
-   std::string GetTitleLabel() override { return "lissajous"; }
+   
    void CreateUIControls() override;
    
    bool IsResizable() const override { return true; }

--- a/Source/LiveGranulator.h
+++ b/Source/LiveGranulator.h
@@ -46,7 +46,7 @@ public:
    
    static IAudioEffect* Create() { return new LiveGranulator(); }
    
-   std::string GetTitleLabel() override { return "granulator"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/LoopStorer.h
+++ b/Source/LoopStorer.h
@@ -47,7 +47,7 @@ public:
    ~LoopStorer();
    static IDrawableModule* Create() { return new LoopStorer(); }
    
-   std::string GetTitleLabel() override { return "loop storer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -54,7 +54,7 @@ public:
    ~Looper();
    static IDrawableModule* Create() { return new Looper(); }
    
-   std::string GetTitleLabel() override { return "looper"; }
+   
    void CreateUIControls() override;
 
    void SetRecorder(LooperRecorder* recorder);

--- a/Source/LooperGranulator.h
+++ b/Source/LooperGranulator.h
@@ -46,7 +46,7 @@ public:
    virtual ~LooperGranulator();
    static IDrawableModule* Create() { return new LooperGranulator(); }
 
-   std::string GetTitleLabel() override { return "looper granulator"; }
+   
    void CreateUIControls() override;
 
    void ProcessFrame(double time, float bufferOffset, float* output);

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -48,7 +48,7 @@ public:
    ~LooperRecorder();
    static IDrawableModule* Create() { return new LooperRecorder(); }
    
-   std::string GetTitleLabel() override { return "looper recorder"; }
+   
    void CreateUIControls() override;
 
    void Init() override;

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -26,7 +26,7 @@ public:
    virtual ~M185Sequencer();
    static IDrawableModule* Create() { return new M185Sequencer(); }
 
-   std::string GetTitleLabel() override { return "m185 sequencer"; }
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/MPESmoother.h
+++ b/Source/MPESmoother.h
@@ -41,7 +41,7 @@ public:
    virtual ~MPESmoother();
    static IDrawableModule* Create() { return new MPESmoother(); }
    
-   std::string GetTitleLabel() override { return "mpe smoother"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void Init() override;

--- a/Source/MPETweaker.h
+++ b/Source/MPETweaker.h
@@ -40,7 +40,7 @@ public:
    virtual ~MPETweaker();
    static IDrawableModule* Create() { return new MPETweaker(); }
    
-   std::string GetTitleLabel() override { return "mpe tweaker"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/MacroSlider.h
+++ b/Source/MacroSlider.h
@@ -40,7 +40,7 @@ public:
    virtual ~MacroSlider();
    static IDrawableModule* Create() { return new MacroSlider(); }
    
-   std::string GetTitleLabel() override { return "macroslider"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/Metronome.h
+++ b/Source/Metronome.h
@@ -41,7 +41,7 @@ public:
    ~Metronome();
    static IDrawableModule* Create() { return new Metronome(); }
    
-   std::string GetTitleLabel() override { return "metronome"; }
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/MidiCapturer.h
+++ b/Source/MidiCapturer.h
@@ -58,7 +58,7 @@ public:
    virtual ~MidiCapturer();
    static IDrawableModule* Create() { return new MidiCapturer(); }
    
-   std::string GetTitleLabel() override { return "midi capturer"; }
+   
    void Init() override;
    
    void AddDummyController(MidiCapturerDummyController* controller);

--- a/Source/MidiControlChange.h
+++ b/Source/MidiControlChange.h
@@ -41,7 +41,7 @@ public:
    MidiControlChange();
    static IDrawableModule* Create() { return new MidiControlChange(); }
    
-   std::string GetTitleLabel() override { return "midicc"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -265,7 +265,6 @@ public:
    ~MidiController();
    static IDrawableModule* Create() { return new MidiController(); }
    
-   std::string GetTitleLabel() override { return Name() + std::string("   "); }
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/MidiOutput.h
+++ b/Source/MidiOutput.h
@@ -42,7 +42,7 @@ public:
    virtual ~MidiOutputModule();
    static IDrawableModule* Create() { return new MidiOutputModule(); }
    
-   std::string GetTitleLabel() override { return mDevice.Name(); }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/Minimap.cpp
+++ b/Source/Minimap.cpp
@@ -14,10 +14,6 @@ bool Minimap::AlwaysOnTop() { return true; }
 
 bool Minimap::IsSingleton() const { return true; }
 
-bool Minimap::HasTitleBar() const { return false; }
-
-std::string Minimap::GetTitleLabel() { return ""; }
-
 void Minimap::GetDimensions(float& width, float& height)
 {
     float windowWidth = ofGetWidth();

--- a/Source/Minimap.h
+++ b/Source/Minimap.h
@@ -38,11 +38,10 @@ class Minimap : public IDrawableModule
     ~Minimap();
     void DrawModule() override;
     bool AlwaysOnTop() override;
-    std::string GetTitleLabel() override;
+    
     void GetDimensions(float & width, float & height) override;
   private:
     bool IsSingleton() const override;
-    bool HasTitleBar() const override;
     void ComputeBoundingBox(ofRectangle & rect);
     ofRectangle CoordsToMinimap(ofRectangle & boundingBox, ofRectangle & source);
     void DrawModulesOnMinimap();

--- a/Source/ModWheel.h
+++ b/Source/ModWheel.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModWheel();
    static IDrawableModule* Create() { return new ModWheel(); }
    
-   std::string GetTitleLabel() override { return "modwheel"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModWheelToCV.h
+++ b/Source/ModWheelToCV.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModWheelToCV();
    static IDrawableModule* Create() { return new ModWheelToCV(); }
    
-   std::string GetTitleLabel() override { return "modwheel to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -310,7 +310,7 @@ void ModularSynth::LoadResources(void* nanoVG, void* fontBoundsNanoVG)
    LoadGlobalResources();
 
    if (!gFont.IsLoaded())
-      mFatalError = "couldn't load font from " + gFont.GetFontPath();
+      mFatalError = "couldn't load font from " + gFont.GetFontPath() + "\nmaybe bespoke can't find your resources directory?";
 }
 
 void ModularSynth::InitIOBuffers(int inputChannelCount, int outputChannelCount)

--- a/Source/ModulationVisualizer.h
+++ b/Source/ModulationVisualizer.h
@@ -37,7 +37,7 @@ public:
    ModulationVisualizer();
    static IDrawableModule* Create() { return new ModulationVisualizer(); }
    
-   std::string GetTitleLabel() override { return "modulation visualizer"; }
+   
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/ModulatorAccum.h
+++ b/Source/ModulatorAccum.h
@@ -43,7 +43,7 @@ public:
    virtual ~ModulatorAccum();
    static IDrawableModule* Create() { return new ModulatorAccum(); }
 
-   std::string GetTitleLabel() override { return "accum"; }
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/ModulatorAdd.h
+++ b/Source/ModulatorAdd.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorAdd();
    static IDrawableModule* Create() { return new ModulatorAdd(); }
    
-   std::string GetTitleLabel() override { return "add"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorAddCentered.h
+++ b/Source/ModulatorAddCentered.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorAddCentered();
    static IDrawableModule* Create() { return new ModulatorAddCentered(); }
    
-   std::string GetTitleLabel() override { return "add centered"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModulatorCurve();
    static IDrawableModule* Create() { return new ModulatorCurve(); }
    
-   std::string GetTitleLabel() override { return "curve"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorExpression.h
+++ b/Source/ModulatorExpression.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModulatorExpression();
    static IDrawableModule* Create() { return new ModulatorExpression(); }
    
-   std::string GetTitleLabel() override { return "expression"; }
+   
    void CreateUIControls() override;
    
    //IModulator

--- a/Source/ModulatorGravity.h
+++ b/Source/ModulatorGravity.h
@@ -43,7 +43,7 @@ public:
    virtual ~ModulatorGravity();
    static IDrawableModule* Create() { return new ModulatorGravity(); }
    
-   std::string GetTitleLabel() override { return "gravity"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ModulatorMult.h
+++ b/Source/ModulatorMult.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorMult();
    static IDrawableModule* Create() { return new ModulatorMult(); }
    
-   std::string GetTitleLabel() override { return "mult"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModulatorSmoother.h
+++ b/Source/ModulatorSmoother.h
@@ -41,7 +41,7 @@ public:
    virtual ~ModulatorSmoother();
    static IDrawableModule* Create() { return new ModulatorSmoother(); }
    
-   std::string GetTitleLabel() override { return "smoother"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/ModulatorSubtract.h
+++ b/Source/ModulatorSubtract.h
@@ -39,7 +39,7 @@ public:
    virtual ~ModulatorSubtract();
    static IDrawableModule* Create() { return new ModulatorSubtract(); }
    
-   std::string GetTitleLabel() override { return "subtract"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -103,7 +103,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
    
    mAlignmentX = 10 + maxWidth;
    int x = mAlignmentX;
-   int y = 5;
+   int y = 5 + itemSpacing;
    
    TextEntry* nameEntry = new TextEntry(this,"",x,y,27,mSaveModule->NameMutable());
    mSaveDataControls.push_back(nameEntry);
@@ -198,9 +198,13 @@ void ModuleSaveDataPanel::DrawModule()
 {
    if (Minimized() || mAppearAmount < 1)
       return;
-   
+
    int x = mAlignmentX-5;
    int y = 5;
+
+   DrawTextLeftJustify("type", x, y + 12);
+   DrawTextBold(mSaveModule->GetTypeName(), mAlignmentX, y + 12);
+   y += itemSpacing;
    
    DrawTextLeftJustify("name", x, y+12);
    y += itemSpacing;

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -47,7 +47,7 @@ public:
    static IDrawableModule* Create() { return new ModuleSaveDataPanel(); }
    static bool CanCreate() { return TheSaveDataPanel == nullptr; }
    
-   std::string GetTitleLabel() override { return ""; }
+   std::string GetTitleLabel() const override { return ""; }
    bool AlwaysOnTop() override { return true; }
    bool CanMinimize() override { return false; }
    bool IsSingleton() const override { return true; }

--- a/Source/ModwheelToPressure.h
+++ b/Source/ModwheelToPressure.h
@@ -37,7 +37,7 @@ public:
    virtual ~ModwheelToPressure();
    static IDrawableModule* Create() { return new ModwheelToPressure(); }
    
-   std::string GetTitleLabel() override { return "modwheel to pressure"; }
+   
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //INoteReceiver

--- a/Source/ModwheelToVibrato.h
+++ b/Source/ModwheelToVibrato.h
@@ -40,7 +40,7 @@ public:
    virtual ~ModwheelToVibrato();
    static IDrawableModule* Create() { return new ModwheelToVibrato(); }
    
-   std::string GetTitleLabel() override { return "modwheel to vibrato"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -39,7 +39,7 @@ public:
    Monophonify();
    static IDrawableModule* Create() { return new Monophonify(); }
    
-   std::string GetTitleLabel() override { return "portamento"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/MultibandCompressor.h
+++ b/Source/MultibandCompressor.h
@@ -44,7 +44,7 @@ public:
    virtual ~MultibandCompressor();
    static IDrawableModule* Create() { return new MultibandCompressor(); }
    
-   std::string GetTitleLabel() override { return "multiband compressor"; }
+   
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -47,7 +47,7 @@ public:
    ~MultitapDelay();
    static IDrawableModule* Create() { return new MultitapDelay(); }
    
-   std::string GetTitleLabel() override { return "multitap delay"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/MultitrackRecorder.h
+++ b/Source/MultitrackRecorder.h
@@ -43,7 +43,7 @@ public:
    virtual ~MultitrackRecorder();
    static IDrawableModule* Create() { return new MultitrackRecorder(); }
    
-   std::string GetTitleLabel() override { return "multitrack recorder"; }
+   
    void CreateUIControls() override;
    ModuleContainer* GetContainer() override { return &mModuleContainer; }
    bool IsResizable() const override { return true; }
@@ -91,7 +91,7 @@ public:
    virtual ~MultitrackRecorderTrack();
    static IDrawableModule* Create() { return new MultitrackRecorderTrack(); }
 
-   std::string GetTitleLabel() override { return " "; }
+   
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
 

--- a/Source/Muter.h
+++ b/Source/Muter.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new Muter(); }
    
-   std::string GetTitleLabel() override { return "muter"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/Neighborhooder.h
+++ b/Source/Neighborhooder.h
@@ -38,7 +38,7 @@ public:
    Neighborhooder();
    static IDrawableModule* Create() { return new Neighborhooder(); }
    
-   std::string GetTitleLabel() override { return "notewrap"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoiseEffect.h
+++ b/Source/NoiseEffect.h
@@ -38,7 +38,7 @@ public:
    
    static IAudioEffect* Create() { return new NoiseEffect(); }
    
-   std::string GetTitleLabel() override { return "noisify"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -47,7 +47,7 @@ public:
    ~NoteCanvas();
    static IDrawableModule* Create() { return new NoteCanvas(); }
    
-   std::string GetTitleLabel() override { return "note canvas"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteChainNode.h
+++ b/Source/NoteChainNode.h
@@ -42,7 +42,7 @@ public:
    virtual ~NoteChainNode();
    static IDrawableModule* Create() { return new NoteChainNode(); }
    
-   std::string GetTitleLabel() override { return "note chain"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteChance.h
+++ b/Source/NoteChance.h
@@ -36,7 +36,7 @@ public:
    virtual ~NoteChance();
    static IDrawableModule* Create() { return new NoteChance(); }
    
-   std::string GetTitleLabel() override { return "note chance"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteCounter.h
+++ b/Source/NoteCounter.h
@@ -39,7 +39,7 @@ public:
    ~NoteCounter();
    static IDrawableModule* Create() { return new NoteCounter(); }
    
-   std::string GetTitleLabel() override { return "note counter"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteCreator.h
+++ b/Source/NoteCreator.h
@@ -41,7 +41,7 @@ public:
    virtual ~NoteCreator();
    static IDrawableModule* Create() { return new NoteCreator(); }
    
-   std::string GetTitleLabel() override { return "note creator"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteDelayer.h
+++ b/Source/NoteDelayer.h
@@ -40,7 +40,7 @@ public:
    ~NoteDelayer();
    static IDrawableModule* Create() { return new NoteDelayer(); }
    
-   std::string GetTitleLabel() override { return "note delayer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteDisplayer.h
+++ b/Source/NoteDisplayer.h
@@ -35,7 +35,7 @@ public:
    NoteDisplayer() = default;
    static IDrawableModule* Create() { return new NoteDisplayer(); }
    
-   std::string GetTitleLabel() override { return "notedisplayer"; }
+   
    
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/NoteFilter.h
+++ b/Source/NoteFilter.h
@@ -35,7 +35,7 @@ public:
    virtual ~NoteFilter();
    static IDrawableModule* Create() { return new NoteFilter(); }
    
-   std::string GetTitleLabel() override { return "note filter"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteFlusher.h
+++ b/Source/NoteFlusher.h
@@ -37,7 +37,7 @@ public:
    NoteFlusher();
    static IDrawableModule* Create() { return new NoteFlusher(); }
    
-   std::string GetTitleLabel() override { return "flusher"; }
+   
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;

--- a/Source/NoteGate.h
+++ b/Source/NoteGate.h
@@ -36,7 +36,7 @@ public:
    virtual ~NoteGate();
    static IDrawableModule* Create() { return new NoteGate(); }
    
-   std::string GetTitleLabel() override { return "note gate"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/NoteHocket.h
+++ b/Source/NoteHocket.h
@@ -40,7 +40,7 @@ public:
    NoteHocket();
    static IDrawableModule* Create() { return new NoteHocket(); }
    
-   std::string GetTitleLabel() override { return "hocket"; }
+   
    void CreateUIControls() override;
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteHumanizer.h
+++ b/Source/NoteHumanizer.h
@@ -43,7 +43,7 @@ public:
    ~NoteHumanizer();
    static IDrawableModule* Create() { return new NoteHumanizer(); }
    
-   std::string GetTitleLabel() override { return "note humanizer"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteLatch.h
+++ b/Source/NoteLatch.h
@@ -37,7 +37,7 @@ public:
    NoteLatch();
    static IDrawableModule* Create() { return new NoteLatch(); }
    
-   std::string GetTitleLabel() override { return "note latch"; }
+   
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -45,7 +45,7 @@ public:
    ~NoteLooper();
    static IDrawableModule* Create() { return new NoteLooper(); }
    
-   std::string GetTitleLabel() override { return "note looper"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteOctaver.h
+++ b/Source/NoteOctaver.h
@@ -39,7 +39,7 @@ public:
    NoteOctaver();
    static IDrawableModule* Create() { return new NoteOctaver(); }
    
-   std::string GetTitleLabel() override { return "octaver"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanAlternator.h
+++ b/Source/NotePanAlternator.h
@@ -39,7 +39,7 @@ public:
    NotePanAlternator();
    static IDrawableModule* Create() { return new NotePanAlternator(); }
    
-   std::string GetTitleLabel() override { return "pan alternator"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanRandom.h
+++ b/Source/NotePanRandom.h
@@ -38,7 +38,7 @@ public:
    NotePanRandom();
    static IDrawableModule* Create() { return new NotePanRandom(); }
    
-   std::string GetTitleLabel() override { return "note pan random"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NotePanner.h
+++ b/Source/NotePanner.h
@@ -39,7 +39,7 @@ public:
    NotePanner();
    static IDrawableModule* Create() { return new NotePanner(); }
    
-   std::string GetTitleLabel() override { return "note panner"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteQuantizer.h
+++ b/Source/NoteQuantizer.h
@@ -42,7 +42,7 @@ public:
    void CreateUIControls() override;
    void Init() override;
 
-   std::string GetTitleLabel() override { return "quantizer"; }
+   
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/NoteRangeFilter.h
+++ b/Source/NoteRangeFilter.h
@@ -37,7 +37,7 @@ public:
    NoteRangeFilter();
    static IDrawableModule* Create() { return new NoteRangeFilter(); }
    
-   std::string GetTitleLabel() override { return "note range filter"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteRatchet.h
+++ b/Source/NoteRatchet.h
@@ -38,7 +38,7 @@ public:
    NoteRatchet();
    static IDrawableModule* Create() { return new NoteRatchet(); }
 
-   std::string GetTitleLabel() override { return "note ratchet"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteRouter.h
+++ b/Source/NoteRouter.h
@@ -38,7 +38,7 @@ public:
    NoteRouter();
    static IDrawableModule* Create() { return new NoteRouter(); }
    
-   std::string GetTitleLabel() override { return "note router"; }
+   
    void CreateUIControls() override;
 
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/NoteSinger.cpp
+++ b/Source/NoteSinger.cpp
@@ -109,13 +109,6 @@ void NoteSinger::OnTransportAdvanced(float amount)
    GetBuffer()->Reset();
 }
 
-std::string NoteSinger::GetTitleLabel()
-{
-   if (Minimized())
-      return "notesinger";
-   return "notesinger "+ofToString(mPitch,2);
-}
-
 void NoteSinger::DrawModule()
 {
    if (Minimized() || IsVisible() == false)

--- a/Source/NoteSinger.h
+++ b/Source/NoteSinger.h
@@ -49,7 +49,7 @@ public:
    ~NoteSinger();
    static IDrawableModule* Create() { return new NoteSinger(); }
    
-   std::string GetTitleLabel() override;
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/NoteSorter.h
+++ b/Source/NoteSorter.h
@@ -40,7 +40,7 @@ public:
    NoteSorter();
    static IDrawableModule* Create() { return new NoteSorter(); }
 
-   std::string GetTitleLabel() override { return "notesorter"; }
+   
    void CreateUIControls() override;
 
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -53,7 +53,7 @@ public:
    virtual ~NoteStepSequencer();
    static IDrawableModule* Create() { return new NoteStepSequencer(); }
    
-   std::string GetTitleLabel() override { return "note sequencer"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -40,7 +40,7 @@ public:
    NoteStepper();
    static IDrawableModule* Create() { return new NoteStepper(); }
    
-   std::string GetTitleLabel() override { return "note stepper"; }
+   
    void CreateUIControls() override;
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;

--- a/Source/NoteStreamDisplay.h
+++ b/Source/NoteStreamDisplay.h
@@ -38,7 +38,7 @@ public:
    static IDrawableModule* Create() { return new NoteStreamDisplay(); }
    void CreateUIControls() override;
    
-   std::string GetTitleLabel() override { return "note stream"; }
+   
    
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;

--- a/Source/NoteStrummer.h
+++ b/Source/NoteStrummer.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteStrummer();
    static IDrawableModule* Create() { return new NoteStrummer(); }
    
-   std::string GetTitleLabel() override { return "note strummer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -38,7 +38,7 @@ public:
    ~NoteSustain();
    static IDrawableModule* Create() { return new NoteSustain(); }
    
-   std::string GetTitleLabel() override { return "note duration"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/NoteToFreq.h
+++ b/Source/NoteToFreq.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteToFreq();
    static IDrawableModule* Create() { return new NoteToFreq(); }
    
-   std::string GetTitleLabel() override { return "notetofreq"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteToMs.h
+++ b/Source/NoteToMs.h
@@ -39,7 +39,7 @@ public:
    virtual ~NoteToMs();
    static IDrawableModule* Create() { return new NoteToMs(); }
    
-   std::string GetTitleLabel() override { return "note to ms"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteToPulse.h
+++ b/Source/NoteToPulse.h
@@ -40,7 +40,7 @@ public:
    virtual ~NoteToPulse();
    static IDrawableModule* Create() { return new NoteToPulse(); }
    
-   std::string GetTitleLabel() override { return "note to pulse"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/NoteTransformer.h
+++ b/Source/NoteTransformer.h
@@ -39,7 +39,7 @@ public:
    ~NoteTransformer();
    static IDrawableModule* Create() { return new NoteTransformer(); }
    
-   std::string GetTitleLabel() override { return "transformer"; }
+   
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/NoteVibrato.h
+++ b/Source/NoteVibrato.h
@@ -41,7 +41,7 @@ public:
    virtual ~NoteVibrato();
    static IDrawableModule* Create() { return new NoteVibrato(); }
    
-   std::string GetTitleLabel() override { return "vibrato"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -47,7 +47,7 @@ public:
    
    void Init() override;
    void Poll() override;
-   std::string GetTitleLabel() override { return "osc output"; }
+   
    void CreateUIControls() override;
 
    void SendFloat(std::string address, float val);

--- a/Source/OutputChannel.h
+++ b/Source/OutputChannel.h
@@ -39,7 +39,6 @@ public:
    virtual ~OutputChannel();
    static IDrawableModule* Create() { return new OutputChannel(); }
    
-   std::string GetTitleLabel() override { return "output"; }
    void CreateUIControls() override;
    
    //IAudioReceiver

--- a/Source/PSMoveController.h
+++ b/Source/PSMoveController.h
@@ -44,7 +44,7 @@ public:
    ~PSMoveController();
    static IDrawableModule* Create() { return new PSMoveController(); }
    
-   std::string GetTitleLabel() override { return "ps move"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Panner.h
+++ b/Source/Panner.h
@@ -43,7 +43,7 @@ public:
    virtual ~Panner();
    static IDrawableModule* Create() { return new Panner(); }
    
-   std::string GetTitleLabel() override { return "panner"; }
+   
    void CreateUIControls() override;
    
    void SetPan(float pan) { mPan = pan; }

--- a/Source/PitchBender.h
+++ b/Source/PitchBender.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchBender();
    static IDrawableModule* Create() { return new PitchBender(); }
    
-   std::string GetTitleLabel() override { return "pitchbend"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchChorus.h
+++ b/Source/PitchChorus.h
@@ -41,7 +41,7 @@ public:
    virtual ~PitchChorus();
    static IDrawableModule* Create() { return new PitchChorus(); }
    
-   std::string GetTitleLabel() override { return "pitchchorus"; }
+   
    void CreateUIControls() override;
    
    //IAudioProcessor

--- a/Source/PitchDive.h
+++ b/Source/PitchDive.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchDive();
    static IDrawableModule* Create() { return new PitchDive(); }
    
-   std::string GetTitleLabel() override { return "pitchdive"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/PitchPanner.h
+++ b/Source/PitchPanner.h
@@ -39,7 +39,7 @@ public:
    PitchPanner();
    static IDrawableModule* Create() { return new PitchPanner(); }
    
-   std::string GetTitleLabel() override { return "pitch panner"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchRemap.h
+++ b/Source/PitchRemap.h
@@ -38,7 +38,7 @@ public:
    PitchRemap();
    static IDrawableModule* Create() { return new PitchRemap(); }
    
-   std::string GetTitleLabel() override { return "pitch remap"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchSetter.h
+++ b/Source/PitchSetter.h
@@ -38,7 +38,7 @@ public:
    PitchSetter();
    static IDrawableModule* Create() { return new PitchSetter(); }
    
-   std::string GetTitleLabel() override { return "pitch"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchShiftEffect.h
+++ b/Source/PitchShiftEffect.h
@@ -40,7 +40,7 @@ public:
    
    static IAudioEffect* Create() { return new PitchShiftEffect(); }
    
-   std::string GetTitleLabel() override { return "pitchshift"; }
+   
    void CreateUIControls() override;
    
    //IAudioEffect

--- a/Source/PitchToCV.h
+++ b/Source/PitchToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchToCV();
    static IDrawableModule* Create() { return new PitchToCV(); }
    
-   std::string GetTitleLabel() override { return "pitch to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PitchToSpeed.h
+++ b/Source/PitchToSpeed.h
@@ -40,7 +40,7 @@ public:
    virtual ~PitchToSpeed();
    static IDrawableModule* Create() { return new PitchToSpeed(); }
    
-   std::string GetTitleLabel() override { return "pitch to speed"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -47,7 +47,7 @@ public:
    ~PlaySequencer();
    static IDrawableModule* Create() { return new PlaySequencer(); }
 
-   std::string GetTitleLabel() override { return "play sequencer"; }
+   
    void CreateUIControls() override;
 
    void Init() override;

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -67,7 +67,7 @@ public:
    ~Polyrhythms();
    static IDrawableModule* Create() { return new Polyrhythms(); }
    
-   std::string GetTitleLabel() override { return "polyrhythms"; }
+   
    void CreateUIControls() override;
    void Init() override;
    bool IsResizable() const override { return true; }

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -57,7 +57,7 @@ void Prefab::CreateUIControls()
    AddPatchCableSource(mRemoveModuleCable);
 }
 
-std::string Prefab::GetTitleLabel()
+std::string Prefab::GetTitleLabel() const
 {
    if (mPrefabName != "")
       return "prefab: "+mPrefabName;

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -41,7 +41,7 @@ public:
    ~Prefab();
    static IDrawableModule* Create() { return new Prefab(); }
    
-   std::string GetTitleLabel() override;
+   std::string GetTitleLabel() const override;
    void CreateUIControls() override;
    
    ModuleContainer* GetContainer() override { return &mModuleContainer; }

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -44,7 +44,7 @@ public:
    virtual ~Presets();
    static IDrawableModule* Create() { return new Presets(); }
    
-   std::string GetTitleLabel() override { return "presets"; }
+   
    void CreateUIControls() override;
    
    //IDrawableModule

--- a/Source/Pressure.h
+++ b/Source/Pressure.h
@@ -40,7 +40,7 @@ public:
    virtual ~Pressure();
    static IDrawableModule* Create() { return new Pressure(); }
    
-   std::string GetTitleLabel() override { return "pressure"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PressureToCV.h
+++ b/Source/PressureToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~PressureToCV();
    static IDrawableModule* Create() { return new PressureToCV(); }
    
-   std::string GetTitleLabel() override { return "pressure to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PressureToModwheel.h
+++ b/Source/PressureToModwheel.h
@@ -37,7 +37,7 @@ public:
    virtual ~PressureToModwheel();
    static IDrawableModule* Create() { return new PressureToModwheel(); }
    
-   std::string GetTitleLabel() override { return "pressure to modwheel"; }
+   
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    
    //INoteReceiver

--- a/Source/PressureToVibrato.h
+++ b/Source/PressureToVibrato.h
@@ -40,7 +40,7 @@ public:
    virtual ~PressureToVibrato();
    static IDrawableModule* Create() { return new PressureToVibrato(); }
    
-   std::string GetTitleLabel() override { return "pressure to vibrato"; }
+   
    void CreateUIControls() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/PreviousNote.h
+++ b/Source/PreviousNote.h
@@ -35,7 +35,7 @@ public:
    PreviousNote();
    static IDrawableModule* Create() { return new PreviousNote(); }
    
-   std::string GetTitleLabel() override { return "previous note"; }
+   
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -50,7 +50,7 @@ public:
    ~Producer();
    static IDrawableModule* Create() { return new Producer(); }
    
-   std::string GetTitleLabel() override { return "producer"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/PulseButton.h
+++ b/Source/PulseButton.h
@@ -38,7 +38,7 @@ public:
    virtual ~PulseButton();
    static IDrawableModule* Create() { return new PulseButton(); }
    
-   std::string GetTitleLabel() override { return "pulse button"; }
+   
    void CreateUIControls() override;
 
    void ButtonClicked(ClickButton* button) override;

--- a/Source/PulseChance.h
+++ b/Source/PulseChance.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseChance();
    static IDrawableModule* Create() { return new PulseChance(); }
    
-   std::string GetTitleLabel() override { return "pulse chance"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseDelayer.h
+++ b/Source/PulseDelayer.h
@@ -40,7 +40,7 @@ public:
    ~PulseDelayer();
    static IDrawableModule* Create() { return new PulseDelayer(); }
    
-   std::string GetTitleLabel() override { return "pulse delayer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/PulseGate.h
+++ b/Source/PulseGate.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseGate();
    static IDrawableModule* Create() { return new PulseGate(); }
    
-   std::string GetTitleLabel() override { return "pulse gate"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseHocket.h
+++ b/Source/PulseHocket.h
@@ -37,7 +37,7 @@ public:
    virtual ~PulseHocket();
    static IDrawableModule* Create() { return new PulseHocket(); }
    
-   std::string GetTitleLabel() override { return "pulse hocket"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -47,7 +47,7 @@ public:
    virtual ~PulseSequence();
    static IDrawableModule* Create() { return new PulseSequence(); }
    
-   std::string GetTitleLabel() override { return "pulse sequence"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -45,7 +45,7 @@ public:
    virtual ~PulseTrain();
    static IDrawableModule* Create() { return new PulseTrain(); }
    
-   std::string GetTitleLabel() override { return "pulse train"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -45,7 +45,7 @@ public:
    virtual ~Pulser();
    static IDrawableModule* Create() { return new Pulser(); }
    
-   std::string GetTitleLabel() override { return "pulser"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -41,7 +41,7 @@ public:
    
    static IAudioEffect* Create() { return new Pumper(); }
    
-   std::string GetTitleLabel() override { return "pumper"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -45,7 +45,7 @@ public:
    virtual ~Push2Control();
    static IDrawableModule* Create() { return new Push2Control(); }
    
-   std::string GetTitleLabel() override { return "push 2 control"; }
+   
    void CreateUIControls() override;
    void Poll() override;
    

--- a/Source/QuickSpawnMenu.h
+++ b/Source/QuickSpawnMenu.h
@@ -39,7 +39,6 @@ public:
    void DrawModule() override;
    void SetDimensions(int w, int h) { mWidth = w; mHeight = h; }
    bool HasTitleBar() const override { return false; }
-   std::string GetTitleLabel() override { return ""; }
    bool IsSaveable() override { return false; }
    std::string GetHoveredModuleTypeName();
    

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -45,7 +45,7 @@ public:
    ~RadioSequencer();
    static IDrawableModule* Create() { return new RadioSequencer(); }
    
-   std::string GetTitleLabel() override { return "radio sequencer"; }
+   
    void CreateUIControls() override;
    
    //IGridListener

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -44,7 +44,7 @@ public:
    ~Ramper();
    static IDrawableModule* Create() { return new Ramper(); }
    
-   std::string GetTitleLabel() override { return "ramper"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/RandomNoteGenerator.h
+++ b/Source/RandomNoteGenerator.h
@@ -40,7 +40,7 @@ public:
    ~RandomNoteGenerator();
    static IDrawableModule* Create() { return new RandomNoteGenerator(); }
    
-   std::string GetTitleLabel() override { return "random note"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -55,7 +55,7 @@ public:
    ~Razor();
    static IDrawableModule* Create() { return new Razor(); }
    
-   std::string GetTitleLabel() override { return "razor"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Rewriter.h
+++ b/Source/Rewriter.h
@@ -43,7 +43,7 @@ public:
    virtual ~Rewriter();
    static IDrawableModule* Create() { return new Rewriter(); }
    
-   std::string GetTitleLabel() override { return "looper rewriter"; }
+   
    void CreateUIControls() override;
 
    void Go();

--- a/Source/RingModulator.h
+++ b/Source/RingModulator.h
@@ -43,7 +43,7 @@ public:
    virtual ~RingModulator();
    static IDrawableModule* Create() { return new RingModulator(); }
    
-   std::string GetTitleLabel() override { return "ring modulator"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -39,7 +39,7 @@ public:
    ~SampleBrowser();
    static IDrawableModule* Create() { return new SampleBrowser(); }
    
-   std::string GetTitleLabel() override { return "sample browser"; }
+   
    
    void CreateUIControls() override;
    

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -45,7 +45,7 @@ public:
    ~SampleCanvas();
    static IDrawableModule* Create() { return new SampleCanvas(); }
    
-   std::string GetTitleLabel() override { return "sample canvas"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -39,7 +39,7 @@ public:
    virtual ~SampleCapturer();
    static IDrawableModule* Create() { return new SampleCapturer(); }
 
-   std::string GetTitleLabel() override { return "sample capturer"; }
+   
    void CreateUIControls() override;
 
    //IAudioSource

--- a/Source/SampleFinder.h
+++ b/Source/SampleFinder.h
@@ -47,7 +47,7 @@ public:
    ~SampleFinder();
    static IDrawableModule* Create() { return new SampleFinder(); }
    
-   std::string GetTitleLabel() override { return "sample finder"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -51,7 +51,7 @@ public:
    ~SamplePlayer();
    static IDrawableModule* Create() { return new SamplePlayer(); }
    
-   std::string GetTitleLabel() override { return "sampleplayer"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void Poll() override;

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -50,7 +50,7 @@ public:
    ~Sampler();
    static IDrawableModule* Create() { return new Sampler(); }
    
-   std::string GetTitleLabel() override { return "sampler"; }
+   
    void CreateUIControls() override;
    
    void Poll() override;

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -50,7 +50,7 @@ public:
    ~SamplerGrid();
    static IDrawableModule* Create() { return new SamplerGrid(); }
    
-   std::string GetTitleLabel() override { return "sampler grid"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -92,7 +92,6 @@ public:
    ~Scale();
    void Init() override;
    
-   std::string GetTitleLabel() override { return "scale"; }
    void CreateUIControls() override;
    
    bool IsSingleton() const override { return true; }

--- a/Source/ScaleDegree.h
+++ b/Source/ScaleDegree.h
@@ -37,7 +37,7 @@ public:
    ScaleDegree();
    static IDrawableModule* Create() { return new ScaleDegree(); }
    
-   std::string GetTitleLabel() override { return "scale degree"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ScaleDetect.h
+++ b/Source/ScaleDetect.h
@@ -46,7 +46,7 @@ public:
    ScaleDetect();
    static IDrawableModule* Create() { return new ScaleDetect(); }
    
-   std::string GetTitleLabel() override { return "detect"; }
+   
    void CreateUIControls() override;
 
    //INoteReceiver

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -53,7 +53,7 @@ public:
    static void InitializePythonIfNecessary();
    static void CheckIfPythonEverSuccessfullyInitialized();
    
-   std::string GetTitleLabel() override { return "script"; }
+   
    void CreateUIControls() override;
    
    void Poll() override;
@@ -291,7 +291,7 @@ public:
    virtual ~ScriptReferenceDisplay();
    static IDrawableModule* Create() { return new ScriptReferenceDisplay(); }
 
-   std::string GetTitleLabel() override { return "script reference"; }
+   
    void CreateUIControls() override;
 
    void ButtonClicked(ClickButton* button) override;

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -41,7 +41,7 @@ public:
    
    void Poll() override;
    
-   std::string GetTitleLabel() override { return "script status"; }
+   
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -47,7 +47,7 @@ public:
    ~SeaOfGrain();
    static IDrawableModule* Create() { return new SeaOfGrain(); }
    
-   std::string GetTitleLabel() override { return "sea of grain"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/Selector.h
+++ b/Source/Selector.h
@@ -39,7 +39,7 @@ public:
    ~Selector();
    static IDrawableModule* Create() { return new Selector(); }
    
-   std::string GetTitleLabel() override { return "selector"; }
+   
    void CreateUIControls() override;
    
    void RadioButtonUpdated(RadioButton* radio, int oldVal) override;

--- a/Source/SignalClamp.h
+++ b/Source/SignalClamp.h
@@ -39,7 +39,7 @@ public:
    virtual ~SignalClamp();
    static IDrawableModule* Create() { return new SignalClamp(); }
    
-   std::string GetTitleLabel() override { return "signal clamp"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/SignalGenerator.h
+++ b/Source/SignalGenerator.h
@@ -45,7 +45,7 @@ public:
    ~SignalGenerator();
    static IDrawableModule* Create() { return new SignalGenerator(); }
    
-   std::string GetTitleLabel() override { return "sig gen"; }
+   
    void CreateUIControls() override;
    
    void SetVol(float vol) { mVol = vol; }

--- a/Source/SingleOscillator.h
+++ b/Source/SingleOscillator.h
@@ -49,7 +49,7 @@ public:
    ~SingleOscillator();
    static IDrawableModule* Create() { return new SingleOscillator(); }
    
-   std::string GetTitleLabel() override { return "oscillator"; }
+   
    void CreateUIControls() override;
    
    void SetType(OscillatorType type) { mVoiceParams.mOscType = type; }

--- a/Source/SliderSequencer.h
+++ b/Source/SliderSequencer.h
@@ -67,7 +67,7 @@ public:
    ~SliderSequencer();
    static IDrawableModule* Create() { return new SliderSequencer(); }
    
-   std::string GetTitleLabel() override { return "slider sequencer"; }
+   
    void CreateUIControls() override;
    void Init() override;
 

--- a/Source/SlowLayers.h
+++ b/Source/SlowLayers.h
@@ -43,7 +43,7 @@ public:
    virtual ~SlowLayers();
    static IDrawableModule* Create() { return new SlowLayers(); }
    
-   std::string GetTitleLabel() override { return "slow layers"; }
+   
    void CreateUIControls() override;
    
    void Clear();

--- a/Source/SpectralDisplay.h
+++ b/Source/SpectralDisplay.h
@@ -41,7 +41,7 @@ public:
    virtual ~SpectralDisplay();
    static IDrawableModule* Create() { return new SpectralDisplay(); }
    
-   std::string GetTitleLabel() override { return "spectrum"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Splitter.h
+++ b/Source/Splitter.h
@@ -41,7 +41,7 @@ public:
    virtual ~Splitter();
    static IDrawableModule* Create() { return new Splitter(); }
    
-   std::string GetTitleLabel() override { return "splitter"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -110,7 +110,7 @@ public:
    ~StepSequencer();
    static IDrawableModule* Create() { return new StepSequencer(); }
    
-   std::string GetTitleLabel() override { return "drum sequencer"; }
+   
    void CreateUIControls() override;
    
    void Init() override;

--- a/Source/StutterControl.h
+++ b/Source/StutterControl.h
@@ -43,7 +43,7 @@ public:
    ~StutterControl();
    static IDrawableModule* Create() { return new StutterControl(); }
    
-   std::string GetTitleLabel() override { return "stutter"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -37,7 +37,7 @@ public:
    SustainPedal();
    static IDrawableModule* Create() { return new SustainPedal(); }
    
-   std::string GetTitleLabel() override { return "sustain"; }
+   
    void CreateUIControls() override;
    
    //INoteReceiver

--- a/Source/TakeRecorder.h
+++ b/Source/TakeRecorder.h
@@ -41,7 +41,7 @@ public:
    virtual ~TakeRecorder();
    static IDrawableModule* Create() { return new TakeRecorder(); }
    
-   std::string GetTitleLabel() override { return "take recorder"; }
+   
    void CreateUIControls() override;
    
    //IAudioProcessor

--- a/Source/TimelineControl.h
+++ b/Source/TimelineControl.h
@@ -37,7 +37,7 @@ public:
    ~TimelineControl();
    static IDrawableModule* Create() { return new TimelineControl(); }
    
-   std::string GetTitleLabel() override { return "timeline control"; }
+   
    void CreateUIControls() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/TimerDisplay.h
+++ b/Source/TimerDisplay.h
@@ -38,7 +38,7 @@ public:
    ~TimerDisplay();
    static IDrawableModule* Create() { return new TimerDisplay(); }
    
-   std::string GetTitleLabel() override { return "timer"; }
+   
    void CreateUIControls() override;
    
    void ButtonClicked(ClickButton* button) override;

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -88,7 +88,7 @@ public:
    TitleBar();
    ~TitleBar();
    
-   std::string GetTitleLabel() override { return ""; }
+   
    void CreateUIControls() override;
    bool HasTitleBar() const override { return false; }
    bool AlwaysOnTop() override { return true; }

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -95,7 +95,7 @@ class Transport : public IDrawableModule, public IButtonListener, public IFloatS
 public:
    Transport();
    
-   std::string GetTitleLabel() override { return "transport"; }
+   
    void CreateUIControls() override;
 
    float GetTempo() { return mTempo; }

--- a/Source/TransposeFrom.h
+++ b/Source/TransposeFrom.h
@@ -41,7 +41,7 @@ public:
    virtual ~TransposeFrom();
    static IDrawableModule* Create() { return new TransposeFrom(); }
    
-   std::string GetTitleLabel() override { return "transpose from"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -40,7 +40,7 @@ public:
    
    static IAudioEffect* Create() { return new TremoloEffect(); }
    
-   std::string GetTitleLabel() override { return "tremolo"; }
+   
    void CreateUIControls() override;
 
    //IAudioEffect

--- a/Source/UnstableModWheel.h
+++ b/Source/UnstableModWheel.h
@@ -41,7 +41,7 @@ public:
    virtual ~UnstableModWheel();
    static IDrawableModule* Create() { return new UnstableModWheel(); }
 
-   std::string GetTitleLabel() override { return "unstable modwheel"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UnstablePitch.h
+++ b/Source/UnstablePitch.h
@@ -63,7 +63,7 @@ public:
    virtual ~UnstablePitch();
    static IDrawableModule* Create() { return new UnstablePitch(); }
 
-   std::string GetTitleLabel() override { return "unstable pitch"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UnstablePressure.h
+++ b/Source/UnstablePressure.h
@@ -41,7 +41,7 @@ public:
    virtual ~UnstablePressure();
    static IDrawableModule* Create() { return new UnstablePressure(); }
 
-   std::string GetTitleLabel() override { return "unstable pressure"; }
+   
    void CreateUIControls() override;
    void Init() override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/UserPrefsEditor.h
+++ b/Source/UserPrefsEditor.h
@@ -41,7 +41,7 @@ public:
    static IDrawableModule* Create() { return new UserPrefsEditor(); }
 
    void CreateUIControls() override;
-   std::string GetTitleLabel() override { return "settings"; }
+   
    bool AlwaysOnTop() override { return true; }
    bool CanMinimize() override { return false; }
    bool IsSingleton() const override { return true; }

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -189,6 +189,8 @@ VSTPlugin::VSTPlugin()
       VSTLookup::sFormatManager.addDefaultFormats();
    
    mChannelModulations.resize(kGlobalModulationIdx+1);
+
+   mPluginName = "no plugin loaded";
 }
 
 void VSTPlugin::CreateUIControls()
@@ -231,21 +233,17 @@ void VSTPlugin::Exit()
    }
 }
 
-std::string VSTPlugin::GetTitleLabel()
+std::string VSTPlugin::GetTitleLabel() const
 {
    return "vst: "+GetPluginName();
 }
 
-std::string VSTPlugin::GetPluginName()
+std::string VSTPlugin::GetPluginName() const
 {
-   if (mPlugin)
-      return mPluginName;
-   if (mModuleSaveData.HasProperty("vst") && mModuleSaveData.GetString("vst").length() > 0)
-      return GetFileNameWithoutExtension(mModuleSaveData.GetString("vst")).toStdString() + " (not loaded)";
-   return "no plugin loaded";
+   return mPluginName;
 }
 
-std::string VSTPlugin::GetPluginId()
+std::string VSTPlugin::GetPluginId() const
 {
    if (mPlugin)
    {
@@ -380,6 +378,9 @@ void VSTPlugin::LoadVST(juce::PluginDescription desc)
    else
    {
       TheSynth->LogEvent("error loading VST: " + errorMessage.toStdString(), kLogEventType_Error);
+
+      if (mModuleSaveData.HasProperty("vst") && mModuleSaveData.GetString("vst").length() > 0)
+         mPluginName = GetFileNameWithoutExtension(mModuleSaveData.GetString("vst")).toStdString() + " (not loaded)";
    }
    mVSTMutex.unlock();
 }
@@ -1057,8 +1058,6 @@ void VSTPlugin::LoadState(FileStreamIn& in)
       if (mPlugin != nullptr)
       {
          ofLog() << "loading vst state for " << mPlugin->getName();
-         
-         mPluginName = mPlugin->getName().toStdString();
 
          mPlugin->setStateInformation(vstState, vstStateSize);
          if (rev >= 1 && vstProgramStateSize > 0)

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -59,7 +59,7 @@ public:
    virtual ~VSTPlugin() override;
    static IDrawableModule* Create() { return new VSTPlugin(); }
    
-   std::string GetTitleLabel() override;
+   std::string GetTitleLabel() const override;
    void CreateUIControls() override;
    
    void SetVol(float vol) { mVol = vol; }
@@ -103,8 +103,8 @@ private:
    bool Enabled() const override { return mEnabled; }
    void LoadVST(juce::PluginDescription desc);
    
-   std::string GetPluginName();
-   std::string GetPluginId();
+   std::string GetPluginName() const;
+   std::string GetPluginId() const;
    void CreateParameterSliders();
    void RefreshPresetFiles();
    

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -41,7 +41,7 @@ public:
    virtual ~ValueSetter();
    static IDrawableModule* Create() { return new ValueSetter(); }
    
-   std::string GetTitleLabel() override { return "value setter"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/ValueStream.h
+++ b/Source/ValueStream.h
@@ -41,7 +41,7 @@ public:
    ~ValueStream();
    static IDrawableModule* Create() { return new ValueStream(); }
 
-   std::string GetTitleLabel() override { return "value stream"; }
+   
    void CreateUIControls() override;
 
    IUIControl* GetUIControl() const { return mUIControl; }

--- a/Source/VelocityScaler.h
+++ b/Source/VelocityScaler.h
@@ -38,7 +38,7 @@ public:
    VelocityScaler();
    static IDrawableModule* Create() { return new VelocityScaler(); }
    
-   std::string GetTitleLabel() override { return "velocity scaler"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VelocitySetter.h
+++ b/Source/VelocitySetter.h
@@ -38,7 +38,7 @@ public:
    VelocitySetter();
    static IDrawableModule* Create() { return new VelocitySetter(); }
    
-   std::string GetTitleLabel() override { return "velocity"; }
+   
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VelocityStepSequencer.h
+++ b/Source/VelocityStepSequencer.h
@@ -48,7 +48,7 @@ public:
    ~VelocityStepSequencer();
    static IDrawableModule* Create() { return new VelocityStepSequencer(); }
    
-   std::string GetTitleLabel() override { return "velocity seq"; }
+   
    void CreateUIControls() override;
    void Init() override;
    

--- a/Source/VelocityToCV.h
+++ b/Source/VelocityToCV.h
@@ -40,7 +40,7 @@ public:
    virtual ~VelocityToCV();
    static IDrawableModule* Create() { return new VelocityToCV(); }
    
-   std::string GetTitleLabel() override { return "velocity to cv"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -61,7 +61,7 @@ public:
    ~VinylTempoControl();
    static IDrawableModule* Create() { return new VinylTempoControl(); }
    
-   std::string GetTitleLabel() override { return "vinylcontrol"; }
+   
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void CreateUIControls() override;

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -44,7 +44,7 @@ public:
    virtual ~Vocoder();
    static IDrawableModule* Create() { return new Vocoder(); }
    
-   std::string GetTitleLabel() override { return "fft vocoder"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/VocoderCarrierInput.h
+++ b/Source/VocoderCarrierInput.h
@@ -44,7 +44,7 @@ public:
    virtual ~VocoderCarrierInput();
    static IDrawableModule* Create() { return new VocoderCarrierInput(); }
    
-   std::string GetTitleLabel() override { return "carrier"; }
+   
    void CreateUIControls() override;
 
    //IAudioProcessor

--- a/Source/VolcaBeatsControl.h
+++ b/Source/VolcaBeatsControl.h
@@ -43,7 +43,7 @@ public:
    virtual ~VolcaBeatsControl();
    static IDrawableModule* Create() { return new VolcaBeatsControl(); }
    
-   std::string GetTitleLabel() override { return "volca beats control"; }
+   
    void CreateUIControls() override;
    
    void SetEnabled(bool enabled) override { mEnabled = enabled; }

--- a/Source/WaveformViewer.h
+++ b/Source/WaveformViewer.h
@@ -42,7 +42,7 @@ public:
    virtual ~WaveformViewer();
    static IDrawableModule* Create() { return new WaveformViewer(); }
    
-   std::string GetTitleLabel() override { return "waveform viewer"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/Waveshaper.h
+++ b/Source/Waveshaper.h
@@ -41,7 +41,7 @@ public:
    virtual ~Waveshaper();
    static IDrawableModule* Create() { return new Waveshaper(); }
    
-   std::string GetTitleLabel() override { return "waveshaper"; }
+   
    void CreateUIControls() override;
    
    //IAudioSource

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -37,7 +37,7 @@ public:
    WhiteKeys();
    static IDrawableModule* Create() { return new WhiteKeys(); }
    
-   std::string GetTitleLabel() override { return "white keys"; }
+   
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 


### PR DESCRIPTION
benefits:
- increases clarity in some cases where the title bar mismatched a name that you'd used to span the module
- allows users to name modules, such as calling an oscillator "sub-bass" as a form of documentation
- makes path lookups clearer for scripting