### PR TITLE
fix issue with Linux apparently crashing on some VSTs when requesting "always on top"

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -310,7 +310,7 @@ void ModularSynth::LoadResources(void* nanoVG, void* fontBoundsNanoVG)
    LoadGlobalResources();
 
    if (!gFont.IsLoaded())
-      mFatalError = "couldn't load font from " + gFont.GetFontPath();
+      mFatalError = "couldn't load font from " + gFont.GetFontPath() + "\nmaybe bespoke can't find your resources directory?";
 }
 
 void ModularSynth::InitIOBuffers(int inputChannelCount, int outputChannelCount)

--- a/Source/VSTWindow.cpp
+++ b/Source/VSTWindow.cpp
@@ -52,6 +52,9 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
    }
 
    setVisible(true);
+#if BESPOKE_LINUX
+   setUsingNativeTitleBar(true);
+#endif
    
 #ifdef JUCE_MAC
    if (pluginEditor->getNumChildComponents() > 0)
@@ -99,10 +102,12 @@ VSTWindow::~VSTWindow()
 
 void VSTWindow::ShowWindow()
 {
+#if !BESPOKE_LINUX
    bool alwaysOnTop = true;
    if (!TheSynth->GetUserPrefs()["vst_always_on_top"].isNull())
       alwaysOnTop = TheSynth->GetUserPrefs()["vst_always_on_top"].asBool();
    setAlwaysOnTop(alwaysOnTop);
+#endif
    toFront(true);
 }
 


### PR DESCRIPTION
new solution: Linux gets native title bars, other platforms get always on top

(note: vital was crashing on windows when I tried to open it with native title bars)