### PR TITLE
Towards a Nightly Installer

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -11,8 +11,26 @@ juce_add_gui_app(BespokeSynth
 # Generate build time info for the cpp
 configure_file(VersionInfo.cpp.in geninclude/VersionInfo.cpp)
 
+option(BESPOKE_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" ON)
+if(BESPOKE_RELIABLE_VERSION_INFO)
+    add_custom_target(version-info BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfoBld.cpp
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -D CMAKE_PROJECT_VERSION_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
+            -D CMAKE_PROJECT_VERSION_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
+            -D BESPOKESRC=${CMAKE_SOURCE_DIR} -D BESPOKEBLD=${CMAKE_CURRENT_BINARY_DIR}
+            -D WIN32=${WIN32}
+            -P ${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake
+            )
+    add_dependencies(BespokeSynth version-info)
+else()
+    set(BESPOKESRC ${CMAKE_CURRENT_SOURCE_DIR})
+    set(BESPOKEBLD ${CMAKE_CURRENT_BINARY_DIR})
+    include(${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake)
+endif()
+
 target_sources(BespokeSynth PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfo.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfoBld.cpp
 
     ADSR.cpp
     ADSRDisplay.cpp
@@ -497,3 +515,40 @@ target_link_libraries(BespokeSynth PRIVATE
     ${Python_LIBRARIES}
     $<$<BOOL:${MINGW}>:dbghelp>
     )
+
+
+# Rules to do some installing and packaging which we will have to refactor  but
+# for now gets a nightly going
+set(BESPOKE_PRODUCT_DIR "${CMAKE_BINARY_DIR}/products")
+set(BESPOKE_NIGHTLY_DIR "${CMAKE_BINARY_DIR}/nightly")
+add_custom_command(TARGET BespokeSynth
+        POST_BUILD
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${BESPOKE_PRODUCT_DIR}
+        )
+add_custom_target(nightly-package)
+add_dependencies(nightly-package BespokeSynth)
+
+if (APPLE)
+    get_target_property(output_dir BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+    add_custom_command(TARGET BespokeSynth
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${output_dir}/BespokeSynth.app/ ${BESPOKE_PRODUCT_DIR}/BespokeSynth.app
+            )
+
+    add_custom_command(TARGET nightly-package
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${BESPOKE_NIGHTLY_DIR}
+            COMMAND hdiutil create /tmp/tmp.dmg -ov -volname "BespokeSynth" -fs HFS+ -srcfolder "${BESPOKE_PRODUCT_DIR}"
+            COMMAND hdiutil convert /tmp/tmp.dmg -format UDZO -o "${BESPOKE_NIGHTLY_DIR}/BespokeNightly.dmg"
+            )
+else()
+    add_custom_command(TARGET nightly-package
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${BESPOKE_NIGHTLY_DIR}
+            COMMAND ${CMAKE_COMMAND} -E echo "coming soon}" > ${BESPOKE_NIGHTLY_DIR}/installer.txt
+            )
+endif()

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -49,7 +49,10 @@ public:
 #if BESPOKE_LINUX
       ofLog() << "   install prefix  : '" << Bespoke::CMAKE_INSTALL_PREFIX << "'";
 #endif
-      
+      ofLog() << "   git hash        : " << Bespoke::GIT_HASH;
+      ofLog() << "   git branch      : " << Bespoke::GIT_BRANCH;
+      ofLog() << "   build time      : " << Bespoke::BUILD_DATE << " at " << Bespoke::BUILD_TIME;
+
       openGLContext.setOpenGLVersionRequired(juce::OpenGLContext::openGL3_2);
       openGLContext.setContinuousRepainting(false);
       openGLContext.setComponentPaintingEnabled(false);

--- a/Source/VersionInfo.h
+++ b/Source/VersionInfo.h
@@ -2,8 +2,16 @@
 
 namespace Bespoke
 {
+    // These are generated at CMake time and are VersionInfo.cpp.in
     extern const char* APP_NAME; // The application name. Taken from the top-level CMake project name.
     extern const char* VERSION; // This will be the same string as Juce::Application::getApplicationVersion()
     extern const char* PYTHON_VERSION; // The python version we compiled with
     extern const char* CMAKE_INSTALL_PREFIX;
+
+    // These are generated at build time and are in VersionInfoBld.cpp.in
+    extern const char* GIT_BRANCH;
+    extern const char* GIT_HASH;
+    extern const char* BUILD_ARCH;
+    extern const char* BUILD_DATE;
+    extern const char* BUILD_TIME;
 }

--- a/Source/VersionInfoBld.cpp.in
+++ b/Source/VersionInfoBld.cpp.in
@@ -1,0 +1,13 @@
+#include "VersionInfo.h"
+
+// This file will get replaced with the CMAKE variables as below at build time
+namespace Bespoke
+{
+
+    const char* GIT_BRANCH = "@GIT_BRANCH@";
+    const char* GIT_HASH = "@GIT_COMMIT_HASH@";
+    const char* BUILD_ARCH = "@BESPOKE_BUILD_ARCH@";
+    const char* BUILD_DATE = "@BESPOKE_BUILD_DATE@";
+    const char* BUILD_TIME = "@BESPOKE_BUILD_TIME@";
+
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,23 +15,15 @@ jobs:
         macOS-x64:
           imageName: 'macos-10.15'
           isMac: True
-          cmakeArguments: "-GXcode -DCMAKE_BUILD_TYPE=Debug -D\"CMAKE_OSX_ARCHITECTURES=x86_64\""
-          cmakeConfig: "Debug"
-        #macOS-arm:
-        #  imageName: 'macos-10.15'
-        #  isMac: True
-        #  cmakeArguments: "-DCMAKE_BUILD_TYPE=Debug -D\"CMAKE_OSX_ARCHITECTURES=arm64\""
-        #  cmakeConfig: "Debug"
+          cmakeArguments: "-GXcode -D\"CMAKE_OSX_ARCHITECTURES=x86_64\""
         windows-x64:
           imageName: 'windows-2019'
           isWindows: True
-          cmakeArguments: "-A x64 -DCMAKE_BUILD_TYPE=Debug"
-          cmakeConfig: "Debug"
+          cmakeArguments: "-A x64"
         linux-x64:
           imageName: 'ubuntu-20.04'
           isLinux: True
-          cmakeArguments: "-GNinja -DCMAKE_BUILD_TYPE=Debug"
-          cmakeConfig: "Debug"
+          cmakeArguments: "-GNinja"
 
     pool:
       vmImage: $(imageName)
@@ -42,9 +34,27 @@ jobs:
         # submodules: recursive # can't do submodules here b'cuz depth=1 fails with Github
 
       - bash: |
-          echo "BUILD REASON   = " $BUILD_REASON
+          echo "BUILD REASON   = " $(Build.Reason)
           echo "cmakeArguments = " $(cmakeArguments)
-          echo "cmakeConfig    = " $(cmakeConfig)
+
+          if [ $(Build.Reason) == "PullRequest" ]; then
+            export CMAKE_CONFIG=Debug
+            export CMAKE_TARGET=BespokeSynth
+            echo "##vso[task.setvariable variable=CMAKE_CONFIG]Debug"
+            echo "##vso[task.setvariable variable=CMAKE_CONFIG;isOutput=true]Debug"
+            echo "##vso[task.setvariable variable=CMAKE_TARGET]BespokeSynth"
+            echo "##vso[task.setvariable variable=CMAKE_TARGET;isOutput=true]BespokeSynth"
+          else
+            export CMAKE_CONFIG=Release
+            export CMAKE_TARGET=nightly-package
+            echo "##vso[task.setvariable variable=CMAKE_CONFIG]Release"
+            echo "##vso[task.setvariable variable=CMAKE_CONFIG;isOutput=true]Release"
+            echo "##vso[task.setvariable variable=CMAKE_TARGET]nightly-package"
+            echo "##vso[task.setvariable variable=CMAKE_TARGET;isOutput=true]nightly-package"
+          fi
+
+          echo "cmakeConfig    = " $CMAKE_CONFIG
+          echo "cmakeTarget    = " $CMAKE_TARGET
         displayName: all - details on build
 
       - bash: |
@@ -92,10 +102,33 @@ jobs:
 
       - bash: |
           set -e
-          cmake -Bbuild $(cmakeArguments)
+          echo Building with BUILD_TYPE = $CMAKE_CONFIG
+          cmake -Bbuild $(cmakeArguments) -DCMAKE_BUILD_TYPE=$CMAKE_CONFIG
         displayName: all - configure with cmake
 
       - bash: |
           set -e
-          cmake --build build --config $(cmakeConfig)
+          echo Building with TARGET = $CMAKE_TARGET
+          cmake --build build --config $CMAKE_CONFIG --target $CMAKE_TARGET
         displayName: all - build with cmake
+
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'INSTALLER_MAC_NIGHTLY'
+          targetPath: 'build/nightly'
+        condition: and(variables.isMac, ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: mac - publish mac artifact
+
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'INSTALLER_WIN_NIGHTLY'
+          targetPath: 'build/nightly'
+        condition: and(variables.isWindows, ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: mac - publish win artifact
+
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'INSTALLER_LIN_NIGHTLY'
+          targetPath: 'build/nightly'
+        condition: and(variables.isLinux, ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: mac - publish lin artifact

--- a/cmake/versiontools.cmake
+++ b/cmake/versiontools.cmake
@@ -1,0 +1,52 @@
+
+find_package(Git)
+
+if (NOT EXISTS ${BESPOKESRC}/.git)
+    message(STATUS "This is not a .git checkout; Defaulting versions")
+    set(GIT_BRANCH "unknown-branch")
+    set(GIT_COMMIT_HASH "deadbeef")
+elseif (Git_FOUND)
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY ${BESPOKESRC}
+            OUTPUT_VARIABLE GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            WORKING_DIRECTORY ${BESPOKESRC}
+            OUTPUT_VARIABLE GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    message(STATUS "GIT EXE not found Defaulting versions")
+    set(GIT_BRANCH "built-without-git")
+    set(GIT_COMMIT_HASH "deadbeef")
+endif ()
+
+if (WIN32)
+    set(BESPOKE_BUILD_ARCH "x86")
+else ()
+    execute_process(
+            COMMAND uname -m
+            OUTPUT_VARIABLE BESPOKE_BUILD_ARCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif ()
+
+cmake_host_system_information(RESULT BESPOKE_BUILD_FQDN QUERY FQDN)
+
+message(STATUS "Setting up BESPOKE version")
+message(STATUS "  git hash is ${GIT_COMMIT_HASH} and branch is ${GIT_BRANCH}")
+message(STATUS "  buildhost is ${BESPOKE_BUILD_FQDN}")
+message(STATUS "  buildarch is ${BESPOKE_BUILD_ARCH}")
+
+string(TIMESTAMP BESPOKE_BUILD_DATE "%Y-%m-%d")
+string(TIMESTAMP BESPOKE_BUILD_TIME "%H:%M:%S")
+
+
+message(STATUS "Configuring ${BESPOKEBLD}/geninclude/VersionInfoBld.cpp")
+configure_file(${BESPOKESRC}/Source/VersionInfoBld.cpp.in
+        ${BESPOKEBLD}/geninclude/VersionInfoBld.cpp)
+


### PR DESCRIPTION
Step one in making a nightly installer includes

1. GitInfo in the executable
2. A target 'nightly-package' which makes `build/nightly/(whatever)`
3. An azure-pipeline which builds release in main and uploads that nigtly
   to the pipeline slots at least

Still to do include: ASIO VST2 and publish to github, as well as
making a suitable nightly asset on lin and win.