### PR TITLE
Don't export `pybind11` symbols

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -497,9 +497,8 @@ target_link_libraries(BespokeSynth PRIVATE
     bespoke::nanovg
     bespoke::psmove
     bespoke::push2
+    bespoke::pybind11
     bespoke::xwax
-
-    pybind11::pybind11
 
     tuning-library
     oddsound-mts

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -7,7 +7,13 @@ add_subdirectory(nanovg EXCLUDE_FROM_ALL)
 add_subdirectory(oddsound-mts EXCLUDE_FROM_ALL)
 add_subdirectory(psmove EXCLUDE_FROM_ALL)
 add_subdirectory(push2 EXCLUDE_FROM_ALL)
+
 set(PYBIND11_NOPYTHON TRUE)
 add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
+add_library(bespoke_pybind11_wrapper INTERFACE)
+target_compile_definitions(bespoke_pybind11_wrapper INTERFACE PYBIND11_EXPORT=)
+target_link_libraries(bespoke_pybind11_wrapper INTERFACE pybind11::pybind11)
+add_library(bespoke::pybind11 ALIAS bespoke_pybind11_wrapper)
+
 add_subdirectory(tuning-library EXCLUDE_FROM_ALL)
 add_subdirectory(xwax EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Slightly smaller binary, gets rid of the import lib and exports file on Windows:

![image](https://user-images.githubusercontent.com/304760/136693488-33fd54d9-4d9a-48ee-a755-3b959017ab6f.png)