### PR TITLE
Added Akai MPD232 midi controller mapping.

### DIFF
--- a/resource/userdata_original/controllers/Akai MPD232 - Generic Preset.json
+++ b/resource/userdata_original/controllers/Akai MPD232 - Generic Preset.json
@@ -1,0 +1,197 @@
+{
+   "groups" : [
+      
+      {
+         "rows": 1,
+         "cols": 1,
+         "position" : [ 0, 0 ],
+         "dimensions" : [28, 21],
+         "spacing" : [0, 0],
+         "controls" : [117],
+         "messageType" : "control",
+         "drawType" : "button"
+      },
+      
+      {
+         "rows": 1,
+         "cols": 1,
+         "position" : [ 30, 0 ],
+         "dimensions" : [28, 21],
+         "spacing" : [0, 0],
+         "controls" : [118],
+         "messageType" : "control",
+         "drawType" : "button"
+      },
+      
+      {
+         "rows": 1,
+         "cols": 1,
+         "position" : [ 60, 0 ],
+         "dimensions" : [28, 21],
+         "spacing" : [0, 0],
+         "controls" : [119],
+         "messageType" : "control",
+         "drawType" : "button"
+      },
+      
+      {
+         "rows": 4,
+         "cols": 4,
+         "position" : [ 0, 60 ],
+         "dimensions" : [28, 28],
+         "spacing" : [30, 30],
+         "controls" : [
+            48,49,50,51,
+            44,45,46,47,
+            40,41,42,43,
+            36,37,38,39
+          ],
+         "messageType" : "note",
+         "drawType" : "button"
+      },
+      {
+        "rows": 4,
+        "cols": 4,
+        "position" : [ 0, 210 ],
+        "dimensions" : [28, 28],
+        "spacing" : [30, 30],
+        "controls" : [
+           64,65,66,67,
+           60,61,62,63,
+           56,57,58,59,
+           52,53,54,55
+         ],
+        "messageType" : "note",
+        "drawType" : "button"
+     },
+      {
+        "rows": 4,
+        "cols": 4,
+        "position" : [ 0, 360 ],
+        "dimensions" : [28, 28],
+        "spacing" : [30, 30],
+        "controls" : [
+           80,81,82,83,
+           76,77,78,79,
+           72,73,74,75,
+           68,69,70,71
+         ],
+        "messageType" : "note",
+        "drawType" : "button"
+     },
+     {
+       "rows": 4,
+       "cols": 4,
+       "position" : [ 0, 510 ],
+       "dimensions" : [28, 28],
+       "spacing" : [30, 30],
+       "controls" : [
+          96,97,98,99,
+          92,93,94,95,
+          88,89,90,91,
+          84,85,86,87
+        ],
+       "messageType" : "note",
+       "drawType" : "button"
+   },
+
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 60 ],
+      "dimensions" : [28, 28],
+      "spacing" : [30, 30],
+      "controls" : [3,9,14,15,16,17,18,19],
+      "messageType" : "control",
+      "drawType" : "knob"
+   },    
+   {
+     "rows": 1,
+     "cols": 8,
+     "position" : [ 150, 97 ],
+     "dimensions" : [28, 14],
+     "spacing" : [30, 16],
+     "controls" : [28,29,30,31,35,41,46,47],
+     "messageType" : "control",
+     "drawType" : "button"
+   },
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 120 ],
+      "dimensions" : [28, 56],
+      "spacing" : [30, 658],
+      "controls" : [20,21,22,23,24,25,26,27],
+      "messageType" : "control",
+      "drawType" : "slider"
+   },
+
+   
+   
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 210 ],
+      "dimensions" : [28, 28],
+      "spacing" : [30, 30],
+      "controls" : [52,53,54,55,57,58,59,60],
+      "messageType" : "control",
+      "drawType" : "knob"
+   },    
+   {
+     "rows": 1,
+     "cols": 8,
+     "position" : [ 150, 247 ],
+     "dimensions" : [28, 14],
+     "spacing" : [30, 16],
+     "controls" : [75,76,77,78,79,80,81,82],
+     "messageType" : "control",
+     "drawType" : "button"
+   },
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 270 ],
+      "dimensions" : [28, 56],
+      "spacing" : [30, 658],
+      "controls" : [61,62,63,70,71,72,73,74],
+      "messageType" : "control",
+      "drawType" : "slider"
+   },
+
+   
+   
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 360 ],
+      "dimensions" : [28, 28],
+      "spacing" : [30, 30],
+      "controls" : [83,85,86,87,88,89,90,91],
+      "messageType" : "control",
+      "drawType" : "knob"
+   },    
+   {
+     "rows": 1,
+     "cols": 8,
+     "position" : [ 150, 397 ],
+     "dimensions" : [28, 14],
+     "spacing" : [30, 16],
+     "controls" : [106,107,108,109,110,111,112,113],
+     "messageType" : "control",
+     "drawType" : "button"
+   },
+   {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 150, 420 ],
+      "dimensions" : [28, 56],
+      "spacing" : [30, 658],
+      "controls" : [92,93,94,95,102,103,104,105],
+      "messageType" : "control",
+      "drawType" : "slider"
+   }
+
+   ],
+   "resend_feedback_on_release" : true
+}


### PR DESCRIPTION
Hello! I've added an MPD232 mapping. It should work with the "Generic" default presets in the MPD.

It includes:

- Stop, Play and Rec buttons support.
- 4 4x4 grids, one for every Pad Bank.
- 3 16 knob / 16 toggles / 16 slider groups, one for every Control Bank.

![Captura de pantalla 2021-10-10 161609](https://user-images.githubusercontent.com/420163/136710309-7b7586b3-3274-4bea-a734-6d9532c27e4a.png)

Please let me know any questions or suggestions.

Thanks for creating Bespoke!
