### PR TITLE
limit slider value entry to min and max range of the slider

### DIFF
--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -722,7 +722,7 @@ void FloatSlider::TextEntryComplete(TextEntry* entry)
       
       float evaluated = 0;
       bool expressionValid = EvaluateExpression(mEntryString, *GetModifyValue(), evaluated);
-      if (expressionValid)
+      if (expressionValid && ((evaluated >= mMin && evaluated <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
          SetValue(evaluated);
    }
    if (entry == mMaxEntry)
@@ -1187,8 +1187,9 @@ void IntSlider::TextEntryComplete(TextEntry* entry)
       
       float evaluated = 0;
       bool expressionValid = EvaluateExpression(mEntryString, *mVar, evaluated);
-      if (expressionValid)
-         SetValue(round(evaluated));
+      int evaluatedInt = round(evaluated);
+      if (expressionValid && ((evaluatedInt >= mMin && evaluatedInt <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
+         SetValue(evaluatedInt);
    }
    if (entry == mMaxEntry)
    {


### PR DESCRIPTION
this prevents users from accidentally setting a slider beyond its safe range, which can result in undefined behavior in some cases.

but, the old functionality is still available as a power-user feature, if you press shift-enter to indicate that you intentionally want to ignore the bounds.