### PR TITLE
fix issue where quickspawn would place modules in the wrong position

### DIFF
--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -172,7 +172,7 @@ void QuickSpawnMenu::OnClicked(int x, int y, bool right)
    std::string moduleTypeName = GetModuleTypeNameAt(x, y);
    if (moduleTypeName != "")
    {
-      IDrawableModule* module = TheSynth->SpawnModuleOnTheFly(moduleTypeName, TheSynth->GetMouseX(GetOwningContainer()) + moduleGrabOffset.x, TheSynth->GetMouseY(GetOwningContainer()) + moduleGrabOffset.y);
+      IDrawableModule* module = TheSynth->SpawnModuleOnTheFly(moduleTypeName, TheSynth->GetMouseX(TheSynth->GetRootContainer()) + moduleGrabOffset.x, TheSynth->GetMouseY(TheSynth->GetRootContainer()) + moduleGrabOffset.y);
       TheSynth->SetMoveModule(module, moduleGrabOffset.x, moduleGrabOffset.y);
    }
    


### PR DESCRIPTION
this was nearly always covered up by a slight mouse movement correcting the module to the intended position, but if you clicked-and-released fast enough, the module would appear at an incorrect position if you were at all zoomed or panned on the canvas
fixes #347