### PR TITLE
Arturia Minilab MKII support

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -1629,6 +1629,16 @@ void MidiController::LoadLayout(std::string filename)
          mResendFeedbackOnRelease = mLayoutData["resend_feedback_on_release"].asBool();
          mModuleSaveData.SetBool("resend_feedback_on_release", mResendFeedbackOnRelease);
       }
+      if (!mLayoutData["channelfilter"].isNull())
+      {
+         const int layoutChannelFilter = mLayoutData["channelfilter"].asInt();
+         if (layoutChannelFilter >= (int)ChannelFilter::k1 && layoutChannelFilter <= (int)ChannelFilter::k16)
+         {
+            mChannelFilter = (ChannelFilter)layoutChannelFilter;
+            // The enum is restored by casting from an int
+            mModuleSaveData.SetInt("channelfilter", layoutChannelFilter);
+         }
+      }
       if (!mLayoutData["groups"].isNull())
       {
          useDefaultLayout = false;

--- a/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
@@ -1,0 +1,77 @@
+{
+    "channelfilter": 1,
+    "groups" : [
+        {
+            "rows": 1,
+            "cols": 2,
+            "position" : [ 0, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [ 113, 115 ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "button"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 35 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "messageType" : "pitchbend",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 30, 35 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "controls" : [1],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 2,
+            "cols": 8,
+            "position" : [ 65, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [
+                 112, 74, 71, 76, 77, 93, 73, 75,
+                 114, 18, 19, 16, 17, 91, 79, 72
+                ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 65, 70 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls" : [ 22, 23, 24, 25, 26, 27, 28, 29 ],
+          "colors" : [ 0, 127],
+          "messageType" : "control",
+          "drawType" : "button"
+       },
+       {
+        "rows": 1,
+        "cols": 25,
+        "position" : [ 65, 110 ],
+        "dimensions" : [14, 84],
+        "spacing" : [16, 30],
+        "controls" : [
+            48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61,
+            62, 63, 64, 65, 66, 67, 68,
+            69, 70, 71, 72
+          ],
+        "colors" : [ 0, 127],
+        "messageType" : "note",
+        "drawType" : "button"
+     }
+    ]
+ }
+ 

--- a/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1_PADS.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1_PADS.json
@@ -1,0 +1,17 @@
+{
+    "channelfilter": 10,
+    "groups" : [
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 0, 0 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls" : [ 36, 37, 38, 39 , 40, 41, 42, 43 ],
+          "colors" : [ 0, 127],
+          "messageType" : "note",
+          "drawType" : "button"
+       }
+    ]
+ }
+ 


### PR DESCRIPTION
In the out-of-the-box state my controller sends notes on channel 10 for the drum pads.
They can be toggled to send control messages via a button.

So I made two layouts which filter on the appropriate channels to make the whole thing usable