### PR TITLE
Some light profiling on OutputChannel

### DIFF
--- a/Source/Amplifier.cpp
+++ b/Source/Amplifier.cpp
@@ -60,10 +60,11 @@ void Amplifier::Process(double time)
       ChannelBuffer* out = target->GetBuffer();
       for (int ch=0; ch<GetBuffer()->NumActiveChannels(); ++ch)
       {
+         auto getBufferChannelCh = GetBuffer()->GetChannel(ch);
          for (int i=0; i<bufferSize; ++i)
          {
             ComputeSliders(i);
-            gWorkBuffer[i] = GetBuffer()->GetChannel(ch)[i] * mGain;
+            gWorkBuffer[i] = getBufferChannelCh[i] * mGain;
          }
          Add(out->GetChannel(ch), gWorkBuffer, GetBuffer()->BufferSize());
          GetVizBuffer()->WriteChunk(gWorkBuffer, GetBuffer()->BufferSize(), ch);

--- a/Source/OutputChannel.cpp
+++ b/Source/OutputChannel.cpp
@@ -73,12 +73,13 @@ void OutputChannel::Process(double time)
    if (numChannels == 1)
    {
       int channel = channelSelectionIndex;
+      auto getBufferGetChannel0 = GetBuffer()->GetChannel(0);
       if (channel >= 0 && channel < TheSynth->GetNumOutputChannels())
       {
          for (int i = 0; i<gBufferSize; ++i)
-            TheSynth->GetOutputBuffer(channel)[i] += CLAMP(GetBuffer()->GetChannel(0)[i], -mLimit, mLimit);
+            TheSynth->GetOutputBuffer(channel)[i] += std::clamp(/*GetBuffer()->GetChannel(0)*/ getBufferGetChannel0[i], -mLimit, mLimit);
       }
-      GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(0), gBufferSize, 0);
+      GetVizBuffer()->WriteChunk(/*GetBuffer()->GetChannel(0)*/ getBufferGetChannel0, gBufferSize, 0);
       
       mLevelMeters[0].mPeakTracker.Process(TheSynth->GetOutputBuffer(channel), gBufferSize);
       mLevelMeters[0].mPeakTrackerSlow.Process(TheSynth->GetOutputBuffer(channel), gBufferSize);


### PR DESCRIPTION
Did some light profiling. In a simple case on mac release build
of note sequencer -> osc -> output about 11% of the audio
time was in OutputChannel::Process -> Buffer::GetChannel.
Fix this by calling the get function outside a loop taking
the time to about 6%.