### PR TITLE
optimizations to FloatSlider::Compute()

### DIFF
--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -615,10 +615,8 @@ std::string FloatSlider::GetDisplayValue(float val) const
    return ofToString(displayVar,decDigits);
 }
 
-void FloatSlider::Compute(int samplesIn /*= 0*/)
+void FloatSlider::DoCompute(int samplesIn /*= 0*/)
 {
-   mComputeHasBeenCalledOnce = true;
-
    if (mLastComputeTime == gTime && mLastComputeSamplesIn == samplesIn)
       return;  //we've just calculated this, no need to do it again! earlying out avoids wasted work and circular modulation loops
 
@@ -630,8 +628,8 @@ void FloatSlider::Compute(int samplesIn /*= 0*/)
 
    float oldVal = *mVar;
 
-   static bool sUseCache = true;
-   if (sUseCache && samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] == gTime)
+   const bool kUseCache = true;
+   if (kUseCache && samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] == gTime)
    {
       *mVar = mLastComputeCacheValue[samplesIn];
    }
@@ -648,7 +646,7 @@ void FloatSlider::Compute(int samplesIn /*= 0*/)
       if (mIsSmoothing)
          *mVar = mRamp.Value(gTime + samplesIn * gInvSampleRateMs);
 
-      if (samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] == gTime)
+      if (samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] != gTime)
       {
          mLastComputeCacheValue[samplesIn] = *mVar;
          mLastComputeCacheTime[samplesIn] = gTime;

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -54,7 +54,12 @@ public:
    void MouseReleased() override;
    bool IsMouseDown() const override { return mMouseDown; }
    void SetExtents(float min, float max) { mMin = min; mMax = max; }
-   void Compute(int samplesIn = 0);
+   void Compute(int samplesIn = 0)
+   {
+      mComputeHasBeenCalledOnce = true;   //mark this slider as one whose owner calls compute on it
+      if (mIsSmoothing || mModulator != nullptr)
+         DoCompute(samplesIn);
+   }
    void DisplayLFOControl();
    void DisableLFO();
    FloatSliderLFOControl* GetLFO() { return mLFOControl; }
@@ -118,6 +123,7 @@ private:
    float ValToPos(float val, bool ignoreSmooth) const;
    bool AdjustSmooth() const;
    void SmoothUpdated();
+   void DoCompute(int samplesIn);
    
    int mWidth;
    int mHeight;


### PR DESCRIPTION
- fixed issue (maybe caused by a bad refactor?) where value caching wasn't working, which greatly reduced performance on modulators which were subject to multiple Compute() calls (most notably on polyphonic synth modules)
- moved Compute() to DoCompute(), and now Compute() is an inlined wrapper that earlys out if no compute work is necessary