### PR TITLE
Add increment epsilon for infinite encoders

### DIFF
--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -175,6 +175,7 @@ struct UIControlConnection
    bool mScaleOutput;
    bool mBlink;
    float mIncrementAmount;
+   float mIncrementThreshold;
    bool mTwoWay;
    int mFeedbackControl;
    SpecialControlBinding mSpecialBinding;
@@ -220,7 +221,7 @@ enum ControlDrawType
 struct ControlLayoutElement
 {
    ControlLayoutElement() : mActive(false), mControlCable(nullptr), mConnectionType(kControlType_Slider) {}
-   void Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h);
+   void Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, float incrementThreshold, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h);
    
    bool mActive;
    MidiMessageType mType;
@@ -229,6 +230,7 @@ struct ControlLayoutElement
    ofVec2f mDimensions;
    ControlDrawType mDrawType;
    bool mIncremental;
+   float mIncrementThreshold;
    int mOffVal;
    int mOnVal;
    bool mScaleOutput;

--- a/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
@@ -33,17 +33,33 @@
         },
         {
             "rows": 2,
-            "cols": 8,
-            "position" : [ 65, 0 ],
+            "cols": 7,
+            "position" : [ 100, 0 ],
             "dimensions" : [28, 28],
             "spacing" : [30, 30],
             "controls" : [
-                 112, 74, 71, 76, 77, 93, 73, 75,
-                 114, 18, 19, 16, 17, 91, 79, 72
+                 74, 71, 76, 77, 93, 73, 75,
+                 18, 19, 16, 17, 91, 79, 72
                 ],
             "colors" : [ 0, 127],
             "messageType" : "control",
             "drawType" : "knob"
+        },
+        {
+            "rows": 2,
+            "cols": 1,
+            "position" : [ 65, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [
+                 112,
+                 114
+                ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "slider",
+            "incremental": true,
+            "incrementThreshold": 0.01
         },
        {
           "rows": 1,


### PR DESCRIPTION
The infinite encoders on my Minilab send two messages for every move
one value in the 'direction', i.e. 0.5 +/- 0.1 and one 'centered' value
very close to, but not quite 0.5.

The absolute of the value must be larger than incrementEpsilon to affect
a change