### PR TITLE
Added an option to send already-sustained notes on sustainpedal

### DIFF
--- a/Source/SustainPedal.cpp
+++ b/Source/SustainPedal.cpp
@@ -28,7 +28,7 @@
 #include "ModularSynth.h"
 
 SustainPedal::SustainPedal()
-: mSustain(false)
+: mSustain(false), mNoteRepeat(false)
 {
 }
 
@@ -37,6 +37,7 @@ void SustainPedal::CreateUIControls()
    IDrawableModule::CreateUIControls();
 
    mSustainCheckbox = new Checkbox(this, "sustain", 3, 3, &mSustain);
+   mNoteRepeatCheckbox = new Checkbox(this, "note repeat", 3, 18, &mNoteRepeat);
 }
 
 void SustainPedal::DrawModule()
@@ -44,6 +45,7 @@ void SustainPedal::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
    mSustainCheckbox->Draw();
+   mNoteRepeatCheckbox->Draw();
 }
 
 void SustainPedal::CheckboxUpdated(Checkbox* checkbox)
@@ -70,8 +72,9 @@ void SustainPedal::PlayNote(double time, int pitch, int velocity, int voiceIdx, 
    {
       if (velocity > 0)
       {
-         if (!mIsNoteBeingSustained[pitch]) //don't replay already-sustained notes
+         if (!mIsNoteBeingSustained[pitch] || mNoteRepeat) //don't replay already-sustained notes
             PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
+
          mIsNoteBeingSustained[pitch] = false;   //not being sustained by this module it if it's held down
       }
       else

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -50,12 +50,14 @@ public:
 private:
    //IDrawableModule
    void DrawModule() override;
-   void GetModuleDimensions(float& width, float& height) override { width = 90; height = 21; }
+   void GetModuleDimensions(float& width, float& height) override { width = 90; height = 36; }
    bool Enabled() const override { return true; }
    
    std::array<bool, 128> mIsNoteBeingSustained{ false };
    bool mSustain;
+   bool mNoteRepeat;
    Checkbox* mSustainCheckbox;
+   Checkbox* mNoteRepeatCheckbox;
 };
 
 #endif /* defined(__Bespoke__SustainPedal__) */


### PR DESCRIPTION
In reference to the issue: #403 
I've added a checkbox to the sustainpedal module to allow sending already-sustained notes.
![imagen](https://user-images.githubusercontent.com/11269785/137520787-f374129f-aeb8-4e0b-8830-1d98e9454688.png)
