### PR TITLE
Change for Discussion nnot Merging

### DIFF
--- a/Source/ChannelBuffer.cpp
+++ b/Source/ChannelBuffer.cpp
@@ -86,6 +86,13 @@ float* ChannelBuffer::GetChannel(int channel)
    return ret;
 }
 
+void ChannelBuffer::GuaranteeChannel(int channel)
+{
+   // For now we can just call GetChannel which guarantees it
+   // but split the API just in case we want to do something else
+   GetChannel(channel);
+}
+
 void ChannelBuffer::Clear() const
 {
    for (int i=0; i<mNumChannels; ++i)

--- a/Source/ChannelBuffer.h
+++ b/Source/ChannelBuffer.h
@@ -37,6 +37,11 @@ public:
    ~ChannelBuffer();
    
    float* GetChannel(int channel);
+   void   GuaranteeChannel(int channel);
+   float* GetChannelUnchecked(int channel) const
+   {
+      return mBuffers[channel];
+   }
    
    void Clear() const;
    

--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -27,6 +27,7 @@
 #include "SynthGlobals.h"
 #include "Profiler.h"
 #include "ChannelBuffer.h"
+#include "juce_dsp/maths/juce_FastMathApproximations.h"
 
 Granulator::Granulator()
 : mNextGrainIdx(0)
@@ -131,9 +132,22 @@ void Grain::Spawn(Granulator* owner, double time, double pos, float speedMult, f
    mSpeedMult = speedMult;
    mStartTime = time;
    mEndTime = time + lengthInMs;
+   mStartToEnd = mEndTime - mStartTime;
+   mStartToEndInv = 1.0 / mStartToEnd;
    mVol = vol;
    mStereoPosition = ofRandom(-width, width);
    mDrawPos = ofRandom(1);
+}
+
+
+inline double Grain::GetWindow(double time)
+{
+   if (time > mStartTime && time < mEndTime)
+   {
+      double phase = (time-mStartTime) * mStartToEndInv;
+      return .5 * (1 - juce::dsp::FastMathApproximations::cos<double>(phase * TWO_PI));
+   }
+   return 0;
 }
 
 void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float* output)
@@ -148,16 +162,6 @@ void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float*
          output[ch] += sample * window * mVol * (1 + (ch == 0 ? mStereoPosition : -mStereoPosition));
       }
    }
-}
-
-double Grain::GetWindow(double time)
-{
-   if (time > mStartTime && time < mEndTime)
-   {
-      double phase = (time-mStartTime)/(mEndTime-mStartTime);
-      return .5 * (1 - cos(phase * TWO_PI));
-   }
-   return 0;
 }
 
 void Grain::DrawGrain(int idx, float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength)

--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -142,12 +142,8 @@ void Grain::Spawn(Granulator* owner, double time, double pos, float speedMult, f
 
 inline double Grain::GetWindow(double time)
 {
-   if (time > mStartTime && time < mEndTime)
-   {
-      double phase = (time-mStartTime) * mStartToEndInv;
-      return .5 * (1 - juce::dsp::FastMathApproximations::cos<double>(phase * TWO_PI));
-   }
-   return 0;
+   double phase = (time-mStartTime) * mStartToEndInv;
+   return .5 * (1 - juce::dsp::FastMathApproximations::cos<double>(phase * TWO_PI));
 }
 
 void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float* output)
@@ -158,7 +154,7 @@ void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float*
       float window = GetWindow(time);
       for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
       {
-         float sample = GetInterpolatedSample(mPos, buffer, bufferLength, ofClamp(ch + mStereoPosition, 0, 1));
+         float sample = GetInterpolatedSample(mPos, buffer, bufferLength, std::clamp(ch + mStereoPosition, 0.f, 1.f));
          output[ch] += sample * window * mVol * (1 + (ch == 0 ? mStereoPosition : -mStereoPosition));
       }
    }
@@ -171,7 +167,7 @@ void Grain::DrawGrain(int idx, float x, float y, float w, float h, int bufferSta
       return;
    ofPushStyle();
    ofFill();
-   float alpha = GetWindow(gTime);
+   float alpha = GetWindow(std::clamp(gTime, mStartTime, mEndTime));
    ofSetColor(255,0,0,alpha*255);
    ofCircle(x+a*w, y+mDrawPos*h, MAX(3,h/MAX_GRAINS/2));
    ofPopStyle();

--- a/Source/Granulator.h
+++ b/Source/Granulator.h
@@ -49,6 +49,7 @@ private:
    float mSpeedMult;
    double mStartTime;
    double mEndTime;
+   double mStartToEnd, mStartToEndInv;
    float mVol;
    float mStereoPosition;
    float mDrawPos;

--- a/Source/LiveGranulator.cpp
+++ b/Source/LiveGranulator.cpp
@@ -115,6 +115,10 @@ void LiveGranulator::ProcessAudio(double time, ChannelBuffer* buffer)
    float bufferSize = buffer->BufferSize();
    mBuffer.SetNumChannels(buffer->NumActiveChannels());
 
+   // guarantee the channels are there so we can use GetChannelUnchecked later
+   for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
+      buffer->GuaranteeChannel(ch);
+
    for (int i=0; i<bufferSize; ++i)
    {
       ComputeSliders(i);
@@ -123,13 +127,13 @@ void LiveGranulator::ProcessAudio(double time, ChannelBuffer* buffer)
       if (!mFreeze)
       {
          for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
-            mBuffer.Write(buffer->GetChannel(ch)[i], ch);
+            mBuffer.Write(buffer->GetChannelUnchecked(ch)[i], ch);
       }
       else if (mFreezeExtraSamples < FREEZE_EXTRA_SAMPLES_COUNT)
       {
          ++mFreezeExtraSamples;
          for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
-            mBuffer.Write(buffer->GetChannel(ch)[i], ch);
+            mBuffer.Write(buffer->GetChannelUnchecked(ch)[i], ch);
       }
       
       if (mEnabled)

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -426,15 +426,15 @@ float GetInterpolatedSample(double offset, ChannelBuffer* buffer, int bufferSize
    assert(channelBlend >= 0);
    
    if (buffer->NumActiveChannels() == 1)
-      return GetInterpolatedSample(offset, buffer->GetChannel(0), bufferSize);
+      return GetInterpolatedSample(offset, buffer->GetChannelUnchecked(0), bufferSize);
    
    int channelA = floor(channelBlend);
    if (channelA == buffer->NumActiveChannels() - 1)
       channelA -= 1;
    int channelB = channelA + 1;
    
-   return (1 - (channelBlend - channelA)) * GetInterpolatedSample(offset, buffer->GetChannel(channelA), bufferSize) +
-          (channelBlend - channelA) * GetInterpolatedSample(offset, buffer->GetChannel(channelB), bufferSize);
+   return (1 - (channelBlend - channelA)) * GetInterpolatedSample(offset, buffer->GetChannelUnchecked(channelA), bufferSize) +
+          (channelBlend - channelA) * GetInterpolatedSample(offset, buffer->GetChannelUnchecked(channelB), bufferSize);
 }
 
 void WriteInterpolatedSample(double offset, float* buffer, int bufferSize, float sample)


### PR DESCRIPTION
So I don't think this is mergable - putting it here as a sort of
draft PR. Using the profiler on a heavy granular patch I found
more time in ChannelBuffer::GetChannel still. So what I did here
(which we can propagate if you agree) is add a GetChannelUnchecked
whcih is const inline direct access to the float with no if and no
alloc, and then used that. It took about 5% out of the CPU time
in the audio thread.

I think there's other performance hits in the granulator path also
and lots of little things like clamps and maps which don't inline
and stuff but pushing this up to see what you think of the idea.

Since I haven't checked every client of Grain::Process I don't
know which ones explicitly or implicitly guanrantee their buffers
so I probably wouldn't merge this