### PR TITLE
Note Expression Router

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -183,6 +183,7 @@ target_sources(BespokeSynth PRIVATE
     NoteCreator.cpp
     NoteDelayer.cpp
     NoteDisplayer.cpp
+    NoteExpressionRouter.cpp
     NoteFilter.cpp
     NoteFlusher.cpp
     NoteGate.cpp

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -247,6 +247,7 @@
 #include "MPETweaker.h"
 
 #include <juce_core/juce_core.h>
+#include "NoteExpressionRouter.h"
 
 #define REGISTER(class,name,type) Register(#name, &(class::Create), &(class::CanCreate), type, false, false);
 #define REGISTER_HIDDEN(class,name,type) Register(#name, &(class::Create), &(class::CanCreate), type, true, false);
@@ -435,6 +436,7 @@ ModuleFactory::ModuleFactory()
    REGISTER(MPETweaker, mpetweaker, kModuleType_Note);
    REGISTER(GridSliders, gridsliders, kModuleType_Modulator);
    REGISTER(MultitrackRecorder, multitrackrecorder, kModuleType_Other);
+   REGISTER(NoteExpressionRouter, noteexpressionrouter, kModuleType_Note);
 
    //REGISTER_EXPERIMENTAL(MidiPlayer, midiplayer, kModuleType_Instrument);
    REGISTER_HIDDEN(Autotalent, autotalent, kModuleType_Audio);

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -245,9 +245,9 @@
 #include "MPESmoother.h"
 #include "MidiControlChange.h"
 #include "MPETweaker.h"
+#include "NoteExpressionRouter.h"
 
 #include <juce_core/juce_core.h>
-#include "NoteExpressionRouter.h"
 
 #define REGISTER(class,name,type) Register(#name, &(class::Create), &(class::CanCreate), type, false, false);
 #define REGISTER_HIDDEN(class,name,type) Register(#name, &(class::Create), &(class::CanCreate), type, true, false);
@@ -436,7 +436,7 @@ ModuleFactory::ModuleFactory()
    REGISTER(MPETweaker, mpetweaker, kModuleType_Note);
    REGISTER(GridSliders, gridsliders, kModuleType_Modulator);
    REGISTER(MultitrackRecorder, multitrackrecorder, kModuleType_Other);
-   REGISTER(NoteExpressionRouter, noteexpressionrouter, kModuleType_Note);
+   REGISTER(NoteExpressionRouter, noteexpression, kModuleType_Note);
 
    //REGISTER_EXPERIMENTAL(MidiPlayer, midiplayer, kModuleType_Instrument);
    REGISTER_HIDDEN(Autotalent, autotalent, kModuleType_Audio);

--- a/Source/NoteExpressionRouter.cpp
+++ b/Source/NoteExpressionRouter.cpp
@@ -1,0 +1,127 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+/*
+  ==============================================================================
+
+    NoteExpressionRouter.cpp
+    Created: 15 Oct 2021
+    Author:  Paul Walker @baconpaul
+
+  ==============================================================================
+*/
+
+#include "NoteExpressionRouter.h"
+#include "OpenFrameworksPort.h"
+#include "Scale.h"
+#include "ModularSynth.h"
+#include "PatchCableSource.h"
+#include "UIControlMacros.h"
+
+NoteExpressionRouter::NoteExpressionRouter()
+{
+   mSymbolTable.add_variable("n", mSTNote);
+   mSymbolTable.add_variable("v", mSTVelocity);
+
+   for (auto i=0; i<kMaxDestinations; ++i)
+   {
+      mExpressions[i].register_symbol_table(mSymbolTable);
+      auto p = exprtk::parser<float>();
+      p.compile( "1", mExpressions[i]);
+   }
+}
+
+void NoteExpressionRouter::CreateUIControls()
+{
+   IDrawableModule::CreateUIControls();
+   
+   UIBLOCK0();
+   for (int i=0; i<kMaxDestinations; ++i)
+   {
+      TEXTENTRY(mExpressionWidget[i],("expression "+ofToString(i)).c_str(),30, mExpressionText[i]);
+      mDestinationCables[i] = new AdditionalNoteCable();
+      mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
+      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1,0));
+      AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
+      ofRectangle rect = mExpressionWidget[i]->GetRect(true);
+      mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height/2);
+   }
+   ENDUIBLOCK(mWidth,mHeight);
+   mWidth += 20;
+   
+   GetPatchCableSource()->SetEnabled(false);
+}
+
+void NoteExpressionRouter::DrawModule()
+{
+   if (Minimized() || IsVisible() == false)
+      return;
+   
+   for (int i=0; i<kMaxDestinations; ++i)
+      mExpressionWidget[i]->Draw();
+}
+
+void NoteExpressionRouter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
+{
+   mSTNote = pitch;
+   mSTVelocity = velocity;
+   for (auto i=0; i<kMaxDestinations; ++i)
+   {
+      auto rt = mExpressions[i].value();
+      if (rt != 0)
+      {
+         mDestinationCables[i]->PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
+      }
+   }
+}
+
+void NoteExpressionRouter::SendCC(int control, int value, int voiceIdx)
+{
+   SendCCOutput(control, value, voiceIdx);
+}
+
+void NoteExpressionRouter::LoadLayout(const ofxJSONElement& moduleInfo)
+{
+   SetUpFromSaveData();
+}
+
+void NoteExpressionRouter::SetUpFromSaveData()
+{
+}
+
+void NoteExpressionRouter::SaveLayout(ofxJSONElement& moduleInfo)
+{
+   IDrawableModule::SaveLayout(moduleInfo);
+}
+
+void NoteExpressionRouter::TextEntryComplete(TextEntry *entry) {
+   if (strlen(entry->GetText()) == 0)
+      return;
+
+   for (auto i=0; i<kMaxDestinations; ++i)
+   {
+      if (entry == mExpressionWidget[i])
+      {
+         auto p = exprtk::parser<float>();
+         if (!p.compile( entry->GetText(), mExpressions[i]))
+         {
+            ofLog() << "Error parsing expression '" << entry->GetText() << "' " << p.error();
+         }
+      }
+   }
+
+}

--- a/Source/NoteExpressionRouter.cpp
+++ b/Source/NoteExpressionRouter.cpp
@@ -27,7 +27,6 @@
 
 #include "NoteExpressionRouter.h"
 #include "OpenFrameworksPort.h"
-#include "Scale.h"
 #include "ModularSynth.h"
 #include "PatchCableSource.h"
 #include "UIControlMacros.h"

--- a/Source/NoteExpressionRouter.cpp
+++ b/Source/NoteExpressionRouter.cpp
@@ -33,7 +33,7 @@
 
 NoteExpressionRouter::NoteExpressionRouter()
 {
-   mSymbolTable.add_variable("n", mSTNote);
+   mSymbolTable.add_variable("p", mSTNote);
    mSymbolTable.add_variable("v", mSTVelocity);
 
    for (auto i=0; i<kMaxDestinations; ++i)
@@ -51,7 +51,7 @@ void NoteExpressionRouter::CreateUIControls()
    UIBLOCK0();
    for (int i=0; i<kMaxDestinations; ++i)
    {
-      TEXTENTRY(mExpressionWidget[i],("expression "+ofToString(i)).c_str(),30, mExpressionText[i]);
+      TEXTENTRY(mExpressionWidget[i],("expression"+ofToString(i)).c_str(),30, mExpressionText[i]);
       mDestinationCables[i] = new AdditionalNoteCable();
       mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
       mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1,0));

--- a/Source/NoteExpressionRouter.h
+++ b/Source/NoteExpressionRouter.h
@@ -1,0 +1,74 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+/*
+  ==============================================================================
+
+    NoteExpressionRouter.h
+    Created: 19 Dec 2019 10:40:58pm
+    Author:  Ryan Challinor
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <iostream>
+#include "NoteEffectBase.h"
+#include "IDrawableModule.h"
+#include "Checkbox.h"
+#include "INoteSource.h"
+#include "Slider.h"
+#include "exprtk/exprtk.hpp"
+
+class NoteExpressionRouter : public INoteReceiver, public INoteSource, public IDrawableModule, public ITextEntryListener
+{
+public:
+   NoteExpressionRouter();
+   static IDrawableModule* Create() { return new NoteExpressionRouter(); }
+   
+   
+   void CreateUIControls() override;
+   
+   void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
+   void SendCC(int control, int value, int voiceIdx = -1) override;
+   
+   virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
+   virtual void SetUpFromSaveData() override;
+   virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
+private:
+   //IDrawableModule
+   void DrawModule() override;
+   void GetModuleDimensions(float& width, float& height) override { width = mWidth; height = mHeight; }
+   bool Enabled() const override { return true; }
+
+   static const int kMaxDestinations = 5;
+   AdditionalNoteCable* mDestinationCables[kMaxDestinations];
+   float mWidth;
+   float mHeight;
+
+public:
+    void TextEntryComplete(TextEntry *entry) override;
+
+private:
+
+   exprtk::symbol_table<float> mSymbolTable;
+   float mSTNote{0}, mSTVelocity{0}; // bound to the symbol table
+   std::array<exprtk::expression<float>, kMaxDestinations> mExpressions;
+   TextEntry* mExpressionWidget[kMaxDestinations];
+   char mExpressionText[kMaxDestinations][MAX_TEXTENTRY_LENGTH];
+};

--- a/Source/NoteExpressionRouter.h
+++ b/Source/NoteExpressionRouter.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include <iostream>
+#include <array>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"
 #include "INoteSource.h"
-#include "Slider.h"
+#include "TextEntry.h"
 #include "exprtk/exprtk.hpp"
 
 class NoteExpressionRouter : public INoteReceiver, public INoteSource, public IDrawableModule, public ITextEntryListener

--- a/Source/NoteExpressionRouter.h
+++ b/Source/NoteExpressionRouter.h
@@ -46,6 +46,8 @@ public:
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
+
+   void TextEntryComplete(TextEntry *entry) override;
    
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
@@ -60,9 +62,6 @@ private:
    AdditionalNoteCable* mDestinationCables[kMaxDestinations];
    float mWidth;
    float mHeight;
-
-public:
-    void TextEntryComplete(TextEntry *entry) override;
 
 private:
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1520,6 +1520,11 @@ noterouter~allows you to control where notes are routed to using a UI control. t
 
 
 
+noteexpression~control where notes are routed based upon evaluated expressions. the variable "p" represents pitch, and "v" represents velocity
+~expression*~expression to evaluate for this cable. example expression to route notes with pitch greater than 80 and velocity less than 60:\n"p > 80 && v < 60"
+
+
+
 noteratchet~rapidly repeat an input note over a duration
 ~duration~total length of time repeats should last
 ~subdivision~length of each repeat


### PR DESCRIPTION
The Note Expression Router is a new module which is like
a note hocket but rather than having a propability per
bus, it has an expresison in two variables 'n' and 'v'
for the note and velocity, which allows you to choose
where to route the note.