### PR TITLE
json: Silence bogus deprecation warnings on GCC

### DIFF
--- a/libs/json/CMakeLists.txt
+++ b/libs/json/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(${PROJECT_NAME}
         )
 
 target_include_directories(${PROJECT_NAME} PUBLIC jsoncpp/include)
-
+target_compile_options(${PROJECT_NAME} PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>)
 add_library(bespoke::${PROJECT_NAME} ALIAS ${PROJECT_NAME})


### PR DESCRIPTION
For some reason, GCC issues deprecation warnings in the implementation of a deprecated class:
```
/home/xbuilder/src/bespoke/libs/json/jsoncpp/src/lib_json/json_reader.cpp:756:34: warning: 'Reader' is deprecated: Use CharReader and CharReaderBuilder instead. [-Wdeprecated-declarations]
  756 | Reader::Char Reader::getNextChar() {
      |                                  ^
In file included from /home/xbuilder/src/bespoke/libs/json/jsoncpp/src/lib_json/json_reader.cpp:10:
/home/xbuilder/src/bespoke/libs/json/jsoncpp/include/json/reader.h:37:63: note: declared here
   37 |     "Use CharReader and CharReaderBuilder instead.") JSON_API Reader {
      |                                                               ^~~~~~
/home/xbuilder/src/bespoke/libs/json/jsoncpp/src/lib_json/json_reader.cpp:810:21: warning: 'Reader' is deprecated: Use CharReader and CharReaderBuilder instead. [-Wdeprecated-declarations]
  810 | std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
      |                     ^~~~~~~~~~~~~~~
In file included from /home/xbuilder/src/bespoke/libs/json/jsoncpp/src/lib_json/json_reader.cpp:10:
/home/xbuilder/src/bespoke/libs/json/jsoncpp/include/json/reader.h:37:63: note: declared here
   37 |     "Use CharReader and CharReaderBuilder instead.") JSON_API Reader {
      |                                                               ^~~~~~
```
Not sure what's up with that, but it's not in Bespoke code and it also occurs with the official JsonCpp `CMakeLists.txt`, so let's just silence it.