### PR TITLE
VST manager window with scanning as a subprocess

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -319,6 +319,7 @@ target_sources(BespokeSynth PRIVATE
     VSTPlayhead.cpp
     VSTPlugin.cpp
     VSTWindow.cpp
+    VSTScanner.cpp
     ValueSetter.cpp
     ValueStream.cpp
     VelocityScaler.cpp

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -530,7 +530,7 @@ std::vector<std::string> ModuleFactory::GetSpawnableModules(std::string keys)
    }
 
    std::vector<std::string> vsts;
-   VSTLookup::GetAvailableVSTs(vsts, false);
+   VSTLookup::GetAvailableVSTs(vsts);
    for (auto vstFile : vsts)
    {
       std::string vstName = juce::File(vstFile).getFileName().toStdString();

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -31,11 +31,13 @@
 #include "DropdownList.h"
 #include "ClickButton.h"
 #include "Slider.h"
+#include "WindowCloseListener.h"
 
 class ModuleFactory;
 class TitleBar;
 class HelpDisplay;
 struct SpawnListManager;
+class PluginListWindow;
 
 class SpawnList
 {
@@ -65,7 +67,7 @@ struct SpawnListManager
    SpawnListManager(IDropdownListener* owner);
    
    void SetModuleFactory(ModuleFactory* factory);
-   void SetUpVstDropdown(bool rescan);
+   void SetUpVstDropdown();
    std::vector<SpawnList*> GetDropdowns() { return mDropdowns; }
    
    SpawnList mInstrumentModules;
@@ -82,7 +84,7 @@ private:
    std::vector<SpawnList*> mDropdowns;
 };
 
-class TitleBar : public IDrawableModule, public IDropdownListener, public IButtonListener, public IFloatSliderListener
+class TitleBar : public IDrawableModule, public IDropdownListener, public IButtonListener, public IFloatSliderListener, public WindowCloseListener
 {
 public:
    TitleBar();
@@ -93,17 +95,19 @@ public:
    bool HasTitleBar() const override { return false; }
    bool AlwaysOnTop() override { return true; }
    bool IsSingleton() const override { return true; }
-   void Poll() override;
    
    HelpDisplay* GetHelpDisplay() { return mHelpDisplay; }
 
    void SetModuleFactory(ModuleFactory* factory) { mSpawnLists.SetModuleFactory(factory); }
    void ListLayouts();
-   void RescanVSTs() { mVstRescanCountdown = 5; }
+   void ManageVSTs();
    
    bool IsSaveable() override { return false; }
+
+   void OnWindowClosed() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownClicked(DropdownList* list) override;
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void ButtonClicked(ClickButton* button) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
@@ -139,9 +143,10 @@ private:
    HelpDisplay* mHelpDisplay;
    
    SpawnListManager mSpawnLists;
-   int mVstRescanCountdown;
    
    bool mLeftCornerHovered;
+
+   std::unique_ptr<PluginListWindow> mPluginListWindow;
 };
 
 extern TitleBar* TheTitleBar;

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -67,7 +67,6 @@ void UserPrefsEditor::CreateUIControls()
    TEXTENTRY(mDefaultLayoutPathEntry, "layout", 100, &mDefaultLayoutPath);
    TEXTENTRY(mYoutubeDlPathEntry, "youtube-dl_path", 100, &mYoutubeDlPath);
    TEXTENTRY(mFfmpegPathEntry, "ffmpeg_path", 100, &mFfmpegPath);
-   TEXTENTRY(mVstSearchDirsEntry, "vstsearchdirs", 1000, &mVstSearchDirs);
    CHECKBOX(mShowTooltipsOnLoadCheckbox, "show_tooltips_on_load", &mShowTooltipsOnLoad);
    CHECKBOX(mShowMinimapCheckbox, "show_minimap", &mShowMinimap);
    UIBLOCK_SHIFTDOWN();
@@ -81,7 +80,6 @@ void UserPrefsEditor::CreateUIControls()
    mUIScaleSlider->SetShowName(false);
    mScrollMultiplierVerticalSlider->SetShowName(false);
    mScrollMultiplierHorizontalSlider->SetShowName(false);
-   mVstSearchDirsEntry->SetFlexibleWidth(true);
 }
 
 void UserPrefsEditor::Show()
@@ -177,28 +175,6 @@ void UserPrefsEditor::Show()
    }
    else
       mFfmpegPath = TheSynth->GetUserPrefs()["ffmpeg_path"].asString();
-   
-   if (TheSynth->GetUserPrefs()["vstsearchdirs"].isNull())
-   {
-#if BESPOKE_MAC
-      mVstSearchDirs = "/Library/Audio/Plug-Ins/VST3, /Library/Audio/Plug-Ins/VST";
-#elif BESPOKE_LINUX
-      mVstSearchDirs = "~/.vst/, /usr/lib64/vst, /usr/lib64/vst3, /usr/lib/lxvst";
-#else
-      mVstSearchDirs = "C:/Program Files/Common Files/VST2, C:/Program Files/Common Files/VST3, C:/Program Files/Steinberg/VSTPlugins";
-#endif
-   }
-   else
-   {
-      const ofxJSONElement& strArray = TheSynth->GetUserPrefs()["vstsearchdirs"];
-      mVstSearchDirs = "";
-      for (unsigned int i=0; i<strArray.size(); ++i)
-      {
-         mVstSearchDirs += strArray[i].asString();
-         if (i < strArray.size()-1)
-            mVstSearchDirs += ", ";
-      }
-   }
 
    if (TheSynth->GetUserPrefs()["show_tooltips_on_load"].isNull())
       mShowTooltipsOnLoad = true;
@@ -506,9 +482,6 @@ void UserPrefsEditor::ButtonClicked(ClickButton* button)
       UpdatePrefStr(userPrefs, "layout", mDefaultLayoutPath);
       UpdatePrefStr(userPrefs, "youtube-dl_path", mYoutubeDlPath);
       UpdatePrefStr(userPrefs, "ffmpeg_path", mFfmpegPath);
-      std::string vstSearchDirs = mVstSearchDirs;
-      ofStringReplace(vstSearchDirs, ", ", ",");
-      UpdatePrefStrArray(userPrefs, "vstsearchdirs", ofSplitString(vstSearchDirs, ","));
       UpdatePrefBool(userPrefs, "show_tooltips_on_load", mShowTooltipsOnLoad);
       UpdatePrefBool(userPrefs, "show_minimap", mShowMinimap);
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -47,7 +47,7 @@ class ofxJSONElement;
 
 namespace VSTLookup
 {
-   void GetAvailableVSTs(std::vector<std::string>& vsts, bool rescan);
+   void GetAvailableVSTs(std::vector<std::string>& vsts);
    void FillVSTList(DropdownList* list);
    std::string GetVSTPath(std::string vstName);
 }
@@ -92,8 +92,9 @@ public:
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
-   
-   static bool sIsRescanningVsts;
+
+   static juce::AudioPluginFormatManager sFormatManager;
+   static juce::KnownPluginList sPluginList;
    
 private:
    //IDrawableModule

--- a/Source/VSTScanner.cpp
+++ b/Source/VSTScanner.cpp
@@ -69,7 +69,7 @@ bool CustomPluginScanner::findPluginTypesFor(juce::AudioPluginFormat& format,
    stream.writeString(format.getName());
    stream.writeString(fileOrIdentifier);
 
-   if (superprocess->sendMessageToSlave(block))
+   if (superprocess->sendMessageToFollower(block))
    {
       std::unique_lock<std::mutex> lock(mutex);
       gotResponse = false;
@@ -124,10 +124,10 @@ void CustomPluginScanner::changeListenerCallback(juce::ChangeBroadcaster*)
 CustomPluginScanner::Superprocess::Superprocess(CustomPluginScanner& o)
    : owner(o)
 {
-   launchSlaveProcess(juce::File::getSpecialLocation(juce::File::currentExecutableFile), kScanProcessUID, 0, 0);
+   launchFollowerProcess(juce::File::getSpecialLocation(juce::File::currentExecutableFile), kScanProcessUID, 0, 0);
 }
 
-void CustomPluginScanner::Superprocess::handleMessageFromSlave(const juce::MemoryBlock& mb)
+void CustomPluginScanner::Superprocess::handleMessageFromFollower(const juce::MemoryBlock& mb)
 {
    auto xml = parseXML(mb.toString());
 
@@ -245,7 +245,7 @@ PluginScannerSubprocess::PluginScannerSubprocess()
    formatManager.addDefaultFormats();
 }
 
-void PluginScannerSubprocess::handleMessageFromMaster(const juce::MemoryBlock& mb)
+void PluginScannerSubprocess::handleMessageFromLeader(const juce::MemoryBlock& mb)
 {
    {
       const std::lock_guard<std::mutex> lock(mutex);
@@ -296,7 +296,7 @@ void PluginScannerSubprocess::handleAsyncUpdate()
          xml.addChildElement(desc->createXml().release());
 
       const auto str = xml.toString();
-      sendMessageToMaster({ str.toRawUTF8(), str.getNumBytesAsUTF8() });
+      sendMessageToLeader({ str.toRawUTF8(), str.getNumBytesAsUTF8() });
    }
 }
 

--- a/Source/VSTScanner.cpp
+++ b/Source/VSTScanner.cpp
@@ -1,0 +1,302 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  VSTScanner.cpp
+//  Bespoke
+//
+//  Created by Ryan Challinor on 10/16/21.
+//
+//
+
+#include "VSTScanner.h"
+#include "VSTPlugin.h"
+#include "ModularSynth.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+extern juce::ApplicationProperties& getAppProperties();
+
+CustomPluginScanner::CustomPluginScanner()
+{
+   if (auto* file = getAppProperties().getUserSettings())
+      file->addChangeListener(this);
+
+   changeListenerCallback(nullptr);
+}
+
+CustomPluginScanner::~CustomPluginScanner()
+{
+   if (auto* file = getAppProperties().getUserSettings())
+      file->removeChangeListener(this);
+}
+
+bool CustomPluginScanner::findPluginTypesFor(juce::AudioPluginFormat& format,
+                                             juce::OwnedArray<juce::PluginDescription>& result,
+                                             const juce::String& fileOrIdentifier)
+{
+   if (!scanWithExternalProcess)
+   {
+      superprocess = nullptr;
+      format.findAllTypesForFile(result, fileOrIdentifier);
+      return true;
+   }
+
+   if (superprocess == nullptr)
+   {
+      superprocess = std::make_unique<Superprocess>(*this);
+
+      std::unique_lock<std::mutex> lock(mutex);
+      connectionLost = false;
+   }
+
+   juce::MemoryBlock block;
+   juce::MemoryOutputStream stream{ block, true };
+   stream.writeString(format.getName());
+   stream.writeString(fileOrIdentifier);
+
+   if (superprocess->sendMessageToSlave(block))
+   {
+      std::unique_lock<std::mutex> lock(mutex);
+      gotResponse = false;
+      pluginDescription = nullptr;
+
+      for (;;)
+      {
+         if (condvar.wait_for(lock,
+            std::chrono::milliseconds(50),
+            [this] { return gotResponse || shouldExit(); }))
+         {
+            break;
+         }
+      }
+
+      if (shouldExit())
+      {
+         superprocess = nullptr;
+         return true;
+      }
+
+      if (connectionLost)
+      {
+         superprocess = nullptr;
+         return false;
+      }
+
+      if (pluginDescription != nullptr)
+      {
+         for (const auto* item : pluginDescription->getChildIterator())
+         {
+            auto desc = std::make_unique<juce::PluginDescription>();
+
+            if (desc->loadFromXml(*item))
+               result.add(std::move(desc));
+         }
+      }
+
+      return true;
+   }
+
+   superprocess = nullptr;
+   return false;
+}
+
+void CustomPluginScanner::changeListenerCallback(juce::ChangeBroadcaster*)
+{
+   if (auto* file = getAppProperties().getUserSettings())
+      scanWithExternalProcess = (file->getIntValue(kScanModeKey) == 0);
+}
+
+CustomPluginScanner::Superprocess::Superprocess(CustomPluginScanner& o)
+   : owner(o)
+{
+   launchSlaveProcess(juce::File::getSpecialLocation(juce::File::currentExecutableFile), kScanProcessUID, 0, 0);
+}
+
+void CustomPluginScanner::Superprocess::handleMessageFromSlave(const juce::MemoryBlock& mb)
+{
+   auto xml = parseXML(mb.toString());
+
+   const std::lock_guard<std::mutex> lock(owner.mutex);
+   owner.pluginDescription = std::move(xml);
+   owner.gotResponse = true;
+   owner.condvar.notify_one();
+}
+
+void CustomPluginScanner::Superprocess::handleConnectionLost()
+{
+   const std::lock_guard<std::mutex> lock(owner.mutex);
+   owner.pluginDescription = nullptr;
+   owner.gotResponse = true;
+   owner.connectionLost = true;
+   owner.condvar.notify_one();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+CustomPluginListComponent::CustomPluginListComponent(juce::AudioPluginFormatManager& manager,
+   juce::KnownPluginList& listToRepresent,
+   const juce::File& pedal,
+   juce::PropertiesFile* props,
+   bool async)
+   : juce::PluginListComponent(manager, listToRepresent, pedal, props, async)
+{
+   addAndMakeVisible(validationModeLabel);
+   addAndMakeVisible(validationModeBox);
+
+   validationModeLabel.attachToComponent(&validationModeBox, true);
+   validationModeLabel.setJustificationType(juce::Justification::right);
+   validationModeLabel.setSize(100, 30);
+
+   auto unusedId = 1;
+
+   for (const auto mode : { "Avoid crashes", "Within process" })
+      validationModeBox.addItem(mode, unusedId++);
+
+   validationModeBox.setSelectedItemIndex(getAppProperties().getUserSettings()->getIntValue(kScanModeKey));
+
+   validationModeBox.onChange = [this]
+   {
+      getAppProperties().getUserSettings()->setValue(kScanModeKey, validationModeBox.getSelectedItemIndex());
+   };
+
+   OnResize();
+}
+
+void CustomPluginListComponent::OnResize()
+{
+   const auto& buttonBounds = getOptionsButton().getBounds();
+   validationModeBox.setBounds(buttonBounds.withWidth(130).withRightX(getWidth() - buttonBounds.getX()));
+
+   //validationModeBox.setBounds(juce::Rectangle(5,5,130,40));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+PluginListWindow::PluginListWindow(juce::AudioPluginFormatManager& pluginFormatManager, WindowCloseListener* listener)
+   : juce::DocumentWindow("Available Plugins",
+      juce::LookAndFeel::getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),
+      juce::DocumentWindow::minimiseButton | juce::DocumentWindow::closeButton)
+   , mListener(listener)
+{
+   auto deadMansPedalFile(juce::File(ofToDataPath("vst/deadmanspedal.txt")));
+
+   VSTPlugin::sPluginList.setCustomScanner(std::make_unique<CustomPluginScanner>());
+
+   mComponent = new CustomPluginListComponent(pluginFormatManager,
+                                              VSTPlugin::sPluginList,
+                                              deadMansPedalFile,
+                                              nullptr, true);
+
+   setContentOwned(mComponent, true);
+
+   setResizable(true, false);
+   setResizeLimits(300, 400, 1500, 1500);
+   setSize(600, 600);
+   setAlwaysOnTop(true);
+
+   if (const auto* dpy = juce::Desktop::getInstance().getDisplays().getDisplayForRect(TheSynth->GetMainComponent()->getScreenBounds()))
+   {
+      const auto& mainMon = dpy->userArea;
+      setTopLeftPosition(mainMon.getX() + mainMon.getWidth() / 4,
+         mainMon.getY() + mainMon.getHeight() / 4);
+   }
+
+   restoreWindowStateFromString(getAppProperties().getUserSettings()->getValue("listWindowPos"));
+   setVisible(true);
+}
+
+PluginListWindow::~PluginListWindow()
+{
+   getAppProperties().getUserSettings()->setValue("listWindowPos", getWindowStateAsString());
+   clearContentComponent();
+}
+
+void PluginListWindow::resized()
+{
+   juce::DocumentWindow::resized();
+
+   mComponent->OnResize();
+}
+
+void PluginListWindow::closeButtonPressed()
+{
+   mListener->OnWindowClosed();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+PluginScannerSubprocess::PluginScannerSubprocess()
+{
+   formatManager.addDefaultFormats();
+}
+
+void PluginScannerSubprocess::handleMessageFromMaster(const juce::MemoryBlock& mb)
+{
+   {
+      const std::lock_guard<std::mutex> lock(mutex);
+      pendingBlocks.emplace(mb);
+   }
+
+   triggerAsyncUpdate();
+}
+
+void PluginScannerSubprocess::handleConnectionLost()
+{
+   juce::JUCEApplicationBase::quit();
+}
+
+// It's important to run the plugin scan on the main thread!
+void PluginScannerSubprocess::handleAsyncUpdate()
+{
+   for (;;)
+   {
+      const auto block = [&]() -> juce::MemoryBlock
+      {
+         const std::lock_guard<std::mutex> lock(mutex);
+
+         if (pendingBlocks.empty())
+            return {};
+
+         auto out = std::move(pendingBlocks.front());
+         pendingBlocks.pop();
+         return out;
+      }();
+
+      if (block.isEmpty())
+         return;
+
+      juce::MemoryInputStream stream{ block, false };
+      const auto formatName = stream.readString();
+      const auto identifier = stream.readString();
+
+      juce::OwnedArray<juce::PluginDescription> results;
+
+      for (auto* format : formatManager.getFormats())
+         if (format->getName() == formatName)
+            format->findAllTypesForFile(results, identifier);
+
+      juce::XmlElement xml("LIST");
+
+      for (const auto& desc : results)
+         xml.addChildElement(desc->createXml().release());
+
+      const auto str = xml.toString();
+      sendMessageToMaster({ str.toRawUTF8(), str.getNumBytesAsUTF8() });
+   }
+}
+

--- a/Source/VSTScanner.h
+++ b/Source/VSTScanner.h
@@ -1,0 +1,130 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  VSTScanner.h
+//  Bespoke
+//
+//  Created by Ryan Challinor on 10/16/21.
+//
+//
+
+#pragma once
+
+#include "WindowCloseListener.h"
+
+#include "juce_audio_processors/juce_audio_processors.h"
+
+constexpr const char* kScanProcessUID = "bespokesynth";
+constexpr const char* kScanModeKey = "pluginScanMode";
+
+class CustomPluginScanner : public juce::KnownPluginList::CustomScanner,
+                            private juce::ChangeListener
+{
+public:
+   CustomPluginScanner();
+   ~CustomPluginScanner() override;
+
+   bool findPluginTypesFor(juce::AudioPluginFormat& format,
+                           juce::OwnedArray<juce::PluginDescription>& result,
+                           const juce::String& fileOrIdentifier) override;
+   void scanFinished() override { superprocess = nullptr; }
+
+private:
+   class Superprocess : public juce::ChildProcessMaster
+   {
+   public:
+      explicit Superprocess(CustomPluginScanner& o);
+
+   private:
+      void handleMessageFromSlave(const juce::MemoryBlock& mb) override;
+      void handleConnectionLost() override;
+
+      CustomPluginScanner& owner;
+
+      JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Superprocess)
+   };
+
+   void changeListenerCallback(juce::ChangeBroadcaster*) override;
+
+   std::unique_ptr<Superprocess> superprocess;
+   std::mutex mutex;
+   std::condition_variable condvar;
+   std::unique_ptr<juce::XmlElement> pluginDescription;
+   bool gotResponse = false;
+   bool connectionLost = false;
+
+   std::atomic<bool> scanWithExternalProcess{ true };
+
+   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CustomPluginScanner)
+};
+
+//==============================================================================
+class CustomPluginListComponent : public juce::PluginListComponent
+{
+public:
+   CustomPluginListComponent(juce::AudioPluginFormatManager& manager,
+                             juce::KnownPluginList& listToRepresent,
+                             const juce::File& pedal,
+                             juce::PropertiesFile* props,
+                             bool async);
+
+   void OnResize();
+
+private:
+   juce::Label validationModeLabel{ {}, "Scan mode" };
+   juce::ComboBox validationModeBox;
+
+   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CustomPluginListComponent)
+};
+
+class PluginListWindow : public juce::DocumentWindow
+{
+public:
+   PluginListWindow(juce::AudioPluginFormatManager& pluginFormatManager, WindowCloseListener* listener);
+   ~PluginListWindow() override;
+
+   void resized() override;
+   void closeButtonPressed() override;
+
+private:
+   WindowCloseListener* mListener;
+   CustomPluginListComponent* mComponent;
+
+   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginListWindow)
+};
+
+class PluginScannerSubprocess : private juce::ChildProcessSlave,
+                                private juce::AsyncUpdater
+{
+public:
+   PluginScannerSubprocess();
+
+   using juce::ChildProcessSlave::initialiseFromCommandLine;
+
+private:
+   void handleMessageFromMaster(const juce::MemoryBlock& mb) override;
+   void handleConnectionLost() override;
+
+   // It's important to run the plugin scan on the main thread!
+   void handleAsyncUpdate() override;
+
+   juce::AudioPluginFormatManager formatManager;
+
+   std::mutex mutex;
+   std::queue<juce::MemoryBlock> pendingBlocks;
+};

--- a/Source/VSTWindow.cpp
+++ b/Source/VSTWindow.cpp
@@ -41,6 +41,7 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
 #endif
 {
    setSize (400, 300);
+   setResizable(true, true);
    
    setContentOwned (pluginEditor, true);
 
@@ -64,7 +65,7 @@ VSTWindow::VSTWindow (VSTPlugin* vst,
 }
 
 //static
-VSTWindow* VSTWindow::CreateWindow(VSTPlugin* vst, WindowFormatType type)
+VSTWindow* VSTWindow::CreateVSTWindow(VSTPlugin* vst, WindowFormatType type)
 {
    juce::AudioProcessorEditor* ui = nullptr;
    

--- a/Source/VSTWindow.h
+++ b/Source/VSTWindow.h
@@ -53,7 +53,7 @@ public:
 
    void ShowWindow();
    
-   static VSTWindow* CreateWindow(VSTPlugin* vst, WindowFormatType);
+   static VSTWindow* CreateVSTWindow(VSTPlugin* vst, WindowFormatType);
    
    static void closeCurrentlyOpenWindowsFor (const juce::uint32 nodeId);
    static void closeAllCurrentlyOpenWindows();

--- a/Source/WindowCloseListener.h
+++ b/Source/WindowCloseListener.h
@@ -1,0 +1,32 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  WindowCloseListener.h
+//  Bespoke
+//
+//  Created by Ryan Challinor on 10/17/21.
+//
+//
+
+#pragma once
+
+class WindowCloseListener
+{
+public:
+   virtual void OnWindowClosed() = 0;
+};


### PR DESCRIPTION
now bespoke can scan VSTs and not crash if a buggy VST is encountered in the scan.
this code follows the subprocess scanning method shown here: https://github.com/juce-framework/JUCE/commit/7da8b73a968f9a5ba7a48f3ff2849dc9d033d9ca