### PR TITLE
Add a play/pause button to the transport module

### DIFF
--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -75,6 +75,7 @@ void Transport::CreateUIControls()
    mTimeSigTopDropdown = new DropdownList(this,"timesigtop",101,42,&mTimeSigTop);
    mTimeSigBottomDropdown = new DropdownList(this,"timesigbottom",101,60,&mTimeSigBottom);
    mResetButton = new ClickButton(this, "reset",5,78);
+   mPlayPauseButton = new ClickButton(this, "play/pause",42,78,ButtonDisplayStyle::kPause);
    mNudgeBackButton = new ClickButton(this," < ",80,78);
    mNudgeForwardButton = new ClickButton(this," > ",110,78);
    mSetTempoCheckbox = new Checkbox(this,"set tempo",HIDDEN_UICONTROL,HIDDEN_UICONTROL,&mSetTempoBool);
@@ -222,6 +223,11 @@ void Transport::DrawModule()
 
    mSwingSlider->Draw();
    mResetButton->Draw();
+   if (TheSynth->IsAudioPaused())
+      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPlay);
+   else
+      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPause);
+   mPlayPauseButton->Draw();
    mTimeSigTopDropdown->Draw();
    mTimeSigBottomDropdown->Draw();
    mSwingIntervalDropdown->Draw();
@@ -259,6 +265,8 @@ void Transport::ButtonClicked(ClickButton *button)
       AdjustTempo(1);
    if (button == mDecreaseTempoButton)
       AdjustTempo(-1);
+   if (button == mPlayPauseButton)
+      TheSynth->ToggleAudioPaused();
 }
 
 TransportListenerInfo* Transport::AddListener(ITimeListener* listener, NoteInterval interval, OffsetInfo offsetInfo, bool useEventLookahead)

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -171,6 +171,7 @@ private:
    float mSwing;
    FloatSlider* mSwingSlider;
    ClickButton* mResetButton;
+   ClickButton* mPlayPauseButton;
    DropdownList* mTimeSigTopDropdown;
    DropdownList* mTimeSigBottomDropdown;
    DropdownList* mSwingIntervalDropdown;


### PR DESCRIPTION
This allows for control of the global transport play/pause state
via a midi controller

The only issue I see is that the control activation indicator circle is frozen when the transport is paused
![Screenshot from 2021-10-18 19-55-18](https://user-images.githubusercontent.com/1253741/137782714-f9ffcd4d-c368-4054-8333-830ede067eb8.png)

