### PR TITLE
Using a more precise "center" value for endless encoders

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -190,7 +190,6 @@ UIControlConnection* MidiController::AddControlConnection(MidiMessageType messag
    if (layoutControl != -1)
    {
       connection->mIncrementAmount = mLayoutControls[layoutControl].mIncremental ? 1 : 0;
-      connection->mIncrementThreshold = mLayoutControls[layoutControl].mIncrementThreshold;
       connection->mMidiOffValue = mLayoutControls[layoutControl].mOffVal;
       connection->mMidiOnValue = mLayoutControls[layoutControl].mOnVal;
       connection->mScaleOutput = mLayoutControls[layoutControl].mScaleOutput;
@@ -574,10 +573,10 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                float increment = connection->mIncrementAmount / 100;
                if (GetKeyModifiers() & kModifier_Shift)
                   increment /= 50;
-               const float diff = std::abs(value - 64/127.0f);
-               if (diff > connection->mIncrementThreshold)
+               const float midpoint = 64.0f / 127.0f;
+               if (value != midpoint)
                {
-                   if (value > 64/127.0f)
+                   if (value > midpoint)
                       curValue += increment;
                    else
                       curValue -= increment;
@@ -1681,9 +1680,6 @@ void MidiController::LoadLayout(std::string filename)
                incremental = mLayoutData["groups"][group]["incremental"].asBool();
             int offVal = 0;
             int onVal = 127;
-            float incrementThreshold = 0;
-            if (!mLayoutData["groups"][group]["incrementThreshold"].isNull())
-               incrementThreshold = mLayoutData["groups"][group]["incrementThreshold"].asFloat();
             if (!mLayoutData["groups"][group]["colors"].isNull() &&
                mLayoutData["groups"][group]["colors"].size() > 2)
             {
@@ -1707,7 +1703,7 @@ void MidiController::LoadLayout(std::string filename)
                {
                   int index = col + row * cols;
                   int control = mLayoutData["groups"][group]["controls"][index].asInt();
-                  GetLayoutControl(control, messageType).Setup(this, messageType, control, drawType, incremental, incrementThreshold, offVal, onVal, false, connectionType, pos.x + kLayoutButtonsX + spacing.x*col, pos.y + kLayoutButtonsY + spacing.y*row, dim.x, dim.y);
+                  GetLayoutControl(control, messageType).Setup(this, messageType, control, drawType, incremental, offVal, onVal, false, connectionType, pos.x + kLayoutButtonsX + spacing.x*col, pos.y + kLayoutButtonsY + spacing.y*row, dim.x, dim.y);
 
                   //clear out values on controllers
                   /*if (messageType == kMidiMessage_Note)
@@ -1771,13 +1767,13 @@ void MidiController::LoadLayout(std::string filename)
       for (int i=0; i<128; ++i)
       {
          GetLayoutControl(i, kMidiMessage_Control).
-            Setup(this, kMidiMessage_Control, i, kDrawType_Slider, false, 0, 0, 127, true, kControlType_Default, i%8 * kSpacingX + kLayoutButtonsX + 9, i/8 * kSpacingY + kLayoutButtonsY, kSpacingX * .666f, kSpacingY * .93f);
+            Setup(this, kMidiMessage_Control, i, kDrawType_Slider, false, 0, 127, true, kControlType_Default, i%8 * kSpacingX + kLayoutButtonsX + 9, i/8 * kSpacingY + kLayoutButtonsY, kSpacingX * .666f, kSpacingY * .93f);
          GetLayoutControl(i, kMidiMessage_Note).
-            Setup(this, kMidiMessage_Note, i, kDrawType_Button, false, 0, 0, 127, true, kControlType_Default, i%8 * kSpacingX + 8 * kSpacingX + kLayoutButtonsX + 15, i/8 * kSpacingY + kLayoutButtonsY, kSpacingX * .93f, kSpacingY * .93f);
+            Setup(this, kMidiMessage_Note, i, kDrawType_Button, false, 0, 127, true, kControlType_Default, i%8 * kSpacingX + 8 * kSpacingX + kLayoutButtonsX + 15, i/8 * kSpacingY + kLayoutButtonsY, kSpacingX * .93f, kSpacingY * .93f);
       }
       
       GetLayoutControl(0, kMidiMessage_PitchBend).
-         Setup(this, kMidiMessage_PitchBend, 0, kDrawType_Slider, false, 0, 0, 127, true, kControlType_Default, kLayoutButtonsX + kSpacingX * 17, kLayoutButtonsY, 25, 100);
+         Setup(this, kMidiMessage_PitchBend, 0, kDrawType_Slider, false, 0, 127, true, kControlType_Default, kLayoutButtonsX + kSpacingX * 17, kLayoutButtonsY, 25, 100);
    }
    
    mLayoutWidth = 0;
@@ -2706,7 +2702,7 @@ UIControlConnection::~UIControlConnection()
    mEditorControls.clear();
 }
 
-void ControlLayoutElement::Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, float incrementThreshold, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h)
+void ControlLayoutElement::Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h)
 {
    assert(incremental == false || type == kMidiMessage_Control);  //only control type can be incremental
    
@@ -2715,7 +2711,6 @@ void ControlLayoutElement::Setup(MidiController* owner, MidiMessageType type, in
    mControl = control;
    mDrawType = drawType;
    mIncremental = incremental;
-   mIncrementThreshold = incrementThreshold;
    mOffVal = offVal;
    mOnVal = onVal;
    mScaleOutput = scaleOutput;

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -574,10 +574,10 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                float increment = connection->mIncrementAmount / 100;
                if (GetKeyModifiers() & kModifier_Shift)
                   increment /= 50;
-               const float diff = std::abs(value - .5f);
+               const float diff = std::abs(value - 64/127.0f);
                if (diff > connection->mIncrementThreshold)
                {
-                   if (value > .5f)
+                   if (value > 64/127.0f)
                       curValue += increment;
                    else
                       curValue -= increment;

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -175,7 +175,6 @@ struct UIControlConnection
    bool mScaleOutput;
    bool mBlink;
    float mIncrementAmount;
-   float mIncrementThreshold;
    bool mTwoWay;
    int mFeedbackControl;
    SpecialControlBinding mSpecialBinding;
@@ -221,7 +220,7 @@ enum ControlDrawType
 struct ControlLayoutElement
 {
    ControlLayoutElement() : mActive(false), mControlCable(nullptr), mConnectionType(kControlType_Slider) {}
-   void Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, float incrementThreshold, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h);
+   void Setup(MidiController* owner, MidiMessageType type, int control, ControlDrawType drawType, bool incremental, int offVal, int onVal, bool scaleOutput, ControlType connectionType, float x, float y, float w, float h);
    
    bool mActive;
    MidiMessageType mType;

--- a/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
@@ -59,7 +59,6 @@
             "messageType" : "control",
             "drawType" : "slider",
             "incremental": true,
-            "incrementThreshold": 0.01
         },
        {
           "rows": 1,


### PR DESCRIPTION
Using an Arturia Minilab MkII, turning an endless encoder to the left
slightly sends a MIDI CC value of 63, seen in Bespoke as 0.50, and
doesn't effect any change in the value it's mapped to control.
I imagine this is caused by .5f being a less precise "center" value
than is needed in this case. Using 64/127.0f instead, the issue is
fixed.

The incrementThreshold in the Minilab's layout also needs to be set to
0 so as to not block any value from having an effect.