### PR TITLE
changes to dropdownlist and quickspawn to handle massive VST collections

### DIFF
--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -37,7 +37,6 @@ namespace
 DropdownList::DropdownList(IDropdownListener* owner, const char* name, int x, int y, int* var, float width)
 : mWidth(35)
 , mHeight(itemSpacing)
-, mColumns(1)
 , mVar(var)
 , mModalList(this)
 , mOwner(owner)
@@ -117,9 +116,6 @@ void DropdownList::CalculateWidth()
    
    if (mAutoCalculateWidth)
       mWidth = MIN(mModalWidth, 180);
-   
-   mColumns = 1 + ((int)mElements.size()-1) / mMaxPerColumn;
-   mModalList.SetDimensions(mModalWidth*mColumns, itemSpacing * MIN((int)mElements.size(), mMaxPerColumn));
 }
 
 std::string DropdownList::GetLabel(int val) const
@@ -206,7 +202,11 @@ void DropdownList::DrawDropdown(int w, int h)
 {
    ofPushStyle();
 
-   int hoverIndex = GetItemIndex(mModalList.GetMouseX(), mModalList.GetMouseY());
+   int hoverIndex = -1;
+   float dropdownW, dropdownH;
+   mModalList.GetDimensions(dropdownW, dropdownH);
+   if (mModalList.GetMouseX() >= 0 && mModalList.GetMouseY() >= 0 && mModalList.GetMouseX() < dropdownW && mModalList.GetMouseY() < dropdownH)
+      hoverIndex = GetItemIndex(mModalList.GetMouseX(), mModalList.GetMouseY());
 
    ofSetColor(0,0,0);
    ofFill();
@@ -261,8 +261,23 @@ void DropdownList::OnClicked(int x, int y, bool right)
    if (mElements.empty())
       return;
 
-   UpdateModalListPosition();
+   ofVec2f modalPos = GetModalListPosition();
    mModalList.SetOwningContainer(GetModuleParent()->GetOwningContainer());
+
+   float screenX = (modalPos.x + GetModuleParent()->GetOwningContainer()->GetDrawOffset().x) * GetModuleParent()->GetOwningContainer()->GetDrawScale();
+   float screenY = (modalPos.y + GetModuleParent()->GetOwningContainer()->GetDrawOffset().y) * GetModuleParent()->GetOwningContainer()->GetDrawScale();
+   float maxX = ofGetWidth() - 5;
+   float maxY = ofGetHeight() - 5;
+
+   const int kMinPerColumn = 1;
+   mMaxPerColumn = std::max(kMinPerColumn, int((maxY - screenY) / (itemSpacing * GetModuleParent()->GetOwningContainer()->GetDrawScale())));
+
+   int columns = 1 + ((int)mElements.size() - 1) / mMaxPerColumn;
+   ofVec2f modalDimensions(mModalWidth*columns, itemSpacing * std::min((int)mElements.size(), mMaxPerColumn));
+   modalPos.x = std::max(5.0f, std::min(modalPos.x, maxX - modalDimensions.x));
+   mModalList.SetPosition(modalPos.x, modalPos.y);
+   mModalList.SetDimensions(modalDimensions.x, modalDimensions.y);
+   
    TheSynth->PushModalFocusItem(&mModalList);
 }
 
@@ -271,13 +286,13 @@ int DropdownList::GetItemIndex(int x, int y)
    return y / itemSpacing + x / mModalWidth * mMaxPerColumn;
 }
 
-void DropdownList::UpdateModalListPosition()
+ofVec2f DropdownList::GetModalListPosition() const
 {
    float thisx, thisy;
    GetPosition(thisx, thisy);
    if (mDrawLabel)
       thisx += mLabelSize;
-   mModalList.SetPosition(thisx, thisy + itemSpacing);
+   return ofVec2f(thisx, thisy + itemSpacing);
 }
 
 bool DropdownList::MouseMoved(float x, float y)

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -123,12 +123,11 @@ private:
    int FindItemIndex(float val) const;
    void SetValue(int value, bool forceUpdate);
    void CalculateWidth();
-   void UpdateModalListPosition();
+   ofVec2f GetModalListPosition() const;
 
    int mWidth;
    int mHeight;
    int mModalWidth;
-   int mColumns;
    int mMaxPerColumn;
    std::vector<DropdownListElement> mElements;
    int* mVar;

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -533,11 +533,30 @@ std::vector<std::string> ModuleFactory::GetSpawnableModules(std::string keys)
 
    std::vector<std::string> vsts;
    VSTLookup::GetAvailableVSTs(vsts);
+   std::vector<std::string> matchingVsts;
    for (auto vstFile : vsts)
    {
       std::string vstName = juce::File(vstFile).getFileName().toStdString();
       if (tolower(vstName[0]) == c)
+         matchingVsts.push_back(vstFile);
+   }
+   const int kMaxQuickspawnVstCount = 10;
+   if ((int)matchingVsts.size() <= kMaxQuickspawnVstCount)
+   {
+      for (auto vstFile : matchingVsts)
+      {
+         std::string vstName = juce::File(vstFile).getFileName().toStdString();
          modules.push_back(vstName + " " + kVSTSuffix);
+      }
+   }
+   else
+   {
+      VSTLookup::SortByLastUsed(matchingVsts);
+      for (int i = 0; i < kMaxQuickspawnVstCount; ++i)
+      {
+         std::string vstName = juce::File(matchingVsts[i]).getFileName().toStdString();
+         modules.push_back(vstName + " " + kVSTSuffix);
+      }
    }
 
    std::vector<std::string> prefabs;

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -225,8 +225,8 @@ SpawnListManager::SpawnListManager(IDropdownListener* owner)
 , mAudioModules(owner,this,0,0,"audio effects:")
 , mModulatorModules(owner,this,0,0,"modulators:")
 , mPulseModules(owner, this, 0, 0, "pulse:")
+, mVstPlugins(owner, this, 0, 0, "vst plugins:")
 , mOtherModules(owner,this,0,0,"other:")
-, mVstPlugins(owner,this,0,0,"vst plugins:")
 , mPrefabs(owner,this,0,0,"prefabs:")
 {
 }
@@ -253,8 +253,8 @@ void SpawnListManager::SetModuleFactory(ModuleFactory* factory)
    mDropdowns.push_back(&mAudioModules);
    mDropdowns.push_back(&mModulatorModules);
    mDropdowns.push_back(&mPulseModules);
-   mDropdowns.push_back(&mOtherModules);
    mDropdowns.push_back(&mVstPlugins);
+   mDropdowns.push_back(&mOtherModules);
    mDropdowns.push_back(&mPrefabs);
 }
 
@@ -375,8 +375,8 @@ void TitleBar::DrawModule()
                                   &mSpawnLists.mAudioModules,
                                   &mSpawnLists.mModulatorModules,
                                   &mSpawnLists.mPulseModules,
-                                  &mSpawnLists.mOtherModules,
                                   &mSpawnLists.mVstPlugins,
+                                  &mSpawnLists.mOtherModules,
                                   &mSpawnLists.mPrefabs };
 
    for (auto list : lists)
@@ -407,10 +407,10 @@ void TitleBar::DrawModule()
    mSpawnLists.mModulatorModules.Draw();
    mModuleType = kModuleType_Pulse;
    mSpawnLists.mPulseModules.Draw();
-   mModuleType = kModuleType_Other;
-   mSpawnLists.mOtherModules.Draw();
    mModuleType = kModuleType_Synth;
    mSpawnLists.mVstPlugins.Draw();
+   mModuleType = kModuleType_Other;
+   mSpawnLists.mOtherModules.Draw();
    mModuleType = kModuleType_Other;
    mSpawnLists.mPrefabs.Draw();
    mModuleType = type;
@@ -532,8 +532,8 @@ void TitleBar::DropdownUpdated(DropdownList* list, int oldVal)
    mSpawnLists.mAudioModules.OnSelection(list);
    mSpawnLists.mModulatorModules.OnSelection(list);
    mSpawnLists.mPulseModules.OnSelection(list);
-   mSpawnLists.mOtherModules.OnSelection(list);
    mSpawnLists.mVstPlugins.OnSelection(list);
+   mSpawnLists.mOtherModules.OnSelection(list);
    mSpawnLists.mPrefabs.OnSelection(list);
 }
 

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -77,38 +77,14 @@ namespace VSTLookup
       
       auto types = VSTPlugin::sPluginList.getTypes();
       for (int i=0; i<types.size(); ++i)
-      {
          vsts.push_back(types[i].fileOrIdentifier.toStdString());
-      }
-      
-      std::map<std::string, double> lastUsedTimes;
-      
-      if (juce::File(ofToDataPath("vst/used_vsts.json")).existsAsFile())
-      {
-         ofxJSONElement root;
-         root.open(ofToDataPath("vst/used_vsts.json"));
-         ofxJSONElement jsonList = root["vsts"];
 
-         for (auto it = jsonList.begin(); it != jsonList.end(); ++it)
-         {
-            std::string key = it.key().asString();
-            lastUsedTimes[key] = jsonList[key].asDouble();
-         }
-      }
-      
-      std::sort(vsts.begin(), vsts.end(), [lastUsedTimes](std::string a, std::string b) {
-         auto itA = lastUsedTimes.find(a);
-         auto itB = lastUsedTimes.find(b);
-         if (itA == lastUsedTimes.end() && itB == lastUsedTimes.end())
-            return a < b;
-         if (itA != lastUsedTimes.end() && itB == lastUsedTimes.end())
-            return true;
-         if (itA == lastUsedTimes.end() && itB != lastUsedTimes.end())
-            return false;
-         double timeA = (*itA).second;
-         double timeB = (*itB).second;
-         return timeA > timeB;
-      });
+      SortByLastUsed(vsts);
+
+      //add a bunch of duplicates to the list, to simulate a user with many VSTs
+      /*auto vstCopy = vsts;
+      for (int i = 0; i < 40; ++i)
+         vsts.insert(vsts.end(), vstCopy.begin(), vstCopy.end());*/
 
       sFirstTime = false;
    }
@@ -137,6 +113,38 @@ namespace VSTLookup
       }
       
       return "";
+   }
+
+   void SortByLastUsed(std::vector<std::string>& vsts)
+   {
+      std::map<std::string, double> lastUsedTimes;
+
+      if (juce::File(ofToDataPath("vst/used_vsts.json")).existsAsFile())
+      {
+         ofxJSONElement root;
+         root.open(ofToDataPath("vst/used_vsts.json"));
+         ofxJSONElement jsonList = root["vsts"];
+
+         for (auto it = jsonList.begin(); it != jsonList.end(); ++it)
+         {
+            std::string key = it.key().asString();
+            lastUsedTimes[key] = jsonList[key].asDouble();
+         }
+      }
+
+      std::sort(vsts.begin(), vsts.end(), [lastUsedTimes](std::string a, std::string b) {
+         auto itA = lastUsedTimes.find(a);
+         auto itB = lastUsedTimes.find(b);
+         if (itA == lastUsedTimes.end() && itB == lastUsedTimes.end())
+            return a < b;
+         if (itA != lastUsedTimes.end() && itB == lastUsedTimes.end())
+            return true;
+         if (itA == lastUsedTimes.end() && itB != lastUsedTimes.end())
+            return false;
+         double timeA = (*itA).second;
+         double timeB = (*itB).second;
+         return timeA > timeB;
+      });
    }
 }
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -50,6 +50,7 @@ namespace VSTLookup
    void GetAvailableVSTs(std::vector<std::string>& vsts);
    void FillVSTList(DropdownList* list);
    std::string GetVSTPath(std::string vstName);
+   void SortByLastUsed(std::vector<std::string>& vsts);
 }
 
 class VSTPlugin : public IAudioProcessor, public INoteReceiver, public IDrawableModule, public IDropdownListener, public IFloatSliderListener, public IIntSliderListener, public IButtonListener


### PR DESCRIPTION
- dropdownlist now adjusts the dropdown size to fill the screen height, and shift to the left to fit onscreen (fixes #95). this affects dropdowns everywhere and will improve overall usability.
- quickspawn only shows 10 VSTs that match the currently-held key combo, with the most recently-used VSTs winning out in the case of conflicts

this PR doesn't yet implement the "paging dropdowns" feature that I have mentioned on discord (to support users with truly massive VST collections that can't even fit on a full screen), that work is still pending