### PR TITLE
Two CMake Tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ endif ()
 project(BespokeSynth VERSION 1.0.1 LANGUAGES C CXX ASM)
 
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
+math(EXPR BESPOKE_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
+message(STATUS "Targeting ${BESPOKE_BITNESS} bit configuration")
+if (WIN32)
+    if (${BESPOKE_BITNESS} EQUAL 32)
+        message(WARNING "You are trying to do a 32 bit windows build, which is unsupported. This means"
+                " either your IDE tool chain is not set to 64 bits or your command prompt defaults to 32."
+                " It can usually be resolved by either editing your IDE settings to target a 64 bit build"
+                " or by removing this build dir and adding '-A x64' to your cmake command arguments")
+        message(FATAL_ERROR "32 bit build not proceeding")
+    endif()
+endif()
 
 # Global compile options
 add_compile_options(

--- a/Source/cmake/versiontools.cmake
+++ b/Source/cmake/versiontools.cmake
@@ -1,7 +1,12 @@
 # This is a multi-role CMake file. The IF branch runs on include, the ELSE
 # branch runs in script mode or when re-included after setting BESPOKESRC.
 if(CMAKE_PARENT_LIST_FILE AND NOT BESPOKESRC)
-    option(BESPOKE_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" OFF)
+    # Toggle this to on by default. here's my reasoning
+    # 1. Users who know what they are doing and dont want this can turn it off
+    # 2. Self build users who are struggling to build won't know to turn it off but need reliable build inf
+    # so having it 'on' means a few power users add an option but the bug reports on discord get more
+    # version accurate
+    option(BESPOKE_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" ON)
     function(bespoke_buildtime_version_info TARGET)
         configure_file(VersionInfo.cpp.in geninclude/VersionInfo.cpp)
         target_sources(${TARGET} PRIVATE


### PR DESCRIPTION
1. Set the version info to on by default as explained in comment
2. Bail out early on win 32 bit with a clear message