### PR TITLE
Some small granular window changes

### DIFF
--- a/Source/Granulator.h
+++ b/Source/Granulator.h
@@ -49,6 +49,7 @@ private:
    float mSpeedMult;
    double mStartTime;
    double mEndTime;
+   double mStartToEnd, mStartToEndInv;
    float mVol;
    float mStereoPosition;
    float mDrawPos;


### PR DESCRIPTION
- Move the GetWindow function to (1) inline, (2) skipping
a divide and (3) using the pade approx for cos.
- Remove a branch in GetWindow which isn't needed in the audio thread

With this merged we can close PR #412, with which it was intermingled