### PR TITLE
Overflow grid x values in the drumplayer to subsequent rows

### DIFF
--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -838,6 +838,14 @@ void DrumPlayer::DrumHit::DrawUIControls()
 
 int DrumPlayer::GetAssociatedSampleIndex(int x, int y)
 {
+    if (x > 3)
+    {
+        // For long rows, overflow the x value vertically
+        // This makes e.g. 8 pads on a single row usable for
+        // two drumplayer rows
+        y = y + (x / 4);
+        x = x % 4;
+    }
    int pos = x+(3-y)*4;
    if (pos < 16)
       return pos;


### PR DESCRIPTION
This allows for better use of longer, single-row pad setups.

This allows the use of two drumsampler rows from an 8-pad, single line layout as found on the Arturia Minilab.

The alternative would be to tweak the layout which would then not reflect the physical device layout