### PR TITLE
Windows 32-bit: Restore support, fix crash on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,6 @@ project(BespokeSynth VERSION 1.0.1 LANGUAGES C CXX ASM)
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 math(EXPR BESPOKE_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
 message(STATUS "Targeting ${BESPOKE_BITNESS} bit configuration")
-if (WIN32)
-    if (${BESPOKE_BITNESS} EQUAL 32)
-        message(WARNING "You are trying to do a 32 bit windows build, which is unsupported. This means"
-                " either your IDE tool chain is not set to 64 bits or your command prompt defaults to 32."
-                " It can usually be resolved by either editing your IDE settings to target a 64 bit build"
-                " or by removing this build dir and adding '-A x64' to your cmake command arguments")
-        message(FATAL_ERROR "32 bit build not proceeding")
-    endif()
-endif()
 
 # Global compile options
 add_compile_options(
@@ -42,6 +33,14 @@ add_compile_options(
     # Set source and executable charsets to UTF-8. Required for building on CJK Windows.
     $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
     )
+
+if(WIN32 AND ${BESPOKE_BITNESS} EQUAL 32)
+    add_link_options(
+        # Windows 32-bit: Extended address space
+        $<$<CXX_COMPILER_ID:MSVC>:/LARGEADDRESSAWARE>
+        $<$<BOOL:${MINGW}>:LINKER:--large-address-aware>
+        )
+endif()
 
 if(BESPOKE_PYTHON_ROOT)
     set(Python_ROOT "${BESPOKE_PYTHON_ROOT}")

--- a/Source/cmake/versiontools.cmake
+++ b/Source/cmake/versiontools.cmake
@@ -13,12 +13,16 @@ if(CMAKE_PARENT_LIST_FILE AND NOT BESPOKESRC)
             ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfo.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfoBld.cpp
             )
+        set(BESPOKE_BUILD_ARCH "${MSVC_CXX_ARCHITECTURE_ID}")
+        if("${BESPOKE_BUILD_ARCH}" STREQUAL "")
+            set(BESPOKE_BUILD_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+        endif()
         if(BESPOKE_RELIABLE_VERSION_INFO)
             add_custom_target(version-info BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/geninclude/VersionInfoBld.cpp
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 COMMAND ${CMAKE_COMMAND} -D CMAKE_PROJECT_VERSION_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
                 -D CMAKE_PROJECT_VERSION_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
-                -D CMAKE_SYSTEM_PROCESSOR="${CMAKE_SYSTEM_PROCESSOR}"
+                -D BESPOKE_BUILD_ARCH="${BESPOKE_BUILD_ARCH}"
                 -D BESPOKESRC=${CMAKE_SOURCE_DIR} -D BESPOKEBLD=${CMAKE_CURRENT_BINARY_DIR}
                 -D WIN32=${WIN32}
                 -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/versiontools.cmake
@@ -62,11 +66,10 @@ else()
     message(STATUS "Setting up BESPOKE version")
     message(STATUS "  git hash is ${GIT_COMMIT_HASH} and branch is ${GIT_BRANCH}")
     message(STATUS "  buildhost is ${BESPOKE_BUILD_FQDN}")
-    message(STATUS "  buildarch is ${CMAKE_SYSTEM_PROCESSOR}")
+    message(STATUS "  buildarch is ${BESPOKE_BUILD_ARCH}")
 
     string(TIMESTAMP BESPOKE_BUILD_DATE "%Y-%m-%d")
     string(TIMESTAMP BESPOKE_BUILD_TIME "%H:%M:%S")
-    set(BESPOKE_BUILD_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
 
     message(STATUS "Configuring ${BESPOKEBLD}/geninclude/VersionInfoBld.cpp")
     configure_file(${BESPOKESRC}/Source/VersionInfoBld.cpp.in ${BESPOKEBLD}/geninclude/VersionInfoBld.cpp)


### PR DESCRIPTION
32-bit virtual address space is only 2GiB by default. Bespoke allocates
a ~330 MiB chunk on startup, which was failing with `bad_alloc`. So let
the linker set the `IMAGE_FILE_LARGE_ADDRESS_AWARE` flag, extending VA
space to up to 3 GiB on 32-bit systems (when booted with `/3G`) and the
full 4 GiB on 64-bit systems.