### PR TITLE
delete held cable if you right-click

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1260,10 +1260,9 @@ void ModularSynth::MouseDragged(int intX, int intY, int button)
 
 void ModularSynth::MousePressed(int intX, int intY, int button)
 {
+   bool rightButton = button == 2;
+
    mZoomer.ExitVanityPanningMode();
-   
-   if (PatchCable::sActivePatchCable != nullptr)
-      return;
    
    mMousePos.x = intX;
    mMousePos.y = intY;
@@ -1282,11 +1281,16 @@ void ModularSynth::MousePressed(int intX, int intY, int button)
       return;
    }
 
+   if (PatchCable::sActivePatchCable != nullptr)
+   {
+      if (rightButton)
+         PatchCable::sActivePatchCable->Destroy();
+      return;
+   }
+
    mLastMouseDragPos = ofVec2f(x,y);
    mGroupSelectContext = nullptr;
    
-   bool rightButton = button == 2;
-
    IKeyboardFocusListener::sKeyboardFocusBeforeClick = IKeyboardFocusListener::GetActiveKeyboardFocus();
    IKeyboardFocusListener::ClearActiveKeyboardFocus(K(notifyListeners));
 

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -446,6 +446,9 @@ IClickable* PatchCable::GetDropTarget()
 
 bool PatchCable::TestClick(int x, int y, bool right, bool testOnly /* = false */)
 {
+   if (right)
+      return false;
+
    if (mHovered)
    {
       if (!testOnly)

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -460,6 +460,9 @@ bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = fa
    
    if (!mClickable)
       return false;
+
+   if (right)
+      return false;
    
    if (mHoverIndex != -1)
    {


### PR DESCRIPTION
a different take on #466
one issue that I dislike about this is that you can't right click while dragging with the left mouse button down. there seems to be something deeper within juce's mouse handling that prevents additional button clicks from getting through when one mouse button is already held down. needs further research, I think it would be cool to be able to right-click-delete while the left mouse button is held!