### PR TITLE
make scripts properly reload multiple note outputs

### DIFF
--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -567,11 +567,6 @@ ofxJSONElement ModuleContainer::WriteModules()
    return modules;
 }
 
-namespace
-{
-   const int kSaveStateRev = 420;
-}
-
 void ModuleContainer::SaveState(FileStreamOut& out)
 {
    out << kSaveStateRev;
@@ -610,7 +605,7 @@ void ModuleContainer::LoadState(FileStreamIn& in)
    
    int header;
    in >> header;
-   assert(header == kSaveStateRev);
+   assert(header <= kSaveStateRev);
    
    int savedModules;
    in >> savedModules;

--- a/Source/ModuleContainer.h
+++ b/Source/ModuleContainer.h
@@ -89,6 +89,8 @@ public:
    static constexpr int GetModuleSeparatorLength() { return 13; }
    static const char* GetModuleSeparator() { return "ryanchallinor"; }
    static bool DoesModuleHaveMoreSaveData(FileStreamIn& in);
+
+   static constexpr int kSaveStateRev = 421;
    
 private:   
    std::vector<IDrawableModule*> mModules;


### PR DESCRIPTION
this involved me revving the global savestate version
in the near future I need to rev the global savestate and do a full pass on putting module savestate versions before the IDrawableModule::SaveState() call. this will allow me to fix stuff up before the base IDrawableModule::LoadState() call, which I needed to do here to get the patch cables set up before IDrawableModule::LoadState() loaded their data. I am sure that cases like this will come up again, so it will be good to just move all of the module savedata revs to before the parent call