### PR TITLE
Fix missing first notes on notecanvas when resetting the trasnport

### DIFF
--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -121,7 +121,7 @@ public:
    void SetMeasure(int count) { mMeasureTime = mMeasureTime - (int)mMeasureTime + count; }
    void SetDownbeat() { mMeasureTime = mMeasureTime - (int)mMeasureTime - .001; }
    static int CountInStandardMeasure(NoteInterval interval);
-   void Reset(float rewindAmount = 0.001f);
+   void Reset(float rewindAmount = 0.005f);
    void OnDrumEvent(NoteInterval drumEvent);
    void SetLoop(int measureStart, int measureEnd) { assert(measureStart < measureEnd); mLoopStartMeasure = measureStart; mLoopEndMeasure = measureEnd; }
    void ClearLoop() { mLoopStartMeasure = -1; mLoopEndMeasure = -1; }


### PR DESCRIPTION
I could produce the issue by recording from a midi device, quantizing
and moving the notes to the front of the canvas

With the smaller rewind the first notes would not play.
When placing notes with the mouse, the issue did not happen

Maybe fixes #361 