### PR TITLE
Add `BESPOKE_PORTABLE` build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_policy(SET CMP0091 NEW)
 
 # Global build parameters. Optional features are configurable via additional
 # BESPOKE_* variables defined in their respective subdirs.
+option(BESPOKE_PORTABLE "Create a self-contained build that ships all dependencies" OFF)
 set(BESPOKE_JUCE_LOCATION "${CMAKE_SOURCE_DIR}/libs/JUCE" CACHE STRING "Path to JUCE library source tree")
 set(BESPOKE_PYTHON_ROOT "" CACHE STRING "Python search path. Override as needed.")
 set(BESPOKE_VST2_SDK_LOCATION "" CACHE STRING "Steinberg VST2 SDK directory for non-FOSS builds")
@@ -40,6 +41,15 @@ if(WIN32 AND ${BESPOKE_BITNESS} EQUAL 32)
         $<$<CXX_COMPILER_ID:MSVC>:/LARGEADDRESSAWARE>
         $<$<BOOL:${MINGW}>:LINKER:--large-address-aware>
         )
+endif()
+
+if(BESPOKE_PORTABLE)
+    message(STATUS "Portable build enabled")
+    if(MINGW)
+        message(WARNING "Portable MinGW builds don't ship the runtime DLLs \
+        (libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll). Make sure \
+        to copy them to the .exe's directory before distributing this build.")
+    endif()
 endif()
 
 if(BESPOKE_PYTHON_ROOT)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(cmake/lib.cmake)
 include(cmake/versiontools.cmake)
 
 juce_add_gui_app(BespokeSynth
@@ -338,6 +339,12 @@ target_sources(BespokeSynth PRIVATE
     ofxJSONElement.cpp
     )
 
+if(BESPOKE_PORTABLE)
+    set_source_files_properties(ScriptModule.cpp PROPERTIES
+        COMPILE_DEFINITIONS BESPOKE_PORTABLE_PYTHON="$<IF:$<BOOL:${WIN32}>,python.exe,bin/python>"
+        )
+endif()
+
 target_include_directories(BespokeSynth PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${Python_INCLUDE_DIRS}
@@ -394,51 +401,6 @@ if (APPLE)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMAND ${CMAKE_COMMAND} -E copy_directory resource ${OUTDIR}/BespokeSynth.app/Contents/Resources/resource
         )
-
-    get_filename_component(Python_FRAMEWORK_DIR ${Python_LIBRARY_DIRS} DIRECTORY)
-    foreach(PYCAND Python Python3.9 Python3.8 Python3)
-        if (EXISTS "${Python_FRAMEWORK_DIR}/${PYCAND}")
-            set( Python_BIN "${PYCAND}")
-        endif()
-    endforeach()
-    if (NOT DEFINED Python_BIN)
-        message( FATAL_ERROR "Cannot find python binary. Consider setting BESPOKE_PYTHON_ROOT" )
-    endif()
-
-    # Alright what is this doing? Well the python build hard-codes a reference to a python
-    # framework which means this executable wont even *start* on a machine which isn't
-    # configured the same as python. Our desired behavior is that the executable starts
-    # but python doesn't work. So copy the python framework build stub into the resources
-    # framework and repoint the python to it with install_name_tool.
-    #
-    # But also: If you have no python installed, or have BESPOKE_PYTHON_ROOT set oddly,
-    # you end up with a wierdo case where you use XCode python. We warn about that here
-    # but also do the couple of rpath changes just in case below, which deal with that
-    message(STATUS "Mac Python Framework is '${Python_BIN}' from '${Python_FRAMEWORK_DIR}'")
-
-    string(FIND ${Python_FRAMEWORK_DIR} "Xcode.app" IS_PYTHON_XCODE)
-    if (${IS_PYTHON_XCODE} GREATER 0)
-        message( WARNING "Your python built environment came from Xcode.app. "
-            "This may not be what you want. Consider setting BESPOKE_PYTHON_ROOT to "
-            "a python install of your choosing. Especially, if you are on an M1 "
-            "mac and use homebrew, you may want to use something like "
-            "'-DBESPOKE_PYTHON_ROOT=/opt/homebrew/Cellar/python\@3.9/3.9.6'")
-    endif()
-
-    add_custom_command(TARGET BespokeSynth
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTDIR}/BespokeSynth.app/Contents/Frameworks/LocalPython
-        COMMAND ${CMAKE_COMMAND} -E copy ${Python_FRAMEWORK_DIR}/${Python_BIN} ${OUTDIR}/BespokeSynth.app/Contents/Frameworks/LocalPython
-        COMMAND codesign --remove-signature ${OUTDIR}/BespokeSynth.app/Contents/Frameworks/LocalPython/${Python_BIN}
-        COMMAND codesign -s - ${OUTDIR}/BespokeSynth.app/Contents/Frameworks/LocalPython/${Python_BIN}
-        # THis is the 'normal' case
-        COMMAND install_name_tool -change "${Python_FRAMEWORK_DIR}/${Python_BIN}" "@executable_path/../Frameworks/LocalPython/${Python_BIN}" ${OUTDIR}/BespokeSynth.app/Contents/MacOS/BespokeSynth
-        # These are the 'got it from xcode by mistake' cases
-        COMMAND install_name_tool -change "@rpath/Python3.framework/Versions/3.8/Python3" "@executable_path/../Frameworks/LocalPython/${Python_BIN}" ${OUTDIR}/BespokeSynth.app/Contents/MacOS/BespokeSynth
-        COMMAND install_name_tool -change "@rpath/Python3.framework/Versions/3.9/Python3" "@executable_path/../Frameworks/LocalPython/${Python_BIN}" ${OUTDIR}/BespokeSynth.app/Contents/MacOS/BespokeSynth
-        )
-
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE BESPOKE_WINDOWS=1)
 
@@ -501,32 +463,21 @@ target_link_libraries(BespokeSynth PRIVATE
     $<$<BOOL:${MINGW}>:dbghelp>
     )
 
+bespoke_make_portable(BespokeSynth)
 
 # Rules to do some installing and packaging which we will have to refactor  but
 # for now gets a nightly going
-set(BESPOKE_PRODUCT_DIR "${CMAKE_BINARY_DIR}/products")
 set(BESPOKE_NIGHTLY_DIR "${CMAKE_BINARY_DIR}/nightly")
-add_custom_command(TARGET BespokeSynth
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${BESPOKE_PRODUCT_DIR}
-        )
 add_custom_target(nightly-package)
 add_dependencies(nightly-package BespokeSynth)
 
 if (APPLE)
-    get_target_property(output_dir BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
-    add_custom_command(TARGET BespokeSynth
-            POST_BUILD
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMAND ${CMAKE_COMMAND} -E copy_directory ${output_dir}/BespokeSynth.app/ ${BESPOKE_PRODUCT_DIR}/BespokeSynth.app
-            )
-
     add_custom_command(TARGET nightly-package
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${BESPOKE_NIGHTLY_DIR}
-            COMMAND hdiutil create /tmp/tmp.dmg -ov -volname "BespokeSynth" -fs HFS+ -srcfolder "${BESPOKE_PRODUCT_DIR}"
+            COMMAND hdiutil create /tmp/tmp.dmg -ov -volname "BespokeSynth" -fs HFS+ -srcfolder $<TARGET_BUNDLE_DIR:BespokeSynth>
+            COMMAND ${CMAKE_COMMAND} -E rm -f "${BESPOKE_NIGHTLY_DIR}/BespokeNightly.dmg"
             COMMAND hdiutil convert /tmp/tmp.dmg -format UDZO -o "${BESPOKE_NIGHTLY_DIR}/BespokeNightly.dmg"
             )
 else()

--- a/Source/cmake/BespokeSynth.manifest.in
+++ b/Source/cmake/BespokeSynth.manifest.in
@@ -1,0 +1,27 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    name="@PROJECT_NAME@"
+    processorArchitecture="@cpuArch@"
+    type="win32"
+    version="@PROJECT_VERSION@.0"
+  />
+  <description>Bespoke Synth</description>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        language="*"
+        name="python"
+        processorArchitecture="@cpuArch@"
+        type="win32"
+        version="@PROJECT_VERSION@.0"
+      />
+    </dependentAssembly>
+  </dependency>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/Source/cmake/BespokeSynth.manifest.rc.in
+++ b/Source/cmake/BespokeSynth.manifest.rc.in
@@ -1,0 +1,3 @@
+/* Resource script for embedding the manifest on MinGW. On MSVC we embed the manifest directly. */
+#pragma code_page(65001)
+1 /* CREATEPROCESS_MANIFEST_RESOURCE_ID */ 24 /* RT_MANIFEST */ "@manifestPath@"

--- a/Source/cmake/bundle-python.cmake
+++ b/Source/cmake/bundle-python.cmake
@@ -1,0 +1,55 @@
+# Much of this exclusion list was lifted from Blender (GPL-2.0-or-later). Thanks!
+file(INSTALL
+    "${pyBulkInstallFrom}"
+    DESTINATION "${pyBulkInstallTo}"
+    USE_SOURCE_PERMISSIONS
+    PATTERN "*.a" EXCLUDE
+    PATTERN "*.exe" EXCLUDE
+    PATTERN "*.orig" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+    PATTERN "*.pyo" EXCLUDE
+    PATTERN "*.rej" EXCLUDE
+    PATTERN ".DS_Store" EXCLUDE
+    PATTERN ".git" EXCLUDE
+    PATTERN ".svn" EXCLUDE
+    PATTERN "__MACOSX" EXCLUDE
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "idlelib" EXCLUDE
+    PATTERN "lib-dynload/_tkinter.*" EXCLUDE
+    PATTERN "lib2to3" EXCLUDE
+    PATTERN "site-packages" EXCLUDE
+    PATTERN "test" EXCLUDE
+    PATTERN "tkinter" EXCLUDE
+    PATTERN "turtle.py" EXCLUDE
+    PATTERN "turtledemo" EXCLUDE
+    )
+
+if(APPLE)
+    function(relinkPySigned binary newPySO)
+        execute_process(COMMAND codesign --remove-signature "${binary}")
+        execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change "${pySO}" "${newPySO}" "${binary}")
+    endfunction()
+    file(CREATE_LINK "${pyMajDotMin}" "${pyBulkInstallTo}/Current" SYMBOLIC)  # Make codesign happy
+    file(CREATE_LINK "../Frameworks/${pyFWName}/Versions/${pyMajDotMin}" "${bundleContents}/Resources/python" SYMBOLIC)
+    file(CREATE_LINK "python${pyMajDotMin}" "${pyDirDst}/bin/python" SYMBOLIC)
+    get_filename_component(pySO "${Python_LIBRARIES}" REALPATH)
+    get_filename_component(pySOName "${pySO}" NAME)
+    string(REGEX REPLACE ".*/${pyFWName}" "${pyFWName}" pyFWRelative "${pySO}")
+    set(pyExecutable "${pyDirDst}/bin/python${pyMajDotMin}")
+    # python.org Python links and is linked without @rpath, the next 3 lines fix this.
+    execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change "${pySO}" "@loader_path/../Frameworks/${pyFWRelative}" "${targetBinary}")
+    relinkPySigned("${pyExecutable}" "@executable_path/../${pySOName}")
+    relinkPySigned("${pyDirDst}/Resources/Python.app/Contents/MacOS/Python" "@executable_path/../../../../${pySOName}")
+    execute_process(COMMAND codesign -s - --deep "${bundleContents}/Frameworks/${pyFWName}")
+elseif(WIN32)
+    get_filename_component(pyDirSrc "${Python_EXECUTABLE}" DIRECTORY)
+    file(GLOB pyBinaries LIST_DIRECTORIES false "${pyDirSrc}/*.dll" "${pyDirSrc}/*.exe")
+    file(INSTALL ${pyBinaries} DESTINATION "${pyDirDst}")
+    file(INSTALL "${pyDirSrc}/DLLs" DESTINATION "${pyDirDst}")
+    file(INSTALL "${CMAKE_CURRENT_BINARY_DIR}/python.manifest" DESTINATION "${pyDirDst}")
+else()
+    get_filename_component(pySO "${Python_LIBRARIES}" REALPATH)
+    file(INSTALL "${pySO}" DESTINATION "${pyDirDst}/bin")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${Python_EXECUTABLE}" "${pyDirDst}/bin/python")
+    execute_process(COMMAND patchelf --set-rpath "$ORIGIN" "${pyDirDst}/bin/python")
+endif()

--- a/Source/cmake/lib.cmake
+++ b/Source/cmake/lib.cmake
@@ -1,0 +1,67 @@
+# Install dependencies to the output directory and fix up binaries
+function(bespoke_make_portable TARGET)
+    if(NOT BESPOKE_PORTABLE)
+        return()
+    endif()
+    get_target_property(pyDirDst ${TARGET} RUNTIME_OUTPUT_DIRECTORY)
+    set(pyMajDotMin "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+    if(APPLE)
+        string(REGEX REPLACE "\.framework/Versions/${pyMajDotMin}/.*" ".framework/Versions/${pyMajDotMin}" pyFWDirSrc "${Python_STDLIB}")
+        string(REGEX REPLACE "/Versions/${pyMajDotMin}" "" pyFWName "${pyFWDirSrc}")
+        string(REGEX REPLACE ".*/" "" pyFWName "${pyFWName}")
+        set(bundleContents "${pyDirDst}/${TARGET}.app/Contents")
+        set(pyDirDst "${bundleContents}/Frameworks/${pyFWName}/Versions/${pyMajDotMin}")
+    else()
+        set(pyDirDst "${pyDirDst}/python")
+    endif()
+
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        -D APPLE=${APPLE} -D MINGW=${MINGW} -D WIN32=${WIN32} -D UNIX=${UNIX}
+        -D CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}"
+        -D CMAKE_INSTALL_NAME_TOOL="${CMAKE_INSTALL_NAME_TOOL}"
+        -D targetBinary="$<TARGET_FILE:${TARGET}>"
+        -D bundleContents="${bundleContents}"
+        -D pyBulkInstallFrom="$<IF:$<BOOL:${APPLE}>,${pyFWDirSrc},${Python_STDLIB}>"
+        -D pyBulkInstallTo="$<IF:$<BOOL:${APPLE}>,"${bundleContents}/Frameworks/${pyFWName}/Versions",${pyDirDst}$<$<NOT:$<BOOL:${WIN32}>>:/lib>>"
+        -D pyDirDst="${pyDirDst}"
+        -D pyFWDirSrc="${pyFWDirSrc}"
+        -D pyFWName="${pyFWName}"
+        -D pyMajDotMin="${pyMajDotMin}"
+        -D Python_EXECUTABLE="${Python_EXECUTABLE}"
+        -D Python_LIBRARIES="${Python_LIBRARIES}"
+        -D Python_VERSION_MAJOR="${Python_VERSION_MAJOR}"
+        -D Python_VERSION_MINOR="${Python_VERSION_MINOR}"
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bundle-python.cmake"
+        )
+
+    if(UNIX)
+        set_target_properties(${TARGET} PROPERTIES
+            BUILD_RPATH $<IF:$<BOOL:${APPLE}>,@loader_path/../Frameworks,$ORIGIN/python/bin>
+            )
+    elseif(WIN32)
+        if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+            set(cpuArch "x86")
+        else()
+            set(cpuArch "amd64")
+        endif()
+        get_filename_component(pyDLL "${Python_LIBRARIES}" NAME)
+        string(REGEX REPLACE "\.[Ll][Ii][Bb]$" ".dll" pyDLL "${pyDLL}")
+        # Reject alien implibs such as MinGW .dll.a for now. MinGW Python has a
+        # UNIX-y layout and needs different treatment.
+        if("${CMAKE_MATCH_0}" STREQUAL "")
+            message(FATAL_ERROR "The Python library \"${pyDLL}\" does not look \
+            like an import library (.lib extension). Portable builds require \
+            the official Python for Windows from python.org.")
+        endif()
+        configure_file(cmake/python.manifest.in python.manifest @ONLY)
+        set(manifestPath ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.manifest)
+        configure_file(cmake/${TARGET}.manifest.in ${manifestPath} @ONLY)
+        if(MSVC)
+            target_sources(${TARGET} PRIVATE ${manifestPath})
+        else()
+            configure_file(cmake/${TARGET}.manifest.rc.in ${TARGET}.manifest.rc @ONLY)
+            target_sources(${TARGET} PRIVATE ${TARGET}.manifest.rc)
+        endif()
+    endif()
+endfunction()

--- a/Source/cmake/python.manifest.in
+++ b/Source/cmake/python.manifest.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    name="python"
+    processorArchitecture="@cpuArch@"
+    type="win32"
+    version="@PROJECT_VERSION@.0"
+  />
+  <file name="@pyDLL@" />
+</assembly>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,8 @@ jobs:
               libxcursor1 \
               libxcb-cursor-dev \
               libxcb-cursor0 \
-              libusb-1.0.0-dev
+              libusb-1.0.0-dev \
+              patchelf
 
         condition: variables.isLinux
         displayName: linux - run apt-get


### PR DESCRIPTION
When `BESPOKE_PORTABLE` is enabled, the build installs Python to a directory `python` in the output directory (next to `resources`), or into the bundle on macOS. This is somewhat unorthodox. Usually dependencies are bundled at install time. I went with this approach for now, for two reasons:
- It's dead-simple. You build, the output directory has everything, the end.
- It enables debugging portable builds directly from the IDE.

In portable builds, `ScriptModule` uses only the bundled Python and does not display a "make sure you have Python installed" prompt. All platforms also ship a standalone Python interpreter that targets the bundled Python. `pip` is supported via `ensurepip`. Just add a Script module and run:
```python
import ensurepip
ensurepip._main()
```

Platform notes:

**Windows**: Python is deployed as a side-by-side assembly. If the DLL is missing, Windows displays an error message and refuses to start Bespoke. There is no fallback to whatever the user might have installed. Tested with 3.9 (64-bit), 3.10 (32-bit).

**macOS**: The existing `nightly-package` target now produces a `.dmg` with a `Bespoke.app` that works on python-less systems. The uncompressed bundle is currently a tad heavy (~170 MB) with some Python versions. We can probably exclude more stuff during the install step. Tested with Apple 2.7, CommandlineTools 3.8, python.org 3.10.

**UNIX/Linux**: Python is referenced via relative rpath, so there's a fallback to the system python. Won't help much though since `ScriptModule` will insist on the portable `PYTHONHOME`. Tested with 3.10.

The next step is to generate installers for Windows and Linux.