### PR TITLE
Don't re-copy the whole resource dir after every build

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -394,14 +394,6 @@ if (APPLE)
         KompleteKontrol.cpp
         )
     target_link_libraries(BespokeSynth PRIVATE "-framework CoreAudioKit")
-
-    # Post install tasks - copy resources to the bundle
-    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
-    add_custom_command(TARGET BespokeSynth
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_directory resource ${OUTDIR}/BespokeSynth.app/Contents/Resources/resource
-        )
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE BESPOKE_WINDOWS=1)
 
@@ -411,24 +403,11 @@ elseif (WIN32)
         target_include_directories(BespokeSynth PRIVATE ${BESPOKE_ASIO_SDK_LOCATION}/common)
     endif()
 
-    # Post install tasks - copy resources to the exe output directory
     set_target_properties(BespokeSynth PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:BespokeSynth>"
         VS_DEBUGGER_COMMAND           "$<TARGET_FILE:BespokeSynth>"
         VS_DEBUGGER_ENVIRONMENT       "PATH=%PATH%;${CMAKE_PREFIX_PATH}/bin")
-    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
-    add_custom_command(TARGET BespokeSynth
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_directory resource ${OUTDIR}/resource)
 else ()
     target_compile_definitions(BespokeSynth PRIVATE BESPOKE_LINUX=1)
-
-    # Ant put resources with the exe
-    get_target_property(OUTDIR BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
-    add_custom_command(TARGET BespokeSynth
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_directory resource ${OUTDIR}/resource)
 
     # Finally provide install rules if folks want to install into CMAKE_INSTALL_PREFIX
     install(TARGETS BespokeSynth DESTINATION bin)
@@ -464,6 +443,7 @@ target_link_libraries(BespokeSynth PRIVATE
     $<$<BOOL:${MINGW}>:dbghelp>
     )
 
+bespoke_copy_resource_dir(BespokeSynth)
 bespoke_make_portable(BespokeSynth)
 
 # Rules to do some installing and packaging which we will have to refactor  but

--- a/Source/cmake/install-quiet.cmake
+++ b/Source/cmake/install-quiet.cmake
@@ -1,0 +1,15 @@
+# This abomination is the only way I know how to install quietly at build time.
+# Arguments: <source> <destination> [QUIET]
+if("${CMAKE_ARGV5}" STREQUAL "QUIET")
+    execute_process(COMMAND ${CMAKE_COMMAND} -P "${CMAKE_SCRIPT_MODE_FILE}"
+        "${CMAKE_ARGV3}"
+        "${CMAKE_ARGV4}"
+        OUTPUT_VARIABLE output
+        RESULT_VARIABLE result
+        )
+    if(result AND NOT result EQUAL 0)
+        message(SEND_ERROR "Failed to install \"${CMAKE_ARGV3}\" to \"${CMAKE_ARGV4}\"")
+    endif()
+else()
+    file(INSTALL "${CMAKE_ARGV3}" DESTINATION "${CMAKE_ARGV4}" USE_SOURCE_PERMISSIONS)
+endif()

--- a/Source/cmake/lib.cmake
+++ b/Source/cmake/lib.cmake
@@ -1,3 +1,14 @@
+# Install resource directory to the output directory or bundle
+function(bespoke_copy_resource_dir TARGET)
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/cmake/install-quiet.cmake"
+        "${CMAKE_SOURCE_DIR}/resource"
+        "$<TARGET_FILE_DIR:${TARGET}>$<$<BOOL:${APPLE}>:/../Resources>"
+        QUIET
+        VERBATIM
+        )
+endfunction()
+
 # Install dependencies to the output directory and fix up binaries
 function(bespoke_make_portable TARGET)
     if(NOT BESPOKE_PORTABLE)


### PR DESCRIPTION
The resource directory rarely changes but was being bulk-copied to the
output directory after every build. This change lets CMake only update
changed and new files.