### PR TITLE
hint that modulators can be dragged vertically to adjust min value

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -389,6 +389,8 @@ void ModularSynth::Poll()
       {
          if (GetKeyModifiers() == kModifier_Shift)
             desiredCursor = MouseCursor::CrosshairCursor;
+         else if (dynamic_cast<FloatSlider*>(gHoveredUIControl) != nullptr && dynamic_cast<FloatSlider*>(gHoveredUIControl)->GetModulator() != nullptr && dynamic_cast<FloatSlider*>(gHoveredUIControl)->GetModulator()->Active())
+            desiredCursor = MouseCursor::UpDownLeftRightResizeCursor;
          else
             desiredCursor = MouseCursor::LeftRightResizeCursor;
       }


### PR DESCRIPTION
when dragging a floatslider with an LFO or other modulator, change the cursor to 4-way arrows, to hint that you can drag vertically to adjust the min value (in addition to horizontally to adjust the max value)