### PR TITLE
add ability to lock drumsequencer rows to avoid randomness

### DIFF
--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -255,7 +255,7 @@ void NoteStepSequencer::DrawModule()
    {
       ofVec2f pos = mGrid->GetCellPosition(0, i-1) + mGrid->GetPosition(true);
       float scale = MIN(mGrid->IClickable::GetDimensions().y / mGrid->GetRows(), 20);
-      DrawTextNormal(NoteName(RowToPitch(i),false,true) + "("+ ofToString(RowToPitch(i)) + ")", pos.x + 1, pos.y - (scale/8) + 1, scale);
+      DrawTextNormal(NoteName(RowToPitch(i),false,true) + "("+ ofToString(RowToPitch(i)) + ")", pos.x + 1, pos.y - (scale/8), scale);
    }
    ofPopStyle();
    

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -212,8 +212,6 @@ private:
    UIGrid* mGrid;
    float mStrength;
    FloatSlider* mStrengthSlider;
-   bool mUseStrengthSlider;
-   Checkbox* mUseStrengthSliderCheckbox;
    int mGridYOff;
    DropdownList* mPresetDropdown;
    int mPreset;
@@ -224,6 +222,8 @@ private:
    Checkbox* mAdjustOffsetsCheckbox;
    std::array<float, NUM_STEPSEQ_ROWS> mOffsets;
    std::array<FloatSlider*, NUM_STEPSEQ_ROWS> mOffsetSlider;
+   std::array<bool, NUM_STEPSEQ_ROWS> mRandomLock;
+   std::array<Checkbox*, NUM_STEPSEQ_ROWS> mRandomLockCheckbox;
    std::map<int,int> mPadPressures;
    NoteInterval mRepeatRate;
    DropdownList* mRepeatRateDropdown;

--- a/Source/UIGrid.cpp
+++ b/Source/UIGrid.cpp
@@ -243,7 +243,7 @@ void UIGrid::OnClicked(int x, int y, bool right)
          }
          else
          {
-            mData[dataIndex] = 1;
+            mData[dataIndex] = mStrength;
          }
       }
    }
@@ -278,7 +278,7 @@ void UIGrid::OnClicked(int x, int y, bool right)
    }
    else
    {
-      if (mData[dataIndex] == mStrength)
+      if (mData[dataIndex] > 0)
       {
          mData[dataIndex] = 0;
          mLastClickWasClear = true;

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -569,8 +569,7 @@ fouronthefloor~sends note 0 every beat, to trigger a kick drum
 
 
 drumsequencer~step sequencer intended for drums. hold shift when dragging on the grid to adjust step velocity.
-~str~velocity to use when setting a step via a grid controller, if the checkbox next to this slider is checked
-~use str~if the "str" slider should be used for setting velocity
+~vel~velocity to use when setting a step
 ~measures~length of the sequence in measures
 ~preset~select a pattern preset
 ~yoff~vertical offset for grid controller's view of the pattern
@@ -588,6 +587,7 @@ drumsequencer~step sequencer intended for drums. hold shift when dragging on the
 ~randomize~randomize the sequence
 ~r den~density of the randomizer output. the higher this is, the busier the random output will be.
 ~r amt~the chance that each step will change when being randomized. low values will only change a small amount of the sequence, high values will replace more of the sequence.
+~r lock*~lock this row so it doesn't get randomized
 
 
 


### PR DESCRIPTION
- resize the drumsequencer to find these new checkboxes. when enabled for a row the "randomize" checkbox will have no effect on that row
- also, fixed up how the velocity slider works, to be clearer