### PR TITLE
increase sequencing flexibility for controlsequencer and radiosequencer

### DIFF
--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -33,40 +33,57 @@
 #include "Checkbox.h"
 #include "Transport.h"
 #include "DropdownList.h"
+#include "Slider.h"
+#include "IPulseReceiver.h"
+#include "INoteReceiver.h"
+#include "IDrivableSequencer.h"
 
 class PatchCableSource;
 
-class ControlSequencer : public IDrawableModule, public ITimeListener, public IDropdownListener, public UIGridListener, public IButtonListener
+class ControlSequencer : public IDrawableModule, public ITimeListener, public IDropdownListener, public UIGridListener, public IButtonListener, public IIntSliderListener, public IPulseReceiver, public INoteReceiver, public IDrivableSequencer
 {
 public:
    ControlSequencer();
    ~ControlSequencer();
    static IDrawableModule* Create() { return new ControlSequencer(); }
-   
-   
+
+
    void CreateUIControls() override;
    void Init() override;
-   
+
    IUIControl* GetUIControl() const { return mUIControl; }
-   
+
    //IGridListener
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
-   
+
    //IDrawableModule
    void Poll() override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   
+
    //ITimeListener
    void OnTimeEvent(double time) override;
+
+   //IPulseReceiver
+   void OnPulse(double time, float velocity, int flags) override;
+
+   //INoteReceiver
+   void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
+   void SendCC(int control, int value, int voiceIdx = -1) override {}
+
+   //IDrivableSequencer
+   bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
+   void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
    
    void CheckboxUpdated(Checkbox* checkbox) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void ButtonClicked(ClickButton* button) override;
    
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
+   bool LoadOldControl(FileStreamIn& in, std::string& oldName) override;
    void SetUpFromSaveData() override;
    
    void SaveState(FileStreamOut& out) override;
@@ -78,8 +95,8 @@ public:
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
    
 private:
+   void Step(double time, int pulseFlags);
    void SetGridSize(float w, float h);
-   void SetNumSteps(int numSteps, bool stretch);
    
    //IDrawableModule
    void DrawModule() override;
@@ -89,14 +106,18 @@ private:
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
    
-   UIGrid* mGrid;
-   IUIControl* mUIControl;
-   NoteInterval mInterval;
-   DropdownList* mIntervalSelector;
-   int mLength;
-   DropdownList* mLengthSelector;
-   PatchCableSource* mControlCable;
-   ClickButton* mRandomize;
+   UIGrid* mGrid{ nullptr };
+   IUIControl* mUIControl{ nullptr };
+   NoteInterval mInterval{ kInterval_16n };
+   DropdownList* mIntervalSelector{ nullptr };
+   int mLength{ 16 };
+   IntSlider* mLengthSlider{ nullptr };
+   std::string mOldLengthStr;
+   int mLoadRev{ -1 };
+   PatchCableSource* mControlCable{ nullptr };
+   ClickButton* mRandomize{ nullptr };
+   bool mHasExternalPulseSource{ false };
+   int mStep{ 0 };
 
    TransportListenerInfo* mTransportListenerInfo;
 };

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -1126,16 +1126,23 @@ void IDrawableModule::LoadState(FileStreamIn& in)
       bool threwException = false;
       try
       {
-         //ofLog() << "loading control " << uicontrolname;
-         auto* control = FindUIControl(uicontrolname.c_str(), false);
+         if (LoadOldControl(in, uicontrolname))
+         {
+            //old data loaded, we're good now!
+         }
+         else
+         {
+            //ofLog() << "loading control " << uicontrolname;
+            auto* control = FindUIControl(uicontrolname.c_str(), false);
 
-         if (control == nullptr)
-            throw UnknownUIControlException();
-      
-         bool setValue = true;
-         if (VectorContains(control, ControlsToNotSetDuringLoadState()))
-            setValue = false;
-         control->LoadState(in, setValue);
+            if (control == nullptr)
+               throw UnknownUIControlException();
+
+            bool setValue = true;
+            if (VectorContains(control, ControlsToNotSetDuringLoadState()))
+               setValue = false;
+            control->LoadState(in, setValue);
+         }
          
          for (int j=0; j<kControlSeparatorLength; ++j)
          {

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -153,6 +153,7 @@ public:
    virtual std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const;
    virtual std::vector<IUIControl*> ControlsToIgnoreInSaveState() const;
    virtual void UpdateOldControlName(std::string& oldName) {}
+   virtual bool LoadOldControl(FileStreamIn& in, std::string& oldName) { return false; }
    virtual bool CanSaveState() const { return true; }
    virtual size_t GetExpectedSaveStateNumChildren() const { return mChildren.size(); }
    virtual bool HasDebugDraw() const { return false; }

--- a/Source/IDrivableSequencer.h
+++ b/Source/IDrivableSequencer.h
@@ -1,0 +1,33 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  IDrivableSequencer.h
+//  modularSynth
+//
+//  Created by Ryan Challinor 10/30/21
+//
+//
+
+#pragma once
+
+class IDrivableSequencer
+{
+public:
+   virtual bool HasExternalPulseSource() const = 0;
+   virtual void ResetExternalPulseSource() = 0;
+};

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -16,10 +16,11 @@
 #include "INoteSource.h"
 #include "IPulseReceiver.h"
 #include "Slider.h"
+#include "IDrivableSequencer.h"
 
 #define NUM_M185SEQUENCER_STEPS 8
 
-class M185Sequencer : public IDrawableModule, public IButtonListener, public IDropdownListener, public IIntSliderListener, public ITimeListener, public IPulseReceiver, public INoteSource
+class M185Sequencer : public IDrawableModule, public IButtonListener, public IDropdownListener, public IIntSliderListener, public ITimeListener, public IPulseReceiver, public INoteSource, public IDrivableSequencer
 {
 public:
    M185Sequencer();
@@ -41,6 +42,10 @@ public:
 
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
+
+   //IDrivableSequencer
+   bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
+   void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
    //IDropdownListener
    void DropdownUpdated(DropdownList* list, int oldVal) override;

--- a/Source/MathUtils.cpp
+++ b/Source/MathUtils.cpp
@@ -80,4 +80,19 @@ namespace MathUtils
        return ofLerp(a, c, t);*/
       return powf(t, powf(5,-curve));
    }
+
+   int HighestPow2(int n)
+   {
+      int res = 0;
+      for (int i = n; i >= 1; i--)
+      {
+         // If i is a power of 2
+         if ((i & (i - 1)) == 0)
+         {
+            res = i;
+            break;
+         }
+      }
+      return res;
+   }
 };

--- a/Source/MathUtils.h
+++ b/Source/MathUtils.h
@@ -41,4 +41,5 @@ namespace MathUtils
    ofVec2f ScaleVec(ofVec2f a, ofVec2f b);
    ofVec2f Normal(ofVec2f v);
    float Curve(float t, float curve);
+   int HighestPow2(int n);
 };

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -572,7 +572,7 @@ ofxJSONElement ModuleContainer::WriteModules()
 
 namespace
 {
-   const int kSaveStateRev = 421;
+   const int kSaveStateRev = 422;
 }
 
 void ModuleContainer::SaveState(FileStreamOut& out)

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -29,6 +29,7 @@
 #include "IAudioReceiver.h"
 #include "INoteReceiver.h"
 #include "ModuleContainer.h"
+#include "IDrivableSequencer.h"
 
 #include <cstring>
 
@@ -43,6 +44,7 @@ ModuleSaveDataPanel::ModuleSaveDataPanel()
 , mApplyButton(nullptr)
 , mDeleteButton(nullptr)
 , mDrawDebugCheckbox(nullptr)
+, mResetSequencerButton(nullptr)
 {
    assert(TheSaveDataPanel == nullptr);
    TheSaveDataPanel = this;
@@ -194,6 +196,15 @@ void ModuleSaveDataPanel::ReloadSaveData()
       mSaveDataControls.push_back(mDrawDebugCheckbox);
       y += itemSpacing;
    }
+
+   IDrivableSequencer* sequencer = dynamic_cast<IDrivableSequencer*>(mSaveModule);
+   if (sequencer && sequencer->HasExternalPulseSource())
+   {
+      mResetSequencerButton = new ClickButton(this, "resume self-advance mode", x, y);
+      mResetSequencerButton->SetNoHover(true);
+      mSaveDataControls.push_back(mResetSequencerButton);
+      y += itemSpacing;
+   }
    
    mHeight = y+5;
 }
@@ -276,6 +287,12 @@ void ModuleSaveDataPanel::ButtonClicked(ClickButton* button)
    {
       mSaveModule->GetOwningContainer()->DeleteModule(mSaveModule);
       SetModule(nullptr);
+   }
+   if (button == mResetSequencerButton)
+   {
+      IDrivableSequencer* sequencer = dynamic_cast<IDrivableSequencer*>(mSaveModule);
+      if (sequencer && sequencer->HasExternalPulseSource())
+         sequencer->ResetExternalPulseSource();
    }
 }
 

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -82,6 +82,7 @@ private:
    ClickButton* mApplyButton;
    ClickButton* mDeleteButton;
    Checkbox* mDrawDebugCheckbox;
+   ClickButton* mResetSequencerButton;
    std::map<DropdownList*,ModuleSaveData::SaveVal*> mStringDropdowns;
 
    int mHeight;

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -33,6 +33,7 @@
 #include "FillSaveDropdown.h"
 #include "UIControlMacros.h"
 #include "PatchCableSource.h"
+#include "MathUtils.h"
 
 NoteStepSequencer::NoteStepSequencer()
 : mInterval(kInterval_8n)
@@ -1007,24 +1008,6 @@ void NoteStepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-namespace
-{
-   int HighestPow2(int n)
-   {
-      int res = 0;
-      for (int i = n; i >= 1; i--)
-      {
-         // If i is a power of 2
-         if ((i & (i - 1)) == 0)
-         {
-            res = i;
-            break;
-         }
-      }
-      return res;
-   }
-}
-
 void NoteStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
 {
    if (slider == mLoopResetPointSlider || slider == mLengthSlider)
@@ -1036,7 +1019,7 @@ void NoteStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
       if (mLength > oldVal)
       {
          //slice the loop into the nearest power of 2 and loop new steps from there
-         int oldLengthPow2 = HighestPow2(oldVal);
+         int oldLengthPow2 = std::max(1, MathUtils::HighestPow2(oldVal));
          for (int i = oldVal; i < mLength; ++i)
          {
             int loopedFrom = i % oldLengthPow2;

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -41,12 +41,13 @@
 #include "Scale.h"
 #include "IPulseReceiver.h"
 #include "GridController.h"
+#include "IDrivableSequencer.h"
 
 #define NSS_MAX_STEPS 32
 
 class PatchCableSource;
 
-class NoteStepSequencer : public IDrawableModule, public ITimeListener, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public MidiDeviceListener, public UIGridListener, public IAudioPoller, public IScaleListener, public INoteReceiver, public IPulseReceiver, public IGridControllerListener
+class NoteStepSequencer : public IDrawableModule, public ITimeListener, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public MidiDeviceListener, public UIGridListener, public IAudioPoller, public IScaleListener, public INoteReceiver, public IPulseReceiver, public IGridControllerListener, public IDrivableSequencer
 {
 public:
    NoteStepSequencer();
@@ -103,6 +104,10 @@ public:
    //IGridControllerListener
    void OnControllerPageSelected() override;
    void OnGridButton(int x, int y, float velocity, IGridController* grid) override;
+
+   //IDrivableSequencer
+   bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
+   void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
    
    void ButtonClicked(ClickButton* button) override;
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -37,10 +37,11 @@
 #include "Slider.h"
 #include "IPulseReceiver.h"
 #include "UIGrid.h"
+#include "IDrivableSequencer.h"
 
 class PatchCableSource;
 
-class PulseSequence : public IDrawableModule, public ITimeListener, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public IAudioPoller, public IPulseSource, public IPulseReceiver, public UIGridListener
+class PulseSequence : public IDrawableModule, public ITimeListener, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public IAudioPoller, public IPulseSource, public IPulseReceiver, public UIGridListener, public IDrivableSequencer
 {
 public:
    PulseSequence();
@@ -69,6 +70,10 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
+
+   //IDrivableSequencer
+   bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
+   void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
    
    void ButtonClicked(ClickButton* button) override;
    void CheckboxUpdated(Checkbox* checkbox) override;

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -28,6 +28,8 @@
 #include "RadioSequencer.h"
 #include "ModularSynth.h"
 #include "PatchCableSource.h"
+#include "UIControlMacros.h"
+#include "MathUtils.h"
 
 namespace
 {
@@ -35,11 +37,6 @@ namespace
 }
 
 RadioSequencer::RadioSequencer()
-: mGrid(nullptr)
-, mInterval(kInterval_1n)
-, mIntervalSelector(nullptr)
-, mLength(4)
-, mLengthSelector(nullptr)
 {
 }
 
@@ -58,11 +55,15 @@ RadioSequencer::~RadioSequencer()
 void RadioSequencer::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mGrid = new UIGrid(5,23,200,170,mLength,8, this);
-   mIntervalSelector = new DropdownList(this,"interval",5,3,(int*)(&mInterval));
-   mLengthSelector = new DropdownList(this,"length",-1,-1,(int*)(&mLength));
-   mGridControlTarget = new GridControlTarget(this, "grid", -1, -1);
-   
+
+   int width, height;
+   UIBLOCK(3, 3, 200);
+   INTSLIDER(mLengthSlider, "length", &mLength, 1, 16); UIBLOCK_SHIFTRIGHT();
+   DROPDOWN(mIntervalSelector, "interval", (int*)(&mInterval), 40); UIBLOCK_SHIFTRIGHT();
+   UICONTROL_CUSTOM(mGridControlTarget, new GridControlTarget(UICONTROL_BASICS("grid")));
+   ENDUIBLOCK(width, height);
+
+   mGrid = new UIGrid(5, 25, mGridControlTarget->GetRect().getMaxX() - 6, 170, mLength, 8, this);
    mGrid->SetHighlightCol(gTime, -1);
    mGrid->SetSingleColumnMode(true);
    mGrid->SetMajorColSize(4);
@@ -81,17 +82,6 @@ void RadioSequencer::CreateUIControls()
    mIntervalSelector->AddLabel("16nt", kInterval_16nt);
    mIntervalSelector->AddLabel("32n", kInterval_32n);
    mIntervalSelector->AddLabel("64n", kInterval_64n);
-   
-   mLengthSelector->AddLabel("4", 4);
-   mLengthSelector->AddLabel("6", 6);
-   mLengthSelector->AddLabel("8", 8);
-   mLengthSelector->AddLabel("16", 16);
-   mLengthSelector->AddLabel("32", 32);
-   mLengthSelector->AddLabel("64", 64);
-   mLengthSelector->AddLabel("128", 128);
-   
-   mLengthSelector->PositionTo(mIntervalSelector, kAnchor_Right);
-   mGridControlTarget->PositionTo(mLengthSelector, kAnchor_Right);
    
    SyncControlCablesToGrid();
 }
@@ -131,34 +121,86 @@ void RadioSequencer::UpdateGridLights()
    }
 }
 
-void RadioSequencer::OnTimeEvent(double time)
+void RadioSequencer::Step(double time, int pulseFlags)
 {
+   int length = mLength;
+   if (length <= 0)
+      length = 1;
+
+   int direction = 1;
+   if (pulseFlags & kPulseFlag_Backward)
+      direction = -1;
+   if (pulseFlags & kPulseFlag_Repeat)
+      direction = 0;
+
+   mStep = (mStep + direction + length) % length;
+
+   if (pulseFlags & kPulseFlag_Reset)
+      mStep = 0;
+   else if (pulseFlags & kPulseFlag_Random)
+      mStep = gRandom() % length;
+
+   if (!mHasExternalPulseSource || (pulseFlags & kPulseFlag_SyncToTransport))
+   {
+      mStep = TheTransport->GetSyncedStep(time, this, mTransportListenerInfo, length);
+   }
+
+   if (pulseFlags & kPulseFlag_Align)
+   {
+      int stepsPerMeasure = TheTransport->GetStepsPerMeasure(this);
+      int numMeasures = ceil(float(length) / stepsPerMeasure);
+      int measure = TheTransport->GetMeasure(time) % numMeasures;
+      int step = ((TheTransport->GetQuantized(time, mTransportListenerInfo) % stepsPerMeasure) + measure * stepsPerMeasure) % length;
+      mStep = step;
+   }
+
    if (!mEnabled)
       return;
 
-   int step = TheTransport->GetSyncedStep(time, this, mTransportListenerInfo, mGrid->GetCols());
-   
-   mGrid->SetHighlightCol(time, step);
-   
+   mGrid->SetHighlightCol(time, mStep);
+
    IUIControl* controlToEnable = nullptr;
-   for (int i=0; i<mControlCables.size(); ++i)
+   for (int i = 0; i < mControlCables.size(); ++i)
    {
       IUIControl* uicontrol = nullptr;
       if (mControlCables[i]->GetTarget())
          uicontrol = dynamic_cast<IUIControl*>(mControlCables[i]->GetTarget());
       if (uicontrol)
       {
-         if (mGrid->GetVal(step, i) > 0)
+         if (mGrid->GetVal(mStep, i) > 0)
             controlToEnable = uicontrol;
          else
             uicontrol->SetValue(0);
       }
    }
-   
+
    if (controlToEnable)
       controlToEnable->SetValue(1);
-   
+
    UpdateGridLights();
+}
+
+void RadioSequencer::OnPulse(double time, float velocity, int flags)
+{
+   mHasExternalPulseSource = true;
+
+   Step(time, flags);
+}
+
+void RadioSequencer::OnTimeEvent(double time)
+{
+   if (!mHasExternalPulseSource)
+      Step(time, 0);
+}
+
+void RadioSequencer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
+{
+   if (velocity > 0)
+   {
+      mHasExternalPulseSource = true;
+      mStep = pitch % std::max(1, mLength);
+      Step(time, kPulseFlag_Repeat);
+   }
 }
 
 void RadioSequencer::DrawModule()
@@ -168,7 +210,7 @@ void RadioSequencer::DrawModule()
    
    mGrid->Draw();
    mIntervalSelector->Draw();
-   mLengthSelector->Draw();
+   mLengthSlider->Draw();
    mGridControlTarget->Draw();
    
    for (int i=0; i<mControlCables.size(); ++i)
@@ -195,33 +237,6 @@ bool RadioSequencer::MouseMoved(float x, float y)
    IDrawableModule::MouseMoved(x,y);
    mGrid->NotifyMouseMoved(x,y);
    return false;
-}
-
-void RadioSequencer::SetNumSteps(int numSteps, bool stretch)
-{
-   int oldNumSteps = mGrid->GetCols();
-   assert(numSteps != 0);
-   assert(oldNumSteps != 0);
-   if (stretch)   //updated interval, stretch old pattern out to make identical pattern at higher res
-   {              // abcd becomes aabbccdd
-      std::vector<float> pattern;
-      pattern.resize(oldNumSteps);
-      for (int i=0; i<oldNumSteps; ++i)
-         pattern[i] = mGrid->GetVal(i,0);
-      float ratio = float(numSteps)/oldNumSteps;
-      for (int i=0; i<numSteps; ++i)
-         mGrid->SetVal(i, 0, pattern[int(i/ratio)]);
-   }
-   else           //updated length, copy old pattern out to make identical pattern over longer time
-   {              // abcd becomes abcdabcd
-      int numCopies = numSteps / oldNumSteps;
-      for (int i=1; i<numCopies; ++i)
-      {
-         for (int j=0; j<oldNumSteps; ++j)
-            mGrid->SetVal(i*oldNumSteps + j, 0, mGrid->GetVal(j, 0));
-      }
-   }
-   mGrid->SetGrid(numSteps,mGrid->GetRows());
 }
 
 void RadioSequencer::GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue)
@@ -262,27 +277,30 @@ void RadioSequencer::SyncControlCablesToGrid()
 
 void RadioSequencer::DropdownUpdated(DropdownList* list, int oldVal)
 {
-   int newSteps = int(mLength * TheTransport->CountInStandardMeasure(mInterval));
    if (list == mIntervalSelector)
    {
-      if (newSteps > 0)
-      {
-         TransportListenerInfo* transportListenerInfo = TheTransport->GetListenerInfo(this);
-         if (transportListenerInfo != nullptr)
-            transportListenerInfo->mInterval = mInterval;
-         SetNumSteps(newSteps, true);
-      }
-      else
-      {
-         mInterval = (NoteInterval)oldVal;
-      }
+      TransportListenerInfo* transportListenerInfo = TheTransport->GetListenerInfo(this);
+      if (transportListenerInfo != nullptr)
+         transportListenerInfo->mInterval = mInterval;
    }
-   if (list == mLengthSelector)
+}
+
+void RadioSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+{
+   if (slider == mLengthSlider)
    {
-      if (newSteps > 0)
-         SetNumSteps(newSteps, false);
-      else
-         mLength = oldVal;
+      mGrid->SetGrid(mLength, mGrid->GetRows());
+      if (mLength > oldVal)
+      {
+         //slice the loop into the nearest power of 2 and loop new steps from there
+         int oldLengthPow2 = std::max(1, MathUtils::HighestPow2(oldVal));
+         for (int i = oldVal; i < mLength; ++i)
+         {
+            int loopedFrom = i % oldLengthPow2;
+            for (int row = 0; row < mGrid->GetRows(); ++row)
+               mGrid->SetVal(i, row, mGrid->GetVal(i % oldLengthPow2, row));
+         }
+      }
    }
 }
 
@@ -316,28 +334,24 @@ void RadioSequencer::SaveLayout(ofxJSONElement& moduleInfo)
 }
 
 void RadioSequencer::LoadLayout(const ofxJSONElement& moduleInfo)
-{
-   mModuleSaveData.LoadFloat("gridwidth", moduleInfo, 200, 200, 1000);
-   mModuleSaveData.LoadFloat("gridheight", moduleInfo, 170, 170, 1000);
-   
+{  
    SetUpFromSaveData();
 }
 
 void RadioSequencer::SetUpFromSaveData()
 {
-   SetGridSize(mModuleSaveData.GetFloat("gridwidth"), mModuleSaveData.GetFloat("gridheight"));
 }
 
 namespace
 {
-   const int kSaveStateRev = 0;
+   const int kSaveStateRev = 1;
 }
 
 void RadioSequencer::SaveState(FileStreamOut& out)
 {
-   IDrawableModule::SaveState(out);
-   
    out << kSaveStateRev;
+
+   IDrawableModule::SaveState(out);
    
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
@@ -349,15 +363,27 @@ void RadioSequencer::SaveState(FileStreamOut& out)
    }
    
    mGrid->SaveState(out);
+   out << mGrid->GetWidth();
+   out << mGrid->GetHeight();
 }
 
 void RadioSequencer::LoadState(FileStreamIn& in)
 {
+   mLoadRev = -1;
+
+   if (ModuleContainer::sFileSaveStateRev >= 422)
+   {
+      in >> mLoadRev;
+      LoadStateValidate(mLoadRev <= kSaveStateRev);
+   }
+
    IDrawableModule::LoadState(in);
-   
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+
+   if (ModuleContainer::sFileSaveStateRev <= 421)
+   {
+      in >> mLoadRev;
+      LoadStateValidate(mLoadRev <= kSaveStateRev);
+   }
    
    int size;
    in >> size;
@@ -370,4 +396,47 @@ void RadioSequencer::LoadState(FileStreamIn& in)
    }
    
    mGrid->LoadState(in);
+
+   if (mLoadRev >= 1)
+   {
+      float width, height;
+      in >> width;
+      in >> height;
+      mGrid->SetDimensions(width, height);
+   }
+
+   if (mLoadRev == 0)
+   {
+      //port old data
+      float len = 0;
+      if (mOldLengthStr == "4")   len = 4;
+      if (mOldLengthStr == "6")   len = 6;
+      if (mOldLengthStr == "8")   len = 8;
+      if (mOldLengthStr == "16")  len = 16;
+      if (mOldLengthStr == "32")  len = 32;
+      if (mOldLengthStr == "64")  len = 64;
+      if (mOldLengthStr == "128") len = 128;
+
+      mLength = int(len * TheTransport->CountInStandardMeasure(mInterval));
+      int min, max;
+      mLengthSlider->GetRange(min, max);
+      if (mLength > max)
+         mLengthSlider->SetExtents(min, mLength);
+   }
+}
+
+bool RadioSequencer::LoadOldControl(FileStreamIn& in, std::string& oldName)
+{
+   if (mLoadRev < 1)
+   {
+      if (oldName == "length")
+      {
+         //load dropdown string
+         int dropdownRev;
+         in >> dropdownRev;
+         in >> mOldLengthStr;
+         return true;
+      }
+   }
+   return false;
 }

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -41,6 +41,7 @@
 #include "Push2Control.h"
 #include "IPulseReceiver.h"
 #include "TextEntry.h"
+#include "IDrivableSequencer.h"
 
 #define NUM_STEPSEQ_ROWS 16
 #define META_STEP_MAX 64
@@ -103,7 +104,7 @@ private:
    StepSequencer* mSeq;
 };
 
-class StepSequencer : public IDrawableModule, public INoteSource, public ITimeListener, public IFloatSliderListener, public IGridControllerListener, public IButtonListener, public IDropdownListener, public INoteReceiver, public IRadioButtonListener, public IIntSliderListener, public IPush2GridController, public IPulseReceiver, public ITextEntryListener
+class StepSequencer : public IDrawableModule, public INoteSource, public ITimeListener, public IFloatSliderListener, public IGridControllerListener, public IButtonListener, public IDropdownListener, public INoteReceiver, public IRadioButtonListener, public IIntSliderListener, public IPush2GridController, public IPulseReceiver, public ITextEntryListener, public IDrivableSequencer
 {
 public:
    StepSequencer();
@@ -154,7 +155,10 @@ public:
    void UpdatePush2Leds(Push2Control* push2) override;
    
    bool IsMetaStepActive(double time, int col, int row);
-   bool HasExternalPulseSource() const { return mHasExternalPulseSource; }
+
+   //IDrivableSequencer
+   bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
+   void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;


### PR DESCRIPTION
to bring them up to parity with other sequencers

additionally, added the ability to resume self-advancing mode for sequencers who have been externally driven by pulses or notes. access this new button via the triangle menu!