### PR TITLE
Fix notecanvas connections not disconnecting

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -542,7 +542,7 @@ bool Canvas::MouseScrolled(int x, int y, float scrollX, float scrollY)
 
 void Canvas::KeyPressed(int key, bool isRepeat)
 {
-   if (TheSynth->GetLastClickedModule() == GetParent() && gHoveredUIControl == this)
+   if (gHoveredUIControl == this)
    {
       if (key == juce::KeyPress::backspaceKey || key == juce::KeyPress::deleteKey)
       {
@@ -565,22 +565,28 @@ void Canvas::KeyPressed(int key, bool isRepeat)
          for (auto* element : mElements)
             element->SetHighlight(true);
       }
+
+
       if (key == OF_KEY_LEFT || key == OF_KEY_RIGHT)
       {
          int direction = (key == OF_KEY_LEFT) ? -1 : 1;
          for (auto* element : mElements)
          {
             if (element->GetHighlighted())
-               element->mCol += direction;
+               element->mCol = ofClamp(element->mCol + direction, 0, mNumCols-1);
          }
       }
+
+      int pitchDirectionFactor = 1;
+      if (GetKeyModifiers() == kModifier_Shift)
+         pitchDirectionFactor = 12; //octave
       if (key == OF_KEY_UP || key == OF_KEY_DOWN)
       {
          int direction = (key == OF_KEY_UP) ? -1 : 1;
          for (auto* element : mElements)
          {
             if (element->GetHighlighted())
-               element->mRow += direction;
+               element->mRow = ofClamp(element->mRow + (direction * pitchDirectionFactor), 0, mNumRows-1);
          }
       }
    }

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -149,38 +149,7 @@ void NoteCanvas::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
 
 void NoteCanvas::KeyPressed(int key, bool isRepeat)
 {
-   if (TheSynth->GetLastClickedModule() == this)
-   {
-      if (key == OF_KEY_UP || key == OF_KEY_DOWN || key == OF_KEY_RIGHT || key == OF_KEY_LEFT)
-      {
-         int directionUpDown = 0;
-         int directionLeftRight = 0;
-         if (key == OF_KEY_UP)
-            directionUpDown = -1;
-         if (key == OF_KEY_DOWN)
-            directionUpDown = 1;
-         if (key == OF_KEY_LEFT)
-            directionLeftRight = -1;
-         if (key == OF_KEY_RIGHT)
-            directionLeftRight = 1;
-         
-         if (GetKeyModifiers() == kModifier_Shift)
-            directionUpDown *= 12; //octave
-         
-         for (auto element : mCanvas->GetElements())
-         {
-            if (element->GetHighlighted())
-            {
-               element->mRow = ofClamp(element->mRow + directionUpDown, 0, 127);
-               element->mCol = ofClamp(element->mCol + directionLeftRight, 0, mCanvas->GetNumCols()-1);
-            }
-         }
-      }
-      else
-      {
-         mCanvas->KeyPressed(key, isRepeat);
-      }
-   }
+   IDrawableModule::KeyPressed(key, isRepeat);
 }
 
 bool NoteCanvas::FreeRecordParityMatched()


### PR DESCRIPTION
IDrawableModule::KeyPressed needs to be called for the backspace
on the cable to work.
The canvas will still get the keypresses this way.
The `GetLastClickedModule` condition was removed, because
drag-selecting notes in the canvas will not set that properly.
So just placing the mouse over a canvas will allow the key interaction.

This should fix #238 