### PR TITLE
a little hack to make it possible to load older BSK files that were saved in 32-bit

### DIFF
--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -28,6 +28,9 @@
 
 #include "juce_core/juce_core.h"
 
+//static
+bool FileStreamIn::s32BitMode = false;
+
 FileStreamOut::FileStreamOut(const std::string& file)
 : mStream(std::make_unique<juce::FileOutputStream>(juce::File{file}))
 {
@@ -134,7 +137,16 @@ FileStreamIn& FileStreamIn::operator>>(double &var)
 FileStreamIn& FileStreamIn::operator>>(std::string &var)
 {
    uint64_t len;
-   mStream->read(&len, sizeof(len));
+   if (s32BitMode)
+   {
+      uint32_t len32;
+      mStream->read(&len32, sizeof(len32));
+      len = len32;
+   }
+   else
+   {
+      mStream->read(&len, sizeof(len));
+   }
    
    if (TheSynth->IsLoadingModule())
       LoadStateValidate(len < 99999);   //probably garbage beyond this point

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -73,6 +73,7 @@ public:
    int GetFilePosition() const;
    bool OpenedOk() const;
    bool Eof() const;
+   static bool s32BitMode;
 private:
     std::unique_ptr<juce::FileInputStream> mStream;
 };

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2429,6 +2429,14 @@ void ModularSynth::LoadState(std::string file)
    mAudioThreadMutex.Unlock();
    
    FileStreamIn in(ofToDataPath(file));
+
+   //TODO(Ryan) here's a little hack to allow older BSK files that were saved in 32-bit to load.
+   //I guess this could bite me if someone ever has a very massive json. the number corresponds to a long-standing sanity check in FileStreamIn::operator>>(std::string &var), so this shouldn't break any current behavior.
+   //this should definitely be removed if anything about the structure of the BSK format changes.
+   uint64_t firstLength[1];
+   in.Peek(firstLength, sizeof(uint64_t));
+   if (firstLength[0] >= 99999)
+      FileStreamIn::s32BitMode = true;
    
    std::string jsonString;
    in >> jsonString;
@@ -2442,6 +2450,8 @@ void ModularSynth::LoadState(std::string file)
       
       TheTransport->Reset();
    }
+
+   FileStreamIn::s32BitMode = false;
    
    mCurrentSaveStatePath = file;
    std::string filename = File(mCurrentSaveStatePath).getFileName().toStdString();


### PR DESCRIPTION
this way I can avoid a bunch of bug reports about 1.1.0 breaking old BSK files