### PR TITLE
fix notecanvas issues

### DIFF
--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -149,6 +149,8 @@ void NoteCanvas::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
 
 void NoteCanvas::KeyPressed(int key, bool isRepeat)
 {
+   IDrawableModule::KeyPressed(key, isRepeat);
+
    if (TheSynth->GetLastClickedModule() == this)
    {
       if (key == OF_KEY_UP || key == OF_KEY_DOWN || key == OF_KEY_RIGHT || key == OF_KEY_LEFT)


### PR DESCRIPTION
-fix #238 where backspace wouldn't disconnect notecanvas
-fix issue caused by #497 where "last clicked module" wasn't getting set when clicking a UI control, which was preventing users from editing the contents of canvases