### PR TITLE
get rid of part of #484 functionality where you could click a title bar to stick it to the cursor

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1576,11 +1576,7 @@ void ModularSynth::CheckClick(IDrawableModule* clickedModule, int x, int y, bool
    int modulePosY = y - moduleRect.y;
 
    if (modulePosY < 0 && clickedModule != TheTitleBar && (!clickedModule->HasEnableCheckbox() || modulePosX > 20) && modulePosX < moduleRect.width - 15)
-   {
-      mMoveModule = clickedModule;
-      mMoveModuleOffsetX = moduleRect.x - x;
-      mMoveModuleOffsetY = moduleRect.y - y;
-   }
+      SetMoveModule(clickedModule, moduleRect.x - x, moduleRect.y - y, false);
 
    float parentX = 0;
    float parentY = 0;
@@ -1661,6 +1657,9 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
             mMoveModule->ToggleMinimized();
             mMoveModule = nullptr;
          }
+
+         if (!mMoveModuleCanStickToCursor)
+            mMoveModule = nullptr;
       }
       else
       {
@@ -2654,7 +2653,7 @@ void ModularSynth::OnConsoleInput()
          ofLog() << "Creating: " << mConsoleText;
          ofVec2f grabOffset(-40,10);
          IDrawableModule* module = SpawnModuleOnTheFly(mConsoleText, GetMouseX(&mModuleContainer) + grabOffset.x, GetMouseY(&mModuleContainer) + grabOffset.y);
-         TheSynth->SetMoveModule(module, grabOffset.x, grabOffset.y);
+         TheSynth->SetMoveModule(module, grabOffset.x, grabOffset.y, true);
       }
    }
 }
@@ -2838,11 +2837,12 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(std::string moduleName, float
    return module;
 }
 
-void ModularSynth::SetMoveModule(IDrawableModule* module, float offsetX, float offsetY)
+void ModularSynth::SetMoveModule(IDrawableModule* module, float offsetX, float offsetY, bool canStickToCursor)
 {
    mMoveModule = module;
    mMoveModuleOffsetX = offsetX;
    mMoveModuleOffsetY = offsetY;
+   mMoveModuleCanStickToCursor = canStickToCursor;
 }
 
 void ModularSynth::AddMidiDevice(MidiDevice* device)

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -102,7 +102,7 @@ public:
    void AddMidiDevice(MidiDevice* device);
    void ArrangeAudioSourceDependencies();
    IDrawableModule* SpawnModuleOnTheFly(std::string moduleName, float x, float y, bool addToContainer = true);
-   void SetMoveModule(IDrawableModule* module, float offsetX, float offsetY);
+   void SetMoveModule(IDrawableModule* module, float offsetX, float offsetY, bool canStickToCursor);
    
    int GetNumInputChannels() const { return (int)mInputBuffers.size(); }
    int GetNumOutputChannels() const { return (int)mOutputBuffers.size(); }
@@ -260,6 +260,7 @@ private:
    IDrawableModule* mMoveModule;
    int mMoveModuleOffsetX;
    int mMoveModuleOffsetY;
+   bool mMoveModuleCanStickToCursor{ false };   //if the most current mMoveModule can stick to the cursor if you release the mouse button before moving it
    
    ofVec2f mLastMoveMouseScreenPos;
    ofVec2f mLastMouseDragPos;

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -488,7 +488,7 @@ bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = fa
                send->SetTarget(GetTarget());
                SetTarget(send);
                send->SetSend(1, false);
-               TheSynth->SetMoveModule(send, spawnOffset.x, spawnOffset.y);
+               TheSynth->SetMoveModule(send, spawnOffset.x, spawnOffset.y, false);
             }
             else if (mType == kConnectionType_Modulator)
             {
@@ -497,7 +497,7 @@ bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = fa
                IUIControl* currentTarget = dynamic_cast<IUIControl*>(GetTarget());
                SetTarget(macroSlider->GetSlider());
                macroSlider->SetOutputTarget(0, currentTarget);
-               TheSynth->SetMoveModule(macroSlider, spawnOffset.x, spawnOffset.y);
+               TheSynth->SetMoveModule(macroSlider, spawnOffset.x, spawnOffset.y, false);
             }
          }
          else

--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -173,7 +173,7 @@ void QuickSpawnMenu::OnClicked(int x, int y, bool right)
    if (moduleTypeName != "")
    {
       IDrawableModule* module = TheSynth->SpawnModuleOnTheFly(moduleTypeName, TheSynth->GetMouseX(TheSynth->GetRootContainer()) + moduleGrabOffset.x, TheSynth->GetMouseY(TheSynth->GetRootContainer()) + moduleGrabOffset.y);
-      TheSynth->SetMoveModule(module, moduleGrabOffset.x, moduleGrabOffset.y);
+      TheSynth->SetMoveModule(module, moduleGrabOffset.x, moduleGrabOffset.y, true);
    }
    
    SetShowing(false);

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -128,7 +128,7 @@ void SeaOfGrain::Process(double time)
       return;
    
    ComputeSliders(0);
-   int numChannels = mHasRecordedInput ? GetBuffer()->NumActiveChannels() : mSample->NumChannels();
+   int numChannels = 2;
    SyncBuffers(numChannels);
    mRecordBuffer.SetNumChannels(GetBuffer()->NumActiveChannels());
    

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -90,7 +90,7 @@ void SpawnList::OnSelection(DropdownList* list)
    {
       IDrawableModule* module = Spawn();
       if (module != nullptr)
-         TheSynth->SetMoveModule(module, moduleGrabOffset.x, moduleGrabOffset.y);
+         TheSynth->SetMoveModule(module, moduleGrabOffset.x, moduleGrabOffset.y, true);
       mSpawnIndex = -1;
    }
 }


### PR DESCRIPTION
it was getting annoying! the rest of #484 remains, which was my original intent anyway. this "click the module's title bar to stick it to the cursor" seemed like a fun bonus feature, but it's bugging me now.