### PR TITLE
fix some prefab issues

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1650,6 +1650,7 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
 
    if (mMoveModule)
    {
+      Prefab::sJustReleasedModule = mMoveModule;
       if (!source.hasMovedSignificantlySincePressed())
       {
          if (mMoveModule->WasMinimizeAreaClicked())
@@ -1688,6 +1689,7 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
    mClickStartX = INT_MAX;
    mClickStartY = INT_MAX;
    mGroupSelectContext = nullptr;
+   Prefab::sJustReleasedModule = nullptr;
 }
 
 void ModularSynth::AudioOut(float** output, int bufferSize, int nChannels)
@@ -2300,9 +2302,8 @@ IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
    
    ofxJSONElement layoutData;
    module->SaveLayout(layoutData);
-   std::vector<IDrawableModule*> allModules;
-   mModuleContainer.GetAllModules(allModules);
-   std::string newName = GetUniqueName(layoutData["name"].asString(), allModules);
+   std::vector<IDrawableModule*> modules = mModuleContainer.GetModules();
+   std::string newName = GetUniqueName(layoutData["name"].asString(), modules);
    layoutData["name"] = newName;
    
    IDrawableModule* newModule = CreateModule(layoutData);
@@ -2760,9 +2761,8 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(std::string moduleName, float
 
    ofxJSONElement dummy;
    dummy["type"] = moduleType;
-   std::vector<IDrawableModule*> allModules;
-   mModuleContainer.GetAllModules(allModules);
-   dummy["name"] = GetUniqueName(moduleType, allModules);
+   std::vector<IDrawableModule*> modules = mModuleContainer.GetModules();
+   dummy["name"] = GetUniqueName(moduleType, modules);
    dummy["onthefly"] = true;
 
    if (moduleType == "effectchain")

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -307,6 +307,8 @@ void ModuleContainer::TakeModule(IDrawableModule* module)
    if (module->GetOwningContainer()->mOwner)
       module->GetOwningContainer()->mOwner->RemoveChild(module);
    RemoveFromVector(module, module->GetOwningContainer()->mModules);
+
+   std::string newName = GetUniqueName(module->Name(), mModules);
    
    mModules.push_back(module);
    MoveToFront(module);
@@ -316,13 +318,9 @@ void ModuleContainer::TakeModule(IDrawableModule* module)
                        module->GetPosition(true).y + offset.y);
    module->SetOwningContainer(this);
    if (mOwner)
-   {
       mOwner->AddChild(module);
-   }
    else   //root modulecontainer
-   {
-      module->SetName(GetUniqueName(module->Name(), mModules).c_str());
-   }
+      module->SetName(newName.c_str());
 }
 
 void ModuleContainer::DeleteModule(IDrawableModule* module)
@@ -336,6 +334,9 @@ void ModuleContainer::DeleteModule(IDrawableModule* module)
       RemoveFromVector(module, mModules, K(fail));
       return;
    }
+
+   if (module->GetParent())
+      module->GetParent()->GetModuleParent()->RemoveChild(module);
    
    RemoveFromVector(module, mModules, K(fail));
    for (auto iter : mModules)

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -33,6 +33,8 @@
 
 //static
 bool Prefab::sLoadingPrefab = false;
+//static
+IDrawableModule* Prefab::sJustReleasedModule = nullptr;
 
 Prefab::Prefab()
 {
@@ -94,10 +96,14 @@ bool Prefab::CanAddDropModules()
    {
       if (TheSynth->GetMoveModule() != nullptr && !VectorContains(TheSynth->GetMoveModule(), mModuleContainer.GetModules()))
          return true;
+      if (sJustReleasedModule != nullptr && !VectorContains(sJustReleasedModule, mModuleContainer.GetModules()))
+         return true;
       if (!TheSynth->GetGroupSelectedModules().empty())
       {
          for (auto* module : TheSynth->GetGroupSelectedModules())
          {
+            if (module == this)
+               return false;
             if (!VectorContains(module, mModuleContainer.GetModules()))
                return true;
          }
@@ -120,8 +126,8 @@ void Prefab::MouseReleased()
 
    if (CanAddDropModules())
    {
-      if (TheSynth->GetMoveModule() != nullptr && !VectorContains(TheSynth->GetMoveModule(), mModuleContainer.GetModules()))
-         mModuleContainer.TakeModule(TheSynth->GetMoveModule());
+      if (sJustReleasedModule != nullptr && !VectorContains(sJustReleasedModule, mModuleContainer.GetModules()))
+         mModuleContainer.TakeModule(sJustReleasedModule);
 
       for(auto* module : TheSynth->GetGroupSelectedModules())
       {

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -62,8 +62,8 @@ public:
    
    void LoadPrefab(std::string loadPath);
 
-   static bool sSavingPrefab;
    static bool sLoadingPrefab;
+   static IDrawableModule* sJustReleasedModule;
    
 private:
    //IDrawableModule

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -674,7 +674,7 @@ std::string GetUniqueName(std::string name, std::vector<IDrawableModule*> existi
       bool isNameUnique = true;
       for (int i=0; i<existing.size(); ++i)
       {
-         if (existing[i]->Path() == name)
+         if (existing[i]->Name() == name)
          {
             ++suffix;
             name = origName + ofToString(suffix);


### PR DESCRIPTION
- fix disbanded prefab mistakenly renaming contained modules
- fix prefab trying to add itself to the prefab (fixes #451)
- fix deleted modules within a prefab not removing themselves, which causes them to crash when saved and then reloaded
- fix dropping a module onto a prefab not adding it
- fix modules within prefabs not getting assigned unique names (fixes #143 and #513)