### PR TITLE
Make the EnvelopeEditor behave like the LFO w.r.t. delete

### DIFF
--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -441,6 +441,12 @@ void EnvelopeEditor::SetADSRDisplay(ADSRDisplay* adsrDisplay)
    mMaxSustainSlider->SetShowing(mADSRDisplay->GetADSR()->GetHasSustainStage());
 }
 
+void EnvelopeEditor::DoSpecialDelete()
+{
+   mEnabled = false;
+   mPinned = false;
+}
+
 void EnvelopeEditor::DrawModule()
 {
    if (!mPinned)

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -91,6 +91,8 @@ public:
    
    bool IsPinned() const { return mPinned; }
    void SetADSRDisplay(ADSRDisplay* adsrDisplay);
+   bool HasSpecialDelete() const override { return true; }
+   void DoSpecialDelete() override;
    
    void CheckboxUpdated(Checkbox* checkbox) override;
    void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}


### PR DESCRIPTION
Fixes #491 

... but I don't understand how these classes will ever be deleted? Who is responsible? The module factory?