### PR TITLE
Fix deletion of modules at least on patch reset

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1595,7 +1595,7 @@ void ModularSynth::MoveToFront(IDrawableModule* module)
 
 void ModularSynth::OnModuleDeleted(IDrawableModule* module)
 {
-   if (!module->CanBeDeleted() || module->IsDeleted())
+   if (!module->CanBeDeleted() || !module->IsDeleted())
       return;
 
    mDeletedModules.push_back(module);


### PR DESCRIPTION
In all places where `OnModuleDeleted` is called the module is marked as deleted directly before calling, so either the condition is wrong, or the code can be deleted