### PR TITLE
fix issue where modules weren't deleting

### DIFF
--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -49,8 +49,6 @@ EffectChain::EffectChain()
 
 EffectChain::~EffectChain()
 {
-   for (int i=0; i<mEffects.size(); ++i)
-      delete mEffects[i];
 }
 
 void EffectChain::CreateUIControls()
@@ -425,6 +423,8 @@ void EffectChain::DeleteEffect(int index)
       RemoveChild(toRemove);
       //delete toRemove;   TODO(Ryan) can't do this in case stuff is referring to its UI controls
       mEffectMutex.unlock();
+
+      TheSynth->OnModuleDeleted(toRemove);
    }
 }
 

--- a/Source/FilterViz.cpp
+++ b/Source/FilterViz.cpp
@@ -58,8 +58,6 @@ void FilterViz::CreateUIControls()
 
 FilterViz::~FilterViz()
 {
-   for (int i=0; i<mFilters.size(); ++i)
-      delete mFilters[i];
    delete mImpulseBuffer;
    delete mFFTOutReal;
    delete mFFTOutImag;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1614,6 +1614,7 @@ void ModularSynth::OnModuleDeleted(IDrawableModule* module)
    RemoveFromVector(dynamic_cast<IAudioSource*>(module),mSources);
    RemoveFromVector(module,mLissajousDrawers);
    TheTransport->RemoveAudioPoller(dynamic_cast<IAudioPoller*>(module));
+   module->MarkAsDeleted();
    //delete module; TODO(Ryan) deleting is hard... need to clear out everything with a reference to this, or switch to smart pointers
 
    if (module == TheChaosEngine)

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -356,13 +356,11 @@ void ModuleContainer::DeleteModule(IDrawableModule* module)
 
    for (auto* child : module->GetChildren())
    {
-      child->MarkAsDeleted();
       child->SetEnabled(false);
       child->Exit();
       TheSynth->OnModuleDeleted(child);
    }
 
-   module->MarkAsDeleted();
    module->SetEnabled(false);
    module->Exit();
    TheSynth->OnModuleDeleted(module);


### PR DESCRIPTION
I was calling `MarkAsDeleted()` before `OnModuleDeleted()` (must have been a refactor gone awry), which was resulting in the deletion code being ignored, because it was tripping the check to avoid double-deletions