### PR TITLE
Remove the parentComponent for all Filechoosers on Linux

### DIFF
--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -172,6 +172,11 @@ public:
    juce::AudioDeviceManager &GetAudioDeviceManager() { return *mGlobalAudioDeviceManager; }
    juce::AudioFormatManager &GetAudioFormatManager() { return *mGlobalAudioFormatManager; }
    juce::Component* GetMainComponent() { return mMainComponent; }
+#ifdef BESPOKE_LINUX
+   juce::Component* GetModalParent() { return nullptr; }
+#else
+   juce::Component* GetModalParent() { return mMainComponent->getTopLevelComponent(); }
+#endif
    juce::OpenGLContext* GetOpenGLContext() { return mOpenGLContext; }
    IDrawableModule* GetLastClickedModule() const;
    EffectFactory* GetEffectFactory() { return &mEffectFactory; }

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -212,7 +212,7 @@ void Prefab::ButtonClicked(ClickButton* button)
    using namespace juce;
    if (button == mSaveButton)
    {
-      FileChooser chooser("Save prefab as...", File(ofToDataPath("prefabs/prefab.pfb")), "*.pfb", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+      FileChooser chooser("Save prefab as...", File(ofToDataPath("prefabs/prefab.pfb")), "*.pfb", true, false, TheSynth->GetModalParent());
       if (chooser.browseForFileToSave(true))
       {
          std::string savePath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();
@@ -222,7 +222,7 @@ void Prefab::ButtonClicked(ClickButton* button)
    
    if (button == mLoadButton)
    {
-      FileChooser chooser("Load prefab...", File(ofToDataPath("prefabs")), "*.pfb", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+      FileChooser chooser("Load prefab...", File(ofToDataPath("prefabs")), "*.pfb", true, false, TheSynth->GetModalParent());
       if (chooser.browseForFileToOpen())
       {
          std::string loadPath = chooser.getResult().getRelativePathFrom(File(ofToDataPath(""))).toStdString();

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -206,7 +206,7 @@ void SampleCapturer::ButtonClicked(ClickButton* button)
 
    if (button == mSaveButton)
    {
-      FileChooser chooser("Save sample as...", File(ofToDataPath(ofGetTimestampString("samples/%Y-%m-%d_%H-%M.wav"))), "*.wav", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+      FileChooser chooser("Save sample as...", File(ofToDataPath(ofGetTimestampString("samples/%Y-%m-%d_%H-%M.wav"))), "*.wav", true, false, TheSynth->GetModalParent());
       if (chooser.browseForFileToSave(true))
          Sample::WriteDataToFile(chooser.getResult().getFullPathName().toStdString(), &mSamples[mCurrentSampleIndex].mBuffer, mSamples[mCurrentSampleIndex].mRecordingLength);
    }

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -771,7 +771,7 @@ void SamplePlayer::OnYoutubeSearchComplete(std::string searchTerm, double search
 void SamplePlayer::LoadFile()
 {
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetModalParent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();
@@ -786,7 +786,7 @@ void SamplePlayer::LoadFile()
 void SamplePlayer::SaveFile()
 {
    FileChooser chooser("Save sample", File(ofToDataPath("samples")),
-                       "*.wav", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+                       "*.wav", true, false, TheSynth->GetModalParent());
    if (chooser.browseForFileToSave(true))
    {
       auto file = chooser.getResult();

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -722,7 +722,7 @@ void Scale::ButtonClicked(ClickButton *button)
         std::string prompt = "Load ";
         prompt += (button == mLoadSCLButton) ? "SCL" : "KBM";
         std::string pat = (button == mLoadSCLButton) ? "*.scl" : "*.kbm";
-        juce::FileChooser chooser( prompt, juce::File(""), pat, true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+        juce::FileChooser chooser( prompt, juce::File(""), pat, true, false, TheSynth->GetModalParent());
         if (chooser.browseForFileToOpen())
         {
             auto file = chooser.getResult();

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -855,7 +855,7 @@ void ScriptModule::ButtonClicked(ClickButton* button)
    
    if (button == mSaveScriptButton)
    {
-      FileChooser chooser("Save script as...", File(ofToDataPath("scripts/script.py")), "*.py", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+      FileChooser chooser("Save script as...", File(ofToDataPath("scripts/script.py")), "*.py", true, false, TheSynth->GetModalParent());
       if (chooser.browseForFileToSave(true))
       {
          std::string path = chooser.getResult().getFullPathName().toStdString();

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -309,7 +309,7 @@ void SeaOfGrain::LoadFile()
 {
    using namespace juce;
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetModalParent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -876,7 +876,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
    if (button == mSavePresetFileButton && mPlugin != nullptr)
    {
       juce::File(ofToDataPath("vst/presets/"+GetPluginId())).createDirectory();
-      FileChooser chooser("Save preset as...", File(ofToDataPath("vst/presets/"+ GetPluginId()+"/preset.vstp")), "*.vstp", true, false, TheSynth->GetMainComponent()->getTopLevelComponent());
+      FileChooser chooser("Save preset as...", File(ofToDataPath("vst/presets/"+ GetPluginId()+"/preset.vstp")), "*.vstp", true, false, TheSynth->GetModalParent());
       if (chooser.browseForFileToSave(true))
       {
          std::string path = chooser.getResult().getFullPathName().toStdString();


### PR DESCRIPTION
They are modal and will be destroyed anyway, but this change makes the
non-native variants work on Linux

Should fix #537 