### PR TITLE
fix presets module

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1374,22 +1374,30 @@ void ModularSynth::MousePressed(int intX, int intY, int button, const juce::Mous
          }
       }
 
-      IDrawableModule* clicked = GetModuleAtCursor();
+      IDrawableModule* clickedModule = GetModuleAtCursor();
 
       for (auto cable : mPatchCables)
       {
-         if (clicked &&
-            (clicked == GetTopModalFocusItem() ||
-               clicked->AlwaysOnTop() ||
-               mModuleContainer.IsHigherThan(clicked, cable->GetOwningModule())))
-            break;
-         if (cable->TestClick(x,y,rightButton))
-            return;
+         if (clickedModule &&
+             (cable->GetTarget() == nullptr || clickedModule != cable->GetTarget()->GetModuleParent()) &&
+             (clickedModule == GetTopModalFocusItem() ||
+              clickedModule->AlwaysOnTop() ||
+              mModuleContainer.IsHigherThan(clickedModule, cable->GetOwningModule())
+             )
+            )
+         {
+            
+         }
+         else
+         {
+            if (cable->TestClick(x, y, rightButton))
+               return;
+         }
       }
 
       mClickStartX = x;
       mClickStartY = y;
-      if (clicked == nullptr)
+      if (clickedModule == nullptr)
       {
          if (rightButton)
          {
@@ -1410,24 +1418,24 @@ void ModularSynth::MousePressed(int intX, int intY, int button, const juce::Mous
             }
          }
       }
-      if (clicked != nullptr && clicked != TheTitleBar)
-         mLastClickedModule = clicked;
+      if (clickedModule != nullptr && clickedModule != TheTitleBar)
+         mLastClickedModule = clickedModule;
       else
          mLastClickedModule = nullptr;
       mHasDuplicatedDuringDrag = false;
 
       if (mGroupSelectedModules.empty() == false)
       {
-         if (!VectorContains(clicked, mGroupSelectedModules))
+         if (!VectorContains(clickedModule, mGroupSelectedModules))
             mGroupSelectedModules.clear();
          return;
       }
 
-      if (clicked)
+      if (clickedModule)
       {
-         x = GetMouseX(clicked->GetModuleParent()->GetOwningContainer());
-         y = GetMouseY(clicked->GetModuleParent()->GetOwningContainer());
-         CheckClick(clicked, x, y, rightButton);
+         x = GetMouseX(clickedModule->GetModuleParent()->GetOwningContainer());
+         y = GetMouseY(clickedModule->GetModuleParent()->GetOwningContainer());
+         CheckClick(clickedModule, x, y, rightButton);
       }
       else if (TheSaveDataPanel != nullptr)
       {

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -379,14 +379,11 @@ void PatchCable::Render()
 
 bool PatchCable::MouseMoved(float x, float y)
 {
-   if (GetConnectionType() == kConnectionType_Modulator || GetConnectionType() == kConnectionType_UIControl) //no repatching UI control cables by the plug
-      return false;
-   
    x = TheSynth->GetMouseX(GetOwningModule()->GetOwningContainer());
    y = TheSynth->GetMouseY(GetOwningModule()->GetOwningContainer());
    
    PatchCablePos cable = GetPatchCablePos();
-   mHovered = DistSqToLine(ofVec2f(x,y),cable.plug,cable.end) < 25;
+   mHovered = DistSqToLine(ofVec2f(x,y),cable.plug,cable.end) < 25 && gHoveredUIControl == nullptr;
    
    return false;
 }
@@ -446,10 +443,7 @@ IClickable* PatchCable::GetDropTarget()
 
 bool PatchCable::TestClick(int x, int y, bool right, bool testOnly /* = false */)
 {
-   if (right)
-      return false;
-
-   if (mHovered)
+   if (mHovered && !right)
    {
       if (!testOnly)
          Grab();

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -476,7 +476,9 @@ bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = fa
          {
             if (mPatchCables.empty() ||
                 mType == kConnectionType_Note ||
-                mType == kConnectionType_Pulse)
+                mType == kConnectionType_Pulse ||
+                mType == kConnectionType_UIControl ||
+                mType == kConnectionType_Special)
             {
                PatchCable* newCable = AddPatchCable(nullptr);
                newCable->Grab();

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -79,6 +79,7 @@ private:
    void Save();
    void Load();
    void SetGridSize(float w, float h);
+   bool IsConnectedToPath(std::string path) const;
 
    //IDrawableModule
    void DrawModule() override;
@@ -92,6 +93,12 @@ private:
       Preset() {}
       Preset(std::string path, float val) : mControlPath(path), mValue(val), mHasLFO(false) {}
       Preset(IUIControl* control);
+      bool operator==(const Preset& other) const
+      {
+         return mControlPath == other.mControlPath &&
+                mValue == other.mValue &&
+                mHasLFO == other.mHasLFO;
+      }
       std::string mControlPath;
       float mValue;
       bool mHasLFO;
@@ -100,7 +107,7 @@ private:
    
    struct PresetCollection
    {
-      std::vector<Preset> mPresets;
+      std::list<Preset> mPresets;
       std::string mDescription;
    };
    


### PR DESCRIPTION
it was totally broken for 1.0.0, due to some refactors a while back to how cables worked. I also cleaned up a bunch of its functionality, and made it possible to grab modulator/uicontrol cables by their plug ends