### PR TITLE
Working signature with hardened runtime macos

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -408,6 +408,9 @@ if (APPLE)
                 WORKING_DIRECTORY ${SIGN_HERE}
                 COMMAND codesign --force -s "${BESPOKE_SIGN_AS}" --deep BespokeSynth.app/Contents/Frameworks/Python.framework/
                 COMMAND find BespokeSynth.app/Contents/Frameworks/Python.framework/Versions/ -name *.so -exec codesign --force -s "${BESPOKE_SIGN_AS}" {} \;
+                COMMAND find BespokeSynth.app/Contents/Frameworks/Python.framework/Versions/ -name *.o -exec codesign --force -s "${BESPOKE_SIGN_AS}" {} \;
+                COMMAND find BespokeSynth.app/Contents/Frameworks/Python.framework/Versions/ -name python3* -perm +111 -exec codesign -o runtime --force -s "${BESPOKE_SIGN_AS}" {} \;
+                COMMAND find BespokeSynth.app/Contents/Frameworks/Python.framework/Versions/ -name Python -exec codesign -o runtime --force -s "${BESPOKE_SIGN_AS}" {} \;
                 COMMAND codesign --force -s "${BESPOKE_SIGN_AS}" -o runtime --deep BespokeSynth.app
                 )
     endif()

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -387,6 +387,9 @@ if (APPLE)
         BESPOKE_MAC=1
         JUCE_PLUGINHOST_AU=0 # this needs work but if you turn it to 1 with the link below it works
         )
+    set_target_properties(BespokeSynth PROPERTIES
+        XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME YES
+        )
     target_sources(BespokeSynth PRIVATE
         CFMessaging/KontrolKommunicator.cpp
         CFMessaging/ListenPort.cpp
@@ -395,6 +398,19 @@ if (APPLE)
         KompleteKontrol.cpp
         )
     target_link_libraries(BespokeSynth PRIVATE "-framework CoreAudioKit")
+
+    if (BESPOKE_SIGN_AS)
+        add_custom_target(BespokeSynthSigned)
+        add_dependencies(BespokeSynthSigned BespokeSynth)
+
+        get_target_property(SIGN_HERE BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
+        add_custom_command(TARGET BespokeSynthSigned POST_BUILD VERBATIM
+                WORKING_DIRECTORY ${SIGN_HERE}
+                COMMAND codesign --force -s "${BESPOKE_SIGN_AS}" --deep BespokeSynth.app/Contents/Frameworks/Python.framework/
+                COMMAND find BespokeSynth.app/Contents/Frameworks/Python.framework/Versions/ -name *.so -exec codesign --force -s "${BESPOKE_SIGN_AS}" {} \;
+                COMMAND codesign --force -s "${BESPOKE_SIGN_AS}" -o runtime --deep BespokeSynth.app
+                )
+    endif()
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE BESPOKE_WINDOWS=1)
 


### PR DESCRIPTION
This makes it so you can build a signed macos portable but
you do it slightly differently. You build with signing of
then run the custom sign commands at the end of the build phase.

A typical session rather than setting CMAKE_XCODE_ATTRIBUTE_SIGN_AS would be

cmake -Bignore/macBLAH -DBESPOKE_PYTHON_ROOT=/Library/Frameworks/Python.framework/Versions/3.9/ -DBESPOKE_PORTABLE=True -DBESPOKE_SIGN_AS="Apple Development: you@yourspot.com (AFDFS23123)"
cmake --build ignore/macBLAH --parallel 8 --target BespokeSynthSigned