### PR TITLE
fix gridkeyboard stuck notes issue that can happen with push2

### DIFF
--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -51,6 +51,8 @@ public:
    
    void CreateUIControls() override;
    void Init() override;
+   void SetEnabled(bool enabled) override { mEnabled = enabled; }
+   bool HasDebugDraw() const override { return true; }
 
    void SetDisplayer(LaunchpadNoteDisplayer* displayer) { mDisplayer = displayer; }
    void DisplayNote(int pitch, int velocity);
@@ -104,8 +106,11 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
+   void DrawModuleUnclipped() override;
    void GetModuleDimensions(float& width, float& height) override { width=120; height=74; }
+   bool Enabled() const override { return mEnabled; }
    
+   void PlayKeyboardNote(double time, int pitch, int velocity);
    void UpdateLights(bool force = false);
    GridColor GetGridSquareColor(int x, int y);
    int GridToPitch(int x, int y);
@@ -139,6 +144,8 @@ private:
    bool mPreserveChordRoot;
    Checkbox* mPreserveChordRootCheckbox;
    GridControlTarget* mGridControlTarget;
+
+   std::string mDebugLines;
 };
 
 #endif /* defined(__modularSynth__LaunchpadKeyboard__) */

--- a/bespoke_windows_installer/BespokeSynth.wxs
+++ b/bespoke_windows_installer/BespokeSynth.wxs
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?define ProductVersion = "1.0.999"?>
+<?define ProductVersion = "1.0.9992"?>
 <?define ProductUpgradeCode = "ba790d99-4d2c-4e33-a92d-219970637fca"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
    <Product Id="*" UpgradeCode="$(var.ProductUpgradeCode)" 


### PR DESCRIPTION
it's a gross hack (shifting note offs to 1 nanosecond in the future), but it's probably safe. someday, the root cause should be fixed. fixes #586