### PR TITLE
Fix for building with clang and clang-cl on Windows

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -204,9 +204,9 @@ void ModularSynth::DumpStats(bool isCrash, void* crashContext)
                moduleInfo.SizeOfStruct = sizeof(moduleInfo);
 
                if (::SymGetModuleInfo64(process, symbol->ModBase, &moduleInfo))
-                  log.appendText(moduleInfo.ModuleName + String(": "));
+                  log.appendText(String(moduleInfo.ModuleName) + String(": "));
 
-               log.appendText(symbol->Name + String(" + 0x") + String::toHexString((juce::int64)displacement) + "\n");
+               log.appendText(String(symbol->Name) + String(" + 0x") + String::toHexString((juce::int64)displacement) + "\n");
             }
 
          }


### PR DESCRIPTION
This fixes building with clang and clang-cl compilers in Windows.