### PR TITLE
don't include python docs in bundled python

### DIFF
--- a/Source/cmake/bundle-python.cmake
+++ b/Source/cmake/bundle-python.cmake
@@ -22,6 +22,7 @@ file(INSTALL
     PATTERN "tkinter" EXCLUDE
     PATTERN "turtle.py" EXCLUDE
     PATTERN "turtledemo" EXCLUDE
+    PATTERN "Documentation" EXCLUDE
     )
 
 set(BESPOKE_PIP_PACKAGES jedi)


### PR DESCRIPTION
saves 55mb of unnecessary stuff being distributed!