### PR TITLE
Don't depend on Signed if you arent' Signing

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -484,7 +484,10 @@ add_custom_target(nightly-package)
 add_dependencies(nightly-package BespokeSynth)
 
 if (APPLE)
-    add_dependencies(nightly-package BespokeSynthSigned)
+    if (BESPOKE_SIGN_AS)
+        # If we aren't signing there's no target
+        add_dependencies(nightly-package BespokeSynthSigned)
+    endif()
     get_target_property(output_dir BespokeSynth RUNTIME_OUTPUT_DIRECTORY)
     add_custom_command(TARGET nightly-package
              POST_BUILD


### PR DESCRIPTION
the nightly package is ejected always, but it depends on the Signed
target on Apple, which only exists if you are in signing mode,
so basically I can't run in IDE without certs. Conditionalize
this out.