### PR TITLE
Cleanup the mPlugin on ::Exit

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -230,6 +230,10 @@ void VSTPlugin::Exit()
    {
       mWindow.reset();
    }
+   if (mPlugin)
+   {
+      mPlugin.reset();
+   }
 }
 
 std::string VSTPlugin::GetTitleLabel() const


### PR DESCRIPTION
The mPlugin is left around forever which means that the
plugin is not terminated on exit. With some plugins,
as outlined in #666