### PR TITLE
Added midi import and export to note canvas

### DIFF
--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -36,6 +36,8 @@
 #include "CanvasTimeline.h"
 #include "CanvasScrollbar.h"
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 NoteCanvas::NoteCanvas()
 : mCanvas(nullptr)
 , mCanvasControls(nullptr)
@@ -74,6 +76,8 @@ void NoteCanvas::CreateUIControls()
    IDrawableModule::CreateUIControls();
    
    mQuantizeButton = new ClickButton(this,"quantize",160,5);
+   mLoadMidiButton = new ClickButton(this,"load midi", 224, 5);
+   mSaveMidiButton = new ClickButton(this,"save midi", 290, 5);
    //mClipButton = new ClickButton(this,"clip",220,5);
    mPlayCheckbox = new Checkbox(this,"play",5,5,&mPlay);
    mRecordCheckbox = new Checkbox(this,"rec",50,5,&mRecord);
@@ -468,6 +472,8 @@ void NoteCanvas::DrawModule()
    
    mCanvasControls->Draw();
    mQuantizeButton->Draw();
+   mLoadMidiButton->Draw();
+   mSaveMidiButton->Draw();
    //mClipButton->Draw();
    mPlayCheckbox->Draw();
    mRecordCheckbox->Draw();
@@ -604,6 +610,107 @@ void NoteCanvas::QuantizeNotes()
    }
 }
 
+void NoteCanvas::LoadMidi()
+{//sneed
+	using namespace juce;
+	FileChooser chooser("Load midi", File(ofToDataPath("")), "*.mid", true, false, TheSynth->GetFileChooserParent());
+	if (chooser.browseForFileToOpen())
+	{
+
+		mCanvas->Clear();
+		File file = chooser.getResult();
+
+		//get fileinputstream from midi file
+		FileInputStream inputStream(file);
+		MidiFile midifile;
+
+
+		if (midifile.readFrom(inputStream)) {
+			midifile.convertTimestampTicksToSeconds();
+
+
+            int trackToGet = 0;
+			if (midifile.getNumTracks() > 1) {
+				//Midi Type 1 - Prompt user to select which tracks to import
+                trackToGet = 1;
+			}
+			const MidiMessageSequence* trackSequence = midifile.getTrack(trackToGet);
+			for (int eventIndex = 0; eventIndex < trackSequence->getNumEvents(); eventIndex++) {
+				MidiMessageSequence::MidiEventHolder* noteEvent = trackSequence->getEventPointer(eventIndex);
+				if (noteEvent->noteOffObject) {
+					int note = noteEvent->message.getNoteNumber();
+					int veloc = noteEvent->message.getVelocity() * 1.27; //not exact bc AddNote uses int argument
+                    double start = (noteEvent->message.getTimeStamp() / 2);
+					double end = (noteEvent->noteOffObject->message.getTimeStamp() / 2);
+					double length = end - start;
+					
+					AddNote(start, note, veloc, length, -1, ModulationParameters());
+				}
+			}
+
+            //Set new measures slider limit
+            float latest = 0.0;
+            for (auto* element : mCanvas->GetElements()) {
+                if(element->GetEnd() > latest)
+                latest = element->GetEnd();
+            }
+            mNumMeasuresSlider->SetExtents(0, static_cast<int>(std::ceil(latest)));
+
+            //Set new length to length of imported midi            
+            FitNotes();            
+		}
+	}
+}
+
+void NoteCanvas::SaveMidi()
+{//chuck
+    using namespace juce;
+    FileChooser chooser("Save midi", File(ofToDataPath("midi")), "*.mid", true, false,  TheSynth->GetFileChooserParent());
+    if (chooser.browseForFileToSave(true))
+    {
+        MidiFile midifile;  
+        midifile.setTicksPerQuarterNote(96);
+        
+        //Setup track with meta events
+        MidiMessageSequence track1;
+        MidiMessage trackTimeSig = MidiMessage::timeSignatureMetaEvent(TheTransport->GetTimeSigTop(), TheTransport->GetTimeSigBottom());
+        //MidiMessage trackTempo = MidiMessage::tempoMetaEvent((TheTransport->MsPerBar()*1000)/16);//microseconds per 1/4 note = (1000*ms) / 16?
+        track1.addEvent(trackTimeSig);
+        //track1.addEvent(trackTempo);
+
+        for (auto* element : mCanvas->GetElements()) {
+
+            //Note On message
+            NoteCanvasElement* noteOnElement = static_cast<NoteCanvasElement*>(element);
+            int noteNumber = noteOnElement->mRow;
+
+            //float noteStart = element->GetStart() * TheTransport->MsPerBar();
+            float noteStart = (element->mCol + element->mOffset) * TheTransport->MsPerBar(); 
+
+            float velocity = noteOnElement->GetVelocity();
+            MidiMessage messageOn = MidiMessage::noteOn(1, noteNumber, velocity);
+            messageOn.setTimeStamp(noteStart);
+            track1.addEvent(messageOn);
+            //Note Off message
+            //float noteEnd = element->GetEnd() * TheTransport->MsPerBar();
+            float noteEnd = (element->mCol + element->mOffset + element->mLength) * TheTransport->MsPerBar(); 
+            MidiMessage messageOff = MidiMessage::noteOff(1, noteNumber, velocity);
+            messageOff.setTimeStamp(noteEnd);
+            track1.addEvent(messageOff);
+            track1.updateMatchedPairs();
+        }
+        
+        midifile.addTrack(track1);
+
+        std::string savePath = chooser.getResult().getFullPathName().toStdString();
+        File f(savePath);
+        FileOutputStream out(f);
+        midifile.writeTo(out);
+
+
+    }
+}
+
 void NoteCanvas::CheckboxUpdated(Checkbox* checkbox)
 {
    if (checkbox == mEnabledCheckbox)
@@ -641,6 +748,12 @@ void NoteCanvas::ButtonClicked(ClickButton* button)
    
    if (button == mClipButton)
       ClipNotes();
+
+   if (button == mLoadMidiButton)
+       LoadMidi();
+
+   if (button == mSaveMidiButton)
+       SaveMidi();
 }
 
 void NoteCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal)

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -96,6 +96,8 @@ private:
    bool FreeRecordParityMatched();
    void ClipNotes();
    void QuantizeNotes();
+   void LoadMidi();
+   void SaveMidi();
    
    Canvas* mCanvas;
    CanvasControls* mCanvasControls;
@@ -108,6 +110,8 @@ private:
    IntSlider* mNumMeasuresSlider;
    int mNumMeasures;
    ClickButton* mQuantizeButton;
+   ClickButton* mLoadMidiButton;
+   ClickButton* mSaveMidiButton;
    ClickButton* mClipButton;
    bool mPlay;
    Checkbox* mPlayCheckbox;


### PR DESCRIPTION
Note canvas can now load and save .mid files with "load midi" and "save midi" buttons respectively.    
Things to note:    

- Any midi type 0 or 1 file can be loaded but only the first track will be loaded for multi track type 1 midi files, pending a UI solution to select an individual track to import
- Transport tempo not adjusted by incoming midi file
- Transport tempo not exported in outgoing midi files 
- Transport time signature not adjusted by incoming midi files
- Transport time signature is exported in outgoing midi files