### PR TITLE
Added midi import and export to note canvas

### DIFF
--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -35,12 +35,13 @@
 #include "INoteReceiver.h"
 #include "ClickButton.h"
 #include "DropdownList.h"
+#include "TextEntry.h"
 
 class CanvasControls;
 class CanvasTimeline;
 class CanvasScrollbar;
 
-class NoteCanvas : public IDrawableModule, public INoteSource, public ICanvasListener, public IFloatSliderListener, public IAudioPoller, public IIntSliderListener, public INoteReceiver, public IButtonListener, public IDropdownListener
+class NoteCanvas : public IDrawableModule, public INoteSource, public ICanvasListener, public IFloatSliderListener, public IAudioPoller, public IIntSliderListener, public INoteReceiver, public IButtonListener, public IDropdownListener, public ITextEntryListener
 {
 public:
    NoteCanvas();
@@ -76,6 +77,7 @@ public:
    void IntSliderUpdated(IntSlider* slider, int oldVal) override;
    void ButtonClicked(ClickButton* button) override;
    void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void TextEntryComplete(TextEntry* entry) override {}
    
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
@@ -110,8 +112,10 @@ private:
    IntSlider* mNumMeasuresSlider;
    int mNumMeasures;
    ClickButton* mQuantizeButton;
-   ClickButton* mLoadMidiButton;
    ClickButton* mSaveMidiButton;
+   ClickButton* mLoadMidiButton;
+   TextEntry* mLoadMidiTrackEntry;
+   int mLoadMidiTrack{ 1 };
    ClickButton* mClipButton;
    bool mPlay;
    Checkbox* mPlayCheckbox;

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -96,6 +96,8 @@ private:
    bool FreeRecordParityMatched();
    void ClipNotes();
    void QuantizeNotes();
+   void LoadMidi();
+   void SaveMidi();
    
    Canvas* mCanvas;
    CanvasControls* mCanvasControls;
@@ -108,6 +110,8 @@ private:
    IntSlider* mNumMeasuresSlider;
    int mNumMeasures;
    ClickButton* mQuantizeButton;
+   ClickButton* mLoadMidiButton;
+   ClickButton* mSaveMidiButton;
    ClickButton* mClipButton;
    bool mPlay;
    Checkbox* mPlayCheckbox;


### PR DESCRIPTION
Note canvas can now load and save .mid files with "load midi" and "save midi" buttons respectively.
Things to note:

- Any midi type 0 or 1 file can be loaded but only the first track will be loaded for multi track type 1 midi files, pending a UI solution to select an individual track to import    
- Transport tempo not adjusted by incoming midi file    
- Transport tempo not exported in outgoing midi files    
- Transport time signature not adjusted by incoming midi files    
- Transport time signature is exported in outgoing midi files    