### PR TITLE
added ability to send arbitrary midi messages to VST plugins via script

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -635,6 +635,20 @@ void ScriptModule::PlayNoteFromScriptAfterDelay(float pitch, float velocity, dou
    }
 }
 
+void ScriptModule::SendCCFromScript(int control, int value, int noteOutputIndex)
+{
+   if (noteOutputIndex == 0)
+   {
+      SendCC(control, value);
+      return;
+   }
+
+   if (noteOutputIndex - 1 < (int)mExtraNoteOutputs.size())
+   {
+      mExtraNoteOutputs[noteOutputIndex - 1]->SendCCOutput(control, value);
+   }
+}
+
 void ScriptModule::ScheduleNote(double time, float pitch, float velocity, float pan, int noteOutputIndex)
 {
    for (size_t i=0; i<mScheduledNoteOutput.size(); ++i)

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -60,6 +60,7 @@ public:
    
    void PlayNoteFromScript(float pitch, float velocity, float pan, int noteOutputIndex);
    void PlayNoteFromScriptAfterDelay(float pitch, float velocity, double delayMeasureTime, float pan, int noteOutputIndex);
+   void SendCCFromScript(int control, int value, int noteOutputIndex);
    void ScheduleMethod(std::string method, double delayMeasureTime);
    void ScheduleUIControlValue(IUIControl* control, float value, double delayMeasureTime);
    void HighlightLine(int lineNum, int scriptModuleIndex);

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -699,6 +699,16 @@ void VSTPlugin::SendCC(int control, int value, int voiceIdx /*=-1*/)
    mMidiBuffer.addEvent(juce::MidiMessage::controllerEvent((mUseVoiceAsChannel ? channel : mChannel), control, (uint8)value), 0);
 }
 
+void VSTPlugin::SendMidi(const juce::MidiMessage& message)
+{
+   if (!mPluginReady || mPlugin == nullptr)
+      return;
+
+   const juce::ScopedLock lock(mMidiInputLock);
+
+   mMidiBuffer.addEvent(message, 0);
+}
+
 void VSTPlugin::SetEnabled(bool enabled)
 {
    mEnabled = enabled;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -82,6 +82,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
+   void SendMidi(const juce::MidiMessage& message) override;
    
    void DropdownClicked(DropdownList* list) override;
    void DropdownUpdated(DropdownList* list, int oldVal) override;

--- a/resource/python_stubs/me/__init__.pyi
+++ b/resource/python_stubs/me/__init__.pyi
@@ -48,3 +48,6 @@ from __future__ import annotations
    def connect_osc_input(port):
       pass
 
+   def send_cc(control, value, output_index = 0):
+      pass
+

--- a/resource/python_stubs/vstplugin/__init__.pyi
+++ b/resource/python_stubs/vstplugin/__init__.pyi
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+def get(path) -> vstplugin:
+   pass
+
+class vstplugin:
+   def send_cc(this, ctl, value, channel):
+      pass
+
+   def send_program_change(this, program, channel):
+      pass
+
+   def send_data(this, a, b, c):
+      pass
+

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -64,6 +64,8 @@ script-relative:
       example: me.get_caller().play_note(60,127)
    me.set_num_note_outputs(num)
    me.connect_osc_input(port)
+   me.send_cc(control, value, output_index)
+      optional: output_index = 0
 
 
 import notesequencer
@@ -180,6 +182,15 @@ import drumplayer
       drumplayer.get(path)
    instance:
       d.import_sampleplayer_cue(samplePlayer, srcCueIndex, destHitIndex)
+
+
+import vstplugin
+   static:
+      vstplugin.get(path)
+   instance:
+      v.send_cc(ctl, value, channel)
+      v.send_program_change(program, channel)
+      v.send_data(a, b, c)
 
 
 import module


### PR DESCRIPTION
here's a fun "random preset" script, for VSTs that handle program changes appropriately:
```python
import vstplugin

v = vstplugin.get("vstplugin")

v.send_cc(0,random.randint(0, 128),1)
v.send_cc(32,random.randint(0, 128),1)
v.send_program_change(random.randint(0, 128),1)
```