### PR TITLE
Support `hotloading` prefab title bar options

### DIFF
--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -248,10 +248,7 @@ void SpawnListManager::SetModuleFactory(ModuleFactory* factory)
    mOtherModules.SetList(factory->GetSpawnableModules(kModuleType_Other), "");
    
    SetUpVstDropdown();
-   
-   std::vector<std::string> prefabs;
-   ModuleFactory::GetPrefabs(prefabs);
-   mPrefabs.SetList(prefabs, "prefab");
+   SetUpPrefabsDropdown();
    
    mDropdowns.push_back(&mInstrumentModules);
    mDropdowns.push_back(&mNoteModules);
@@ -262,6 +259,13 @@ void SpawnListManager::SetModuleFactory(ModuleFactory* factory)
    mDropdowns.push_back(&mVstPlugins);
    mDropdowns.push_back(&mOtherModules);
    mDropdowns.push_back(&mPrefabs);
+}
+
+void SpawnListManager::SetUpPrefabsDropdown()
+{
+    std::vector<std::string> prefabs;
+    ModuleFactory::GetPrefabs(prefabs);
+    mPrefabs.SetList(prefabs, "prefab");
 }
 
 void SpawnListManager::SetUpVstDropdown()
@@ -560,6 +564,9 @@ void TitleBar::DropdownClicked(DropdownList* list)
 {
    if (list == mSpawnLists.mVstPlugins.GetList())
       mSpawnLists.SetUpVstDropdown();
+
+   if (list == mSpawnLists.mPrefabs.GetList())
+       mSpawnLists.SetUpPrefabsDropdown();
 }
 
 void TitleBar::DropdownUpdated(DropdownList* list, int oldVal)

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -67,7 +67,9 @@ struct SpawnListManager
    SpawnListManager(IDropdownListener* owner);
    
    void SetModuleFactory(ModuleFactory* factory);
+   void SetUpPrefabsDropdown();
    void SetUpVstDropdown();
+   
    std::vector<SpawnList*> GetDropdowns() { return mDropdowns; }
    
    SpawnList mInstrumentModules;


### PR DESCRIPTION
Issue: 
- currently the title bar options for prefabs are loaded at application load time.  If a prefab is removed from the file system and the Bespoke user selects the cached prefab the application will crash
- this enables the use case where a user adds prefabs to the file system during a Bespoke session and essentially "hot loads" them 

Solution:
- read the prefabs directory at runtime when the user selects the prefabs title bar drop down (DropdownClicked).  I believe this is a lightweight operation and improves both user experience and stability