### PR TITLE
handful of improvements

### DIFF
--- a/Source/Compressor.cpp
+++ b/Source/Compressor.cpp
@@ -48,6 +48,7 @@ namespace
 
 Compressor::Compressor()
 : mMix(1)
+, mDrive(1)
 , mThreshold(-24)
 , mRatio(4)
 , mAttack(.1f)
@@ -70,8 +71,10 @@ void Compressor::CreateUIControls()
    IDrawableModule::CreateUIControls();
    UIBLOCK0();
    FLOATSLIDER(mMixSlider, "mix",&mMix,0,1);
+   FLOATSLIDER(mDriveSlider, "drive", &mDrive, .01f, 2);
    FLOATSLIDER(mThresholdSlider, "threshold",&mThreshold,-70,0);
    FLOATSLIDER(mRatioSlider, "ratio",&mRatio,1,40);
+   UIBLOCK_NEWCOLUMN();
    FLOATSLIDER(mAttackSlider, "attack",&mAttack,.1f,kMaxLookaheadMs);
    FLOATSLIDER(mReleaseSlider, "release",&mRelease,.1f,500);
    FLOATSLIDER(mLookaheadSlider, "lookahead",&mLookahead,0,kMaxLookaheadMs);
@@ -107,6 +110,7 @@ void Compressor::ProcessAudio(double time, ChannelBuffer* buffer)
       float input = 0;
       for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
          input = MAX(input, fabsf(buffer->GetChannel(ch)[i]));
+      input *= mDrive;
 
       /* if desired, one could use another EnvelopeDetector to smooth
        * the rectified signal.
@@ -139,7 +143,7 @@ void Compressor::ProcessAudio(double time, ChannelBuffer* buffer)
       // transfer function
       double reduction = overdB * ( invRatio - 1.0 );	// gain reduction (dB)
       double makeup = (-mThreshold * .5) * (1.0 - invRatio);
-      mOutputGain = ofLerp(1, dB2lin( reduction + makeup ) * mOutputAdjust, mMix);
+      mOutputGain = ofLerp(1, dB2lin( reduction + makeup ) * mDrive * mOutputAdjust, mMix);
 
       // output gain
       for (int ch=0; ch<buffer->NumActiveChannels(); ++ch)
@@ -153,6 +157,7 @@ void Compressor::ProcessAudio(double time, ChannelBuffer* buffer)
 void Compressor::DrawModule()
 {
    mMixSlider->Draw();
+   mDriveSlider->Draw();
    mThresholdSlider->Draw();
    mRatioSlider->Draw();
    mAttackSlider->Draw();

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -136,6 +136,7 @@ private:
    bool Enabled() const override { return mEnabled; }
 
    float mMix;
+   float mDrive;
    float mThreshold;
    float mRatio;
    float mAttack;
@@ -143,6 +144,7 @@ private:
    float mLookahead;
    float mOutputAdjust;
    FloatSlider* mMixSlider;
+   FloatSlider* mDriveSlider;
    FloatSlider* mThresholdSlider;
    FloatSlider* mRatioSlider;
    FloatSlider* mAttackSlider;

--- a/Source/MidiClockOut.h
+++ b/Source/MidiClockOut.h
@@ -31,10 +31,11 @@
 #include "DropdownList.h"
 #include "Transport.h"
 #include "Slider.h"
+#include "ClickButton.h"
 
 class IAudioSource;
 
-class MidiClockOut : public IDrawableModule, public IDropdownListener, public IAudioPoller, public IFloatSliderListener
+class MidiClockOut : public IDrawableModule, public IDropdownListener, public IAudioPoller, public IFloatSliderListener, public IButtonListener
 {
 public:
    MidiClockOut();
@@ -51,6 +52,7 @@ public:
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void DropdownClicked(DropdownList* list) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void ButtonClicked(ClickButton* button) override;
    
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
@@ -67,8 +69,21 @@ private:
    float mWidth;
    float mHeight;
    
-   int mDeviceIndex{-1};
+   enum class ClockMultiplier
+   {
+      Quarter,
+      Half,
+      One,
+      Two,
+      Four
+   };
+
+   int mDeviceIndex{ -1 };
    DropdownList* mDeviceList;
+   bool mClockStartQueued{ false };
+   ClickButton* mStartButton;
+   ClockMultiplier mMultiplier{ ClockMultiplier::One };
+   DropdownList* mMultiplierSelector;
    
    MidiDevice mDevice;
 };

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1215,7 +1215,9 @@ void ModularSynth::MouseMoved(int intX, int intY)
          gHoveredUIControl->GetPosition(uiX, uiY);
          float w, h;
          gHoveredUIControl->GetDimensions(w, h);
-         if (x < uiX - 5 || y < uiY - 5 || x > uiX + w + 5 || y > uiY + h + 5)
+         const float kHoverBreakDistance = 5;
+         if (x < uiX - kHoverBreakDistance || y < uiY - kHoverBreakDistance || x > uiX + w + kHoverBreakDistance || y > uiY + h + kHoverBreakDistance || //moved far enough away from ui control
+             (y < gHoveredUIControl->GetModuleParent()->GetPosition().y && uiY > gHoveredUIControl->GetModuleParent()->GetPosition().y)) //hovering over title bar (and it's not the enable/disable checkbox)
             gHoveredUIControl = nullptr;
       }
    }
@@ -1727,6 +1729,7 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
 {
    mMousePos.x = intX;
    mMousePos.y = intY;
+   mMouseMovedSignificantlySincePressed = source.hasMovedSignificantlySincePressed();
 
    if (button >= 0 && button < (int)mIsMouseButtonHeld.size())
       mIsMouseButtonHeld[button] = false;
@@ -1750,7 +1753,7 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
    if (mMoveModule)
    {
       Prefab::sJustReleasedModule = mMoveModule;
-      if (!source.hasMovedSignificantlySincePressed())
+      if (!mMouseMovedSignificantlySincePressed)
       {
          if (mMoveModule->WasMinimizeAreaClicked())
          {
@@ -1782,7 +1785,7 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
       ClearHeldSample();
    }
 
-   if (!mGroupSelectedModules.empty() && !source.hasMovedSignificantlySincePressed())
+   if (!mGroupSelectedModules.empty() && !mMouseMovedSignificantlySincePressed)
       mGroupSelectedModules.clear();
 
    mClickStartX = INT_MAX;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -157,6 +157,7 @@ public:
    float GetUIScale() { return mUILayerModuleContainer.GetDrawScale(); }
    ModuleContainer* GetRootContainer() { return &mModuleContainer; }
    bool ShouldShowGridSnap() const;
+   bool MouseMovedSignificantlySincePressed() const { return mMouseMovedSignificantlySincePressed; }
 
    void ZoomView(float zoomAmount, bool fromMouse);
    void PanView(float x, float y);
@@ -318,6 +319,7 @@ private:
    
    int mClickStartX; //to detect click and release in place
    int mClickStartY;
+   bool mMouseMovedSignificantlySincePressed{ true };
    
    std::string mLoadedLayoutPath;
    bool mWantReloadInitialLayout;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -443,6 +443,12 @@ void SamplePlayer::PlayNote(double time, int pitch, int velocity, int voiceIdx /
    }
 }
 
+void SamplePlayer::OnPulse(double time, float velocity, int flags)
+{
+   if (mSample != nullptr)
+      PlayCuePoint(time, -1, velocity * 127, 1, 0);
+}
+
 void SamplePlayer::PlayCuePoint(double time, int index, int velocity, float speedMult, float startOffsetSeconds)
 {
    if (mSample != nullptr)
@@ -520,7 +526,7 @@ void SamplePlayer::FilesDropped(std::vector<std::string> files, int x, int y)
 
 void SamplePlayer::SampleDropped(int x, int y, Sample* sample)
 {
-   if (gHoveredUIControl == nullptr)   //avoid problem of grabbing a clip via the clip grab button and immediately dropping it onto this sampleplayer by accident
+   if (TheSynth->MouseMovedSignificantlySincePressed())   //avoid problem of grabbing a clip via the clip grab button and immediately dropping it onto this sampleplayer by accident
    {
       Sample* copy = new Sample();
       copy->CopyFrom(sample);
@@ -939,7 +945,7 @@ float SamplePlayer::GetSecondsForMouse(float mouseX) const
 
 void SamplePlayer::GetPlayInfoForPitch(int pitch, float& startSeconds, float& lengthSeconds, float& speed, bool& stopOnNoteOff) const
 {
-   if (pitch < mSampleCuePoints.size())
+   if (pitch >= 0 && pitch < mSampleCuePoints.size())
    {
       startSeconds = mSampleCuePoints[pitch].startSeconds;
       lengthSeconds = mSampleCuePoints[pitch].lengthSeconds;

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -39,12 +39,13 @@
 #include "TextEntry.h"
 #include "RadioButton.h"
 #include "GateEffect.h"
+#include "IPulseReceiver.h"
 
 #include "juce_osc/juce_osc.h"
 
 class Sample;
 
-class SamplePlayer : public IAudioProcessor, public IDrawableModule, public INoteReceiver, public IFloatSliderListener, public IIntSliderListener, public IDropdownListener, public IButtonListener, public IRadioButtonListener, public ITextEntryListener, private juce::OSCReceiver, private juce::OSCReceiver::Listener<juce::OSCReceiver::RealtimeCallback>
+class SamplePlayer : public IAudioProcessor, public IDrawableModule, public INoteReceiver, public IFloatSliderListener, public IIntSliderListener, public IDropdownListener, public IButtonListener, public IRadioButtonListener, public ITextEntryListener, public IPulseReceiver, private juce::OSCReceiver, private juce::OSCReceiver::Listener<juce::OSCReceiver::RealtimeCallback>
 {
 public:
    SamplePlayer();
@@ -58,6 +59,7 @@ public:
    
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
+   void OnPulse(double time, float velocity, int flags) override;
    
    //IAudioSource
    void Process(double time) override;


### PR DESCRIPTION
- compressor has new "drive" parameter
- clockout has new "send start" button
- clockout has multiplier
- module title bar takes precedence over hovered UI control, to avoid pressing UI control when you intend to drag module
- sampleplayer accepts pulse input
- fix sample drag n drop on sampleplayer failing when you're hovered over a control