### PR TITLE
Add Python-Binding midicontroller.send_sysex

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -1526,6 +1526,14 @@ void MidiController::SendData(int page, unsigned char a, unsigned char b, unsign
    }
 }
 
+void MidiController::SendSysEx(int page, std::string data)
+{
+   if (page == mControllerPage)
+   {
+      mDevice.SendSysEx(data);
+   }
+}
+
 UIControlConnection* MidiController::GetConnectionForControl(MidiMessageType messageType, int control)
 {
    for (auto i=mConnections.begin(); i != mConnections.end(); ++i)

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -294,6 +294,7 @@ public:
    void SendProgramChange(int page, int program, int channel = -1);
    void SendPitchBend(int page, int bend, int channel = -1);
    void SendData(int page, unsigned char a, unsigned char b, unsigned char c);
+   void SendSysEx(int page, std::string data);
 
    INonstandardController* GetNonstandardController() { return mNonstandardController; }
 

--- a/Source/MidiDevice.cpp
+++ b/Source/MidiDevice.cpp
@@ -232,6 +232,14 @@ void MidiDevice::SendPitchBend(int bend, int channel /* = -1*/)
    }
 }
 
+void MidiDevice::SendSysEx(std::string data)
+{
+   if (mMidiOut)
+   {
+      mMidiOut->sendMessageNow(MidiMessage::createSysExMessage(data.c_str(), data.length()));
+   }
+}
+
 void MidiDevice::SendData(unsigned char a, unsigned char b, unsigned char c)
 {
    if (mMidiOut)

--- a/Source/MidiDevice.h
+++ b/Source/MidiDevice.h
@@ -107,6 +107,7 @@ public:
    void SendAftertouch(int pressure, int channel = -1);
    void SendProgramChange(int program, int channel = -1);
    void SendPitchBend(int bend, int channel = -1);
+   void SendSysEx(std::string data);
    void SendData(unsigned char a, unsigned char b, unsigned char c);
    void SendMessage(double time, juce::MidiMessage message);
    

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -500,6 +500,10 @@ PYBIND11_EMBEDDED_MODULE(midicontroller, m)
       {
          midicontroller.SendData(page, a, b, c);
       }, "a"_a, "b"_a, "c"_a, "page"_a = 0)
+      .def("send_sysex", [](MidiController& midicontroller, std::string data, int page)
+      {
+         midicontroller.SendSysEx(page, data);
+      }, "data"_a, "page"_a = 0)
       .def("add_script_listener", [](MidiController& midicontroller, ScriptModule* script)
       {
          midicontroller.AddScriptListener(script);

--- a/resource/python_stubs/midicontroller/__init__.pyi
+++ b/resource/python_stubs/midicontroller/__init__.pyi
@@ -32,6 +32,9 @@ class midicontroller:
    def send_data(this, a, b, c, page = 0):
       pass
 
+   def send_sysex(this, data, page = 0):
+      pass
+
    def add_script_listener(this, script):
       pass
 

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -141,6 +141,10 @@ import midicontroller
          optional: channel = -1, page = 0
       m.send_pitchbend(bend, channel, page)
          optional: channel = -1, page = 0
+      m.send_sysex(data, page = 0)
+         description: Sends a system exclusive message. The given data will be wrapped with header and tail bytes of 0xf0 and 0xf7. The example enables Session-Mode on a Launchpad X.
+         optional: page = 0
+         example: m.send_sysex(bytes([0, 32, 41, 2, 12, 16, 1])
       m.send_data(a, b, c, page)
          optional: page = 0
       m.add_script_listener(script)


### PR DESCRIPTION
Allows sending Sys-Ex messages to Midi-Devices to use Vendor-Specific features