### PR TITLE
add transport edit controls

### DIFF
--- a/Source/AbletonLink.cpp
+++ b/Source/AbletonLink.cpp
@@ -123,7 +123,7 @@ void AbletonLink::OnTransportAdvanced(float amount)
          if (abs(difference) > .01f)
          {
             //too far off, correct
-            TheTransport->SetMeasureTime(measureTime);
+            TheTransport->SetTransportPosition(measureTime);
             ofLog() << "correcting transport position for ableton link";
          }
 

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -967,7 +967,7 @@ void BeatBloks::CheckboxUpdated(Checkbox *checkbox)
    {
       if (mSample)
          mSample->Reset();
-      TheTransport->SetMeasureTime(0);
+      TheTransport->SetTransportPosition(0);
    }
    if (checkbox == mPlayRemixCheckbox)
    {

--- a/Source/ControllingSong.cpp
+++ b/Source/ControllingSong.cpp
@@ -196,7 +196,7 @@ void ControllingSong::Process(double time)
          int measure;
          float measurePos;
          mMidiReader.GetMeasurePos(ms, measure, measurePos);
-         TheTransport->SetMeasureTime(measure + measurePos);
+         TheTransport->SetTransportPosition(measure + measurePos);
       }
       
       gWorkChannelBuffer.SetNumActiveChannels(1);

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -634,7 +634,7 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
       pos *= 2;
       count += int(pos);
       pos -= int(pos);
-      TheTransport->SetMeasureTime(count + pos);
+      TheTransport->SetTransportPosition(count + pos);
       for (int i = 0; i < mLoopers.size(); ++i)
       {
          if (mLoopers[i])
@@ -656,7 +656,7 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
       pos /= 2;
       count += int(pos);
       pos -= int(pos);
-      TheTransport->SetMeasureTime(count + pos);
+      TheTransport->SetTransportPosition(count + pos);
       for (int i = 0; i < mLoopers.size(); ++i)
       {
          if (mLoopers[i])
@@ -689,7 +689,7 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
          newMeasure = 7;
       float newMeasurePos = TheTransport->GetMeasurePos(gTime) - .5f;
       FloatWrap(newMeasurePos,1);
-      TheTransport->SetMeasureTime(newMeasure + newMeasurePos);
+      TheTransport->SetTransportPosition(newMeasure + newMeasurePos);
    }
 
    if (button == mShiftDownbeatButton)

--- a/Source/MidiClockIn.cpp
+++ b/Source/MidiClockIn.cpp
@@ -166,7 +166,7 @@ void MidiClockIn::OnMidi(const juce::MidiMessage& message)
       ofLog() << "midi position pointer " << ofToString(message.getSongPositionPointerMidiBeat());
       
       if (mEnabled)
-         TheTransport->SetMeasureTime(message.getSongPositionPointerMidiBeat() / TheTransport->GetTimeSigTop() + mStartOffsetMs / TheTransport->MsPerBar());
+         TheTransport->SetTransportPosition(message.getSongPositionPointerMidiBeat() / TheTransport->GetTimeSigTop() + mStartOffsetMs / TheTransport->MsPerBar());
    }
    if (message.isQuarterFrame())
    {

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2696,6 +2696,15 @@ void ModularSynth::OnConsoleInput()
             (*iter)->SetMinimized(true);
          }
       }
+      else if (tokens[0] == "movetransport")
+      {
+         if (tokens.size() >= 2)
+         {
+            double time = atof(tokens[1].c_str());
+            if (time >= 1)
+                TheTransport->SetTransportPosition(time-1);
+         }
+      }
       else if (tokens[0] == "resettime")
       {
          gTime = 0;

--- a/Source/TimelineControl.cpp
+++ b/Source/TimelineControl.cpp
@@ -109,7 +109,7 @@ void TimelineControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
 {
    if (slider == mTimeSlider)
    {
-      TheTransport->SetMeasureTime(mTime);
+      TheTransport->SetTransportPosition(mTime);
    }
 }
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1775,6 +1775,8 @@ transport~controls tempo and current time position
 ~swing interval~interval over which to apply swing
 ~timesigtop~time signature top value
 ~timesigbottom~time signature bottom value
+~measure~current measure
+~measurepos~current position within the measure. a value of .5 represents halfway through the measure.
 ~reset~reset timeline to zero
 ~ < ~nudge current time backward
 ~ > ~nudge current time forward


### PR DESCRIPTION
First of all thank you @awwbees for this awesome program. I just finished creating my first song and really enjoyed using it. I did get pretty frustrated, though, that it's only possible to set the transport to the beginning of the song or nudge it by tiny amounts. This PR is my attempt to add basic edit controls to the transport. This allows setting either the measure or the position within the measure. (For example, 2.5 is the middle of the 2nd measure.) I also added a console command that does the same thing for good measure. Hope you like it! Please let me know what you think.

Here's a screenshot of the new transport UI:

![transport](https://user-images.githubusercontent.com/1551631/154866323-c3b357e3-f65b-49bf-8642-b5630c638bb5.png)

