### PR TITLE
start transport listeners at time zero

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2589,6 +2589,8 @@ void ModularSynth::LoadState(std::string file)
    mIsLoadingState = false;
    LockRender(false);
    mAudioThreadMutex.Unlock();
+
+   TheTransport->Start();
 }
 
 IAudioReceiver* ModularSynth::FindAudioReceiver(std::string name, bool fail)

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -124,6 +124,15 @@ void Transport::AdjustTempo(double amount)
    SetTempo(MAX(1, GetTempo() + amount));
 }
 
+void Transport::Start()
+{
+    for (std::list<TransportListenerInfo>::iterator i = mListeners.begin(); i != mListeners.end(); ++i)
+    {
+        const TransportListenerInfo& info = *i;
+        info.mListener->OnTimeEvent(gTime);
+    }
+}
+
 void Transport::Advance(double ms)
 {
    double amount = ms/MsPerBar();
@@ -248,9 +257,9 @@ void Transport::DrawModule()
    ofRect(0,h-Swing(measurePos)*h,4,1);
 }
 
-void Transport::Reset(float rewindAmount)
+void Transport::Reset()
 {
-   mMeasureTime = -rewindAmount;
+   mMeasureTime = 0;
 }
 
 void Transport::ButtonClicked(ClickButton *button)
@@ -266,7 +275,16 @@ void Transport::ButtonClicked(ClickButton *button)
    if (button == mDecreaseTempoButton)
       AdjustTempo(-1);
    if (button == mPlayPauseButton)
-      TheSynth->ToggleAudioPaused();
+      ToggleAudioPaused();
+}
+
+void Transport::ToggleAudioPaused()
+{
+    TheSynth->ToggleAudioPaused();
+    if (!TheSynth->IsAudioPaused())
+    {
+        Start();
+    }
 }
 
 TransportListenerInfo* Transport::AddListener(ITimeListener* listener, NoteInterval interval, OffsetInfo offsetInfo, bool useEventLookahead)

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -106,6 +106,7 @@ public:
    void SetSwing(float swing) { mSwing = swing; }
    float GetSwing() { return mSwing; }
    double MsPerBar() const { return 60.0/mTempo * 1000 * mTimeSigTop * 4.0/mTimeSigBottom; }
+   void Start();
    void Advance(double ms);
    TransportListenerInfo* AddListener(ITimeListener* listener, NoteInterval interval, OffsetInfo offsetInfo, bool useEventLookahead);
    void RemoveListener(ITimeListener* listener);
@@ -121,7 +122,7 @@ public:
    void SetMeasure(int count) { mMeasureTime = mMeasureTime - (int)mMeasureTime + count; }
    void SetDownbeat() { mMeasureTime = mMeasureTime - (int)mMeasureTime - .001; }
    static int CountInStandardMeasure(NoteInterval interval);
-   void Reset(float rewindAmount = 0.005f);
+   void Reset();
    void OnDrumEvent(NoteInterval drumEvent);
    void SetLoop(int measureStart, int measureEnd) { assert(measureStart < measureEnd); mLoopStartMeasure = measureStart; mLoopEndMeasure = measureEnd; }
    void ClearLoop() { mLoopStartMeasure = -1; mLoopEndMeasure = -1; }
@@ -157,6 +158,7 @@ private:
    double SwingBeat(double pos);
    void Nudge(double amount);
    void AdjustTempo(double amount);
+   void ToggleAudioPaused();
 
    //IDrawableModule
    void DrawModule() override;


### PR DESCRIPTION
This PR addresses https://github.com/BespokeSynth/BespokeSynth/issues/759: Instruments not playing first note when transport is reset. 

It looks like `Transport::Reset()` already applies a "fudge factor" of 0.005s called `rewindAmount` which might be an attempt to fix this. I believe the issue is that transport listeners aren't getting called until the first `audioDeviceIOCallback()` call which then calls `Transport::Advance()`. By this point we've already missed the first `elapsed` secs of playback.

The proposed fix is to add a `Transport::Start()` method analogous to `Transport::Advance()` which gets called on load state or reset transport. This just calls `OnTimeEvent` on all of the transport listeners with `time = gTime` (or `mMeasureTime = 0`). 

This seems like a pretty straightforward, low-risk fix. The only thing that seems a little sketchy to me is calling OnTimeEvent from different thread contexts, first from the UI thread then from the audio thread. So far I haven't run into any issues in my testing, though.