### PR TITLE
Fix crash when midi output device is already in use

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -92,7 +92,6 @@ MidiController::MidiController()
 , mHoveredLayoutElement(-1)
 , mLayoutWidth(0)
 , mLayoutHeight(0)
-, mFoundLayoutFile(false)
 {
    mListeners.resize(MAX_MIDI_PAGES);  
 }
@@ -122,7 +121,7 @@ void MidiController::CreateUIControls()
    mOscInPortEntry->DrawLabel(true);
    mMonomeDeviceDropdown->DrawLabel(true);
    
-   mLayoutFileDropdown->AddLabel("default", 0);
+   mLayoutFileDropdown->AddLabel(kDefaultLayout, 0);
    File dir(ofToDataPath("controllers"));
    Array<File> files;
    for (auto file : dir.findChildFiles(File::findFiles, false, "*.json"))
@@ -1166,8 +1165,8 @@ void MidiController::DrawModule()
       ofRect(kLayoutControlsX,kLayoutControlsY,235,140);
       ofPopStyle();
       
-      if (!mFoundLayoutFile)
-         gFont.DrawStringWrap("couldn't load layout file at "+mLastLoadedLayoutFile+", using the default layout instead", 15, 3, kLayoutControlsY + 160, 235);
+      if (mLayoutLoadError != "")
+         gFont.DrawStringWrap(mLayoutLoadError, 15, 3, kLayoutControlsY + 160, 235);
       
       if (mHighlightedLayoutElement != -1)
       {
@@ -1555,9 +1554,13 @@ ControlLayoutElement& MidiController::GetLayoutControl(int control, MidiMessageT
    return mLayoutControls[index];
 }
 
-void MidiController::LoadLayout(std::string filename)
+void MidiController::LoadControllerLayout(std::string filename)
 {
-   mLastLoadedLayoutFile = ofToDataPath("controllers/"+filename);
+   if (filename != kDefaultLayout)
+      mLastLoadedLayoutFile = ofToDataPath("controllers/"+filename);
+   else
+      mLastLoadedLayoutFile = "";
+   
    for (int i = 0; i < mLayoutFileDropdown->GetNumValues(); ++i)
    {
       if (filename == mLayoutFileDropdown->GetLabel(i))
@@ -1578,7 +1581,8 @@ void MidiController::LoadLayout(std::string filename)
    mGrids.clear();
    
    bool useDefaultLayout = true;
-   bool loaded = mLayoutData.open(mLastLoadedLayoutFile);
+   bool loaded = mLastLoadedLayoutFile != "" &&
+                 mLayoutData.open(mLastLoadedLayoutFile);
    try
    {
       if (loaded)
@@ -1586,7 +1590,6 @@ void MidiController::LoadLayout(std::string filename)
          if (mNonstandardController != nullptr)
             mNonstandardController->SetLayoutData(mLayoutData);
 
-         mFoundLayoutFile = true;
          if (!mLayoutData["outchannel"].isNull())
          {
             mOutChannel = mLayoutData["outchannel"].asInt();
@@ -1765,8 +1768,16 @@ void MidiController::LoadLayout(std::string filename)
    
    if (!loaded)
    {
-      mFoundLayoutFile = false;
+      mLayoutFileIndex = 0;
       mLayoutData.clear();
+      if (mLastLoadedLayoutFile == "")
+         mLayoutLoadError = "using default layout. set up controller files in "+ofToDataPath("controllers");
+      else
+         mLayoutLoadError  = "couldn't load layout file at "+mLastLoadedLayoutFile+", using the default layout instead";
+   }
+   else
+   {
+      mLayoutLoadError = "";
    }
    
    if (useDefaultLayout)
@@ -1804,7 +1815,11 @@ void MidiController::OnDeviceChanged()
    {
       std::string filename = mDeviceIn + ".json";
       ofStringReplace(filename, "/", "");
-      LoadLayout(filename);
+      LoadControllerLayout(filename);
+   }
+   else
+   {
+      LoadControllerLayout(kDefaultLayout);
    }
 
    mModulation.GetModWheel(-1)->SetValue(mModWheelOffset);
@@ -1918,7 +1933,7 @@ void MidiController::DropdownUpdated(DropdownList* list, int oldVal)
    }
    if (list == mLayoutFileDropdown)
    {
-      LoadLayout(mLayoutFileDropdown->GetLabel(mLayoutFileIndex));
+      LoadControllerLayout(mLayoutFileDropdown->GetLabel(mLayoutFileIndex));
    }
 }
 

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -1800,9 +1800,12 @@ void MidiController::LoadLayout(std::string filename)
 
 void MidiController::OnDeviceChanged()
 {
-   std::string filename = mDeviceIn + ".json";
-   ofStringReplace(filename, "/", "");
-   LoadLayout(filename);
+   if (!mDeviceIn.empty()) 
+   {
+      std::string filename = mDeviceIn + ".json";
+      ofStringReplace(filename, "/", "");
+      LoadLayout(filename);
+   }
 
    mModulation.GetModWheel(-1)->SetValue(mModWheelOffset);
    mModulation.GetPressure(-1)->SetValue(mPressureOffset);

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -370,8 +370,10 @@ private:
    int GetLayoutControlIndexForMidi(MidiMessageType type, int control) const;
    std::string GetLayoutTooltip(int controlIndex);
    void UpdateControllerIndex();
-   void LoadLayout(std::string filename);
+   void LoadControllerLayout(std::string filename);
    bool JustBoundControl() const { return gTime - sLastBoundControlTime < 500; }
+   
+   const std::string kDefaultLayout = "default";
    
    float mVelocityMult;
    bool mUseChannelAsVoice;
@@ -432,6 +434,7 @@ private:
    ChannelFilter mChannelFilter;
    std::string mLastLoadedLayoutFile;
    ofxJSONElement mLayoutData;
+   std::string mLayoutLoadError;
    
    std::array<ControlLayoutElement, NUM_LAYOUT_CONTROLS> mLayoutControls;
    int mHighlightedLayoutElement;
@@ -439,7 +442,6 @@ private:
    int mLayoutWidth;
    int mLayoutHeight;
    std::vector<GridLayout*> mGrids;
-   bool mFoundLayoutFile;
    
    ofMutex mQueuedMessageMutex;
 };

--- a/Source/MidiDevice.h
+++ b/Source/MidiDevice.h
@@ -92,7 +92,7 @@ public:
    bool ConnectInput(const char* name);
    void ConnectInput(int index);
    bool ConnectOutput(const char* name, int channel = 1);
-   void ConnectOutput(int index, int channel = 1);
+   bool ConnectOutput(int index, int channel = 1);
    void DisconnectInput();
    void DisconnectOutput();
    bool Reconnect();


### PR DESCRIPTION
* Fix crash when midi output device is already in use
If a midi output device is already used by another program bespoke will no longer crash it will log an error and show "not connected"

* Fix loading of json when there is no device selected yet
No longer tries to load a empty controller json `controllers/.json` when no controller is selected when first adding the midicontroller module