### PR TITLE
timeline control updates

### DIFF
--- a/Source/TimelineControl.h
+++ b/Source/TimelineControl.h
@@ -30,7 +30,7 @@
 #include "OpenFrameworksPort.h"
 #include "Slider.h"
 
-class TimelineControl : public IDrawableModule, public IFloatSliderListener, public IIntSliderListener
+class TimelineControl : public IDrawableModule, public IFloatSliderListener, public IIntSliderListener, public ITextEntryListener
 {
 public:
    TimelineControl();
@@ -43,7 +43,8 @@ public:
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
    void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   
+   void TextEntryComplete(TextEntry* entry) override;
+
    bool IsResizable() const override { return true; }
    void Resize(float width, float height) override;
    
@@ -62,6 +63,7 @@ private:
    float mWidth;
    float mNumMeasures;
    float mTime;
+   TextEntry* mNumMeasuresEntry;
    FloatSlider* mTimeSlider;
    bool mLoop;
    Checkbox* mLoopCheckbox;


### PR DESCRIPTION
This PR attempts to make the hidden timeline control more user-friendly by addressing these issues:

- https://github.com/BespokeSynth/BespokeSynth/issues/767
- https://github.com/BespokeSynth/BespokeSynth/issues/768

With this PR the timeline control UI looks like:

![timelinecontrol](https://user-images.githubusercontent.com/1551631/155644339-fbdda220-a007-4638-84f4-07de0b88047d.png)

