### PR TITLE
prototype - chunked and annotated output

### DIFF
--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -303,6 +303,15 @@ private:
    RollingBuffer* mGlobalRecordBuffer;
    long long mRecordingLength;
    
+   bool mEnableChunkedOutput;
+   int mBarsPerOutputChunk = 2;
+   int mNumOfOutputChunks = 4;
+   std::vector<RollingBuffer*> mGlobalChunkedRecordBuffer;
+   std::vector<long long> mChunkedRecordingLength;
+   std::vector<std::string> mChunkedRecordingLabels;
+   int mOutputChunkIndex = -1;
+   bool mEnableOutputChunkToIncrement = true;
+
    struct LogEventItem
    {
       LogEventItem(double _time, std::string _text, LogEventType _type) : time(_time), text(_text), type(_type) {}

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -62,6 +62,7 @@ struct ScalePitches
    std::vector<int> mScalePitches[2]; //double-buffered to avoid thread safety issues when modifying
    std::atomic<int> mScalePitchesFlip{0};
    std::vector<Accidental> mAccidentals;
+   std::string mNoteNames[12] = { "C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb" };
    
    void SetRoot(int root);
    void SetScaleType(std::string type);

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -233,6 +233,9 @@ public:
    UserPrefBool set_manual_window_position{ "set_manual_window_position", false, UserPrefCategory::General };
    UserPrefTextEntryInt position_x{ "position_x", 200, -10000, 10000, 5, UserPrefCategory::General };
    UserPrefTextEntryInt position_y{ "position_y", 200, -10000, 10000, 5, UserPrefCategory::General };
+   UserPrefDropdownInt bars_per_output_chunk{ "bars_per_output_chunk", 2, 100, UserPrefCategory::General };
+   UserPrefDropdownInt num_of_output_chunks{ "num_of_output_chunks", 16, 100, UserPrefCategory::General };
+   UserPrefBool enable_chunked_output{ "enable_chunked_output", false, UserPrefCategory::General };
    UserPrefFloat zoom{ "zoom", 1, .25f, 2, UserPrefCategory::General };
    UserPrefFloat ui_scale{ "ui_scale", 1, .25f, 2, UserPrefCategory::General };
    UserPrefFloat grid_snap_size{ "grid_snap_size", 30, 5, 150, UserPrefCategory::General };

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -65,6 +65,22 @@ void UserPrefsEditor::CreateUIControls()
       if (UserPrefs.oversampling.Get() == oversample)
          UserPrefs.oversampling.GetIndex() = oversample;
    }
+
+    std::array<int, 3> barsPerOutputOptions { 2, 4, 8 };
+    for (int barsPerOutputOption : barsPerOutputOptions)
+    {
+        UserPrefs.bars_per_output_chunk.GetDropdown()->AddLabel(ofToString(barsPerOutputOption), barsPerOutputOption);
+        if (UserPrefs.bars_per_output_chunk.Get() == barsPerOutputOption)
+            UserPrefs.bars_per_output_chunk.GetIndex() = barsPerOutputOption;
+    }
+
+    std::array<int, 6> numOfOutputChunksOptions { 4, 8, 16, 32, 64, 128 };
+    for (int numOfOutputChunksOption : numOfOutputChunksOptions)
+    {
+        UserPrefs.num_of_output_chunks.GetDropdown()->AddLabel(ofToString(numOfOutputChunksOption), numOfOutputChunksOption);
+        if (UserPrefs.num_of_output_chunks.Get() == numOfOutputChunksOption)
+            UserPrefs.num_of_output_chunks.GetIndex() = numOfOutputChunksOption;
+    }
 }
 
 void UserPrefsEditor::Show()


### PR DESCRIPTION
**Status: WIP - not ready for merge**

**Use case:**
- user wants the bespoke output to be organized and annotated by x number of bars, key, tempo
- a common workflow for producers is based around pulling from loop collections.  In order for that to be effective the loops must be organized and annotated to match the target project

**Whats changed:**
- added an option to create an array of rolling buffer arrays to collect the output if chunks of specified bars

**Open Convo/Subject to change:**
- the output is currently dumping to `/BespokeSynth/recordings/chunked-output`
- the file format is currently [BPM]-[KEY]-[BarIndex]
- what should happen if a user writes to the output mid way through a chunk
- what should happen if a user writes to the output with multiple keys or tempo mid chunk 