### PR TITLE
SynthGlobals: Switch from std::mt19937 to Xoshiro256**

### DIFF
--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -79,7 +79,7 @@ bool gShowDevModules = false;
 float gCornerRoundness = 1;
 
 std::random_device gRandomDevice;
-std::mt19937 gRandom(gRandomDevice());
+bespoke::core::Xoshiro256ss gRandom(gRandomDevice());
 std::uniform_real_distribution<float> gRandom01(0.0f, 1.f);
 std::uniform_real_distribution<float> gRandomBipolarDist(-1.f, 1.f);
 

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -79,7 +79,7 @@ bool gShowDevModules = false;
 float gCornerRoundness = 1;
 
 std::random_device gRandomDevice;
-bespoke::core::Xoshiro256ss gRandom(gRandomDevice());
+bespoke::core::Xoshiro256ss gRandom(gRandomDevice);
 std::uniform_real_distribution<float> gRandom01(0.0f, 1.f);
 std::uniform_real_distribution<float> gRandomBipolarDist(-1.f, 1.f);
 

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -29,6 +29,7 @@
 #pragma clang diagnostic ignored "-Wreorder"
 #endif
 
+#include "Xorshiro256ss.h"
 #include "OpenFrameworksPort.h"
 #include <map>
 #include <list>
@@ -110,8 +111,10 @@ extern float gControlTactileFeedback;
 extern float gDrawScale;
 extern bool gShowDevModules;
 extern float gCornerRoundness;
+
 extern std::random_device gRandomDevice;
-extern std::mt19937 gRandom;
+
+extern bespoke::core::Xoshiro256ss gRandom;
 extern std::uniform_real_distribution<float> gRandom01;
 extern std::uniform_real_distribution<float> gRandomBipolarDist;
 

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -29,7 +29,7 @@
 #pragma clang diagnostic ignored "-Wreorder"
 #endif
 
-#include "Xorshiro256ss.h"
+#include "Xoshiro256ss.h"
 #include "OpenFrameworksPort.h"
 #include <map>
 #include <list>

--- a/Source/Xorshiro256ss.h
+++ b/Source/Xorshiro256ss.h
@@ -28,6 +28,7 @@
 #define BESPOKESYNTH_XORSHIRO256SS_H
 
 #include <cstddef>
+#include <cstdint>
 #include <climits> // CHAR_BIT
 
 namespace bespoke::core
@@ -40,38 +41,35 @@ namespace bespoke::core
             return sizeof(T) * CHAR_BIT;
         }
 
-        using u64 = size_t;
-
-        constexpr u64 splitmix64(u64& x)
+        constexpr std::uint64_t splitmix64(std::uint64_t& x)
         {
-            u64 z = (x += 0x9e3779b97f4a7c15uLL);
+            std::uint64_t z = (x += 0x9e3779b97f4a7c15uLL);
             z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9uLL;
             z = (z ^ (z >> 27)) * 0x94d049bb133111ebuLL;
             return z ^ (z >> 31);
         }
 
-        constexpr u64 rotl(u64 x, int k)
+        constexpr std::uint64_t rotl(std::uint64_t x, int k)
         {
-            return (x << k) | (x >> (BitSizeOf<u64>() - k));
+            return (x << k) | (x >> (BitSizeOf<std::uint64_t>() - k));
         }
 
         /**
-         * Xoshiro256ss as a C++ Random Number Engine.
+         * Xoshiro256** as a C++ Random Number Engine.
          * There's no fancy standardese concept name (Trust me, I checked), unfortunately..
          */
         struct Xoshiro256ss
         {
-            using result_type = u64;
+            using result_type = std::uint64_t;
 
-            static_assert(sizeof(u64) == 8, "size_t needs to be 64 bits");
-            u64 s[4]{};
+            std::uint64_t s[4]{};
 
             constexpr explicit Xoshiro256ss() : Xoshiro256ss(0)
             {
 
             }
 
-            constexpr explicit Xoshiro256ss(u64 seed)
+            constexpr explicit Xoshiro256ss(std::uint64_t seed)
             {
                 s[0] = splitmix64(seed);
                 s[1] = splitmix64(seed);
@@ -86,7 +84,7 @@ namespace bespoke::core
 
             static constexpr result_type max()
             {
-                return u64(-1);
+                return std::uint64_t(-1);
             }
 
             constexpr result_type operator()()

--- a/Source/Xorshiro256ss.h
+++ b/Source/Xorshiro256ss.h
@@ -1,0 +1,110 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+// originally from Quuxplusone/Xoshiro256ss.
+// Upstream's public domain, so I assume all's ok.
+// Original comment:
+// The "xoshiro256** 1.0" generator.
+// C++ port by Arthur O'Dwyer (2021).
+// Based on the C version by David Blackman and Sebastiano Vigna (2018),
+// https://prng.di.unimi.it/xoshiro256starstar.c
+
+#ifndef BESPOKESYNTH_XORSHIRO256SS_H
+#define BESPOKESYNTH_XORSHIRO256SS_H
+
+#include <cstddef>
+#include <climits> // CHAR_BIT
+
+namespace bespoke::core
+{
+    namespace detail
+    {
+        template<class T>
+        constexpr size_t BitSizeOf()
+        {
+            return sizeof(T) * CHAR_BIT;
+        }
+
+        using u64 = size_t;
+
+        constexpr u64 splitmix64(u64& x)
+        {
+            u64 z = (x += 0x9e3779b97f4a7c15uLL);
+            z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9uLL;
+            z = (z ^ (z >> 27)) * 0x94d049bb133111ebuLL;
+            return z ^ (z >> 31);
+        }
+
+        constexpr u64 rotl(u64 x, int k)
+        {
+            return (x << k) | (x >> (BitSizeOf<u64>() - k));
+        }
+
+        /**
+         * Xoshiro256ss as a C++ Random Number Engine.
+         * There's no fancy standardese concept name (Trust me, I checked), unfortunately..
+         */
+        struct Xoshiro256ss
+        {
+            using result_type = u64;
+
+            static_assert(sizeof(u64) == 8, "size_t needs to be 64 bits");
+            u64 s[4]{};
+
+            constexpr explicit Xoshiro256ss() : Xoshiro256ss(0)
+            {
+
+            }
+
+            constexpr explicit Xoshiro256ss(u64 seed)
+            {
+                s[0] = splitmix64(seed);
+                s[1] = splitmix64(seed);
+                s[2] = splitmix64(seed);
+                s[3] = splitmix64(seed);
+            }
+
+            static constexpr result_type min()
+            {
+                return 0;
+            }
+
+            static constexpr result_type max()
+            {
+                return u64(-1);
+            }
+
+            constexpr result_type operator()()
+            {
+                result_type result = rotl(s[1] * 5, 7) * 9;
+                result_type t = s[1] << 17;
+                s[2] ^= s[0];
+                s[3] ^= s[1];
+                s[1] ^= s[2];
+                s[0] ^= s[3];
+                s[2] ^= t;
+                s[3] = rotl(s[3], 45);
+                return result;
+            }
+        };
+    }
+
+    using detail::Xoshiro256ss;
+}
+
+#endif //BESPOKESYNTH_XORSHIRO256SS_H

--- a/Source/Xorshiro256ss.h
+++ b/Source/Xorshiro256ss.h
@@ -33,76 +33,76 @@
 
 namespace bespoke::core
 {
-    namespace detail
-    {
-        template<class T>
-        constexpr size_t BitSizeOf()
-        {
-            return sizeof(T) * CHAR_BIT;
-        }
+   namespace detail
+   {
+      template <class T>
+      constexpr size_t BitSizeOf()
+      {
+         return sizeof(T) * CHAR_BIT;
+      }
 
-        constexpr std::uint64_t splitmix64(std::uint64_t& x)
-        {
-            std::uint64_t z = (x += 0x9e3779b97f4a7c15uLL);
-            z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9uLL;
-            z = (z ^ (z >> 27)) * 0x94d049bb133111ebuLL;
-            return z ^ (z >> 31);
-        }
+      constexpr std::uint64_t splitmix64(std::uint64_t& x)
+      {
+         std::uint64_t z = (x += 0x9e3779b97f4a7c15uLL);
+         z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9uLL;
+         z = (z ^ (z >> 27)) * 0x94d049bb133111ebuLL;
+         return z ^ (z >> 31);
+      }
 
-        constexpr std::uint64_t rotl(std::uint64_t x, int k)
-        {
-            return (x << k) | (x >> (BitSizeOf<std::uint64_t>() - k));
-        }
+      constexpr std::uint64_t rotl(std::uint64_t x, int k)
+      {
+         return (x << k) | (x >> (BitSizeOf<std::uint64_t>() - k));
+      }
 
-        /**
-         * Xoshiro256** as a C++ Random Number Engine.
-         * There's no fancy standardese concept name (Trust me, I checked), unfortunately..
-         */
-        struct Xoshiro256ss
-        {
-            using result_type = std::uint64_t;
+      /**
+       * Xoshiro256** as a C++ Random Number Engine.
+       * There's no fancy standardese concept name (Trust me, I checked), unfortunately..
+       */
+      struct Xoshiro256ss
+      {
+         using result_type = std::uint64_t;
 
-            std::uint64_t s[4]{};
+         std::uint64_t s[4]{};
 
-            constexpr explicit Xoshiro256ss() : Xoshiro256ss(0)
-            {
+         constexpr explicit Xoshiro256ss()
+         : Xoshiro256ss(0)
+         {
+         }
 
-            }
+         constexpr explicit Xoshiro256ss(std::uint64_t seed)
+         {
+            s[0] = splitmix64(seed);
+            s[1] = splitmix64(seed);
+            s[2] = splitmix64(seed);
+            s[3] = splitmix64(seed);
+         }
 
-            constexpr explicit Xoshiro256ss(std::uint64_t seed)
-            {
-                s[0] = splitmix64(seed);
-                s[1] = splitmix64(seed);
-                s[2] = splitmix64(seed);
-                s[3] = splitmix64(seed);
-            }
+         static constexpr result_type min()
+         {
+            return 0;
+         }
 
-            static constexpr result_type min()
-            {
-                return 0;
-            }
+         static constexpr result_type max()
+         {
+            return std::uint64_t(-1);
+         }
 
-            static constexpr result_type max()
-            {
-                return std::uint64_t(-1);
-            }
+         constexpr result_type operator()()
+         {
+            result_type result = rotl(s[1] * 5, 7) * 9;
+            result_type t = s[1] << 17;
+            s[2] ^= s[0];
+            s[3] ^= s[1];
+            s[1] ^= s[2];
+            s[0] ^= s[3];
+            s[2] ^= t;
+            s[3] = rotl(s[3], 45);
+            return result;
+         }
+      };
+   }
 
-            constexpr result_type operator()()
-            {
-                result_type result = rotl(s[1] * 5, 7) * 9;
-                result_type t = s[1] << 17;
-                s[2] ^= s[0];
-                s[3] ^= s[1];
-                s[1] ^= s[2];
-                s[0] ^= s[3];
-                s[2] ^= t;
-                s[3] = rotl(s[3], 45);
-                return result;
-            }
-        };
-    }
-
-    using detail::Xoshiro256ss;
+   using detail::Xoshiro256ss;
 }
 
 #endif //BESPOKESYNTH_XORSHIRO256SS_H


### PR DESCRIPTION
this PR switches the global RNG to an implementation of Xoshiro256** implemented as a C++ random number engine.

Skipping past mt19937 being extremely easy to underseed (and the previous code doing so),
mt19937 also carries a huge amount of baggage state which makes generating random data take it's sweet time.

However, xoshiro256**:

 - has a fraction of the state size
 - cannot be underseeded as easily (if at all),
 - is simply faster for a tiny bit less entropy (well, considering underseeding, it might be *more* entropy.).