### PR TITLE
handle clang-format discrepancy

### DIFF
--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -30,10 +30,12 @@
 #include "IDrawableModule.h"
 #include "IAudioProcessor.h"
 #include "IModulator.h"
+// clang-format off
 extern "C"
 {
 #include "xwax/timecoder.h"
 }
+// clang-format on
 
 class VinylProcessor
 {


### PR DESCRIPTION
differing clang-format versions seem to disagree about how this extern block should be formatted, so disable clang-format for this section to avoid future issues