### PR TITLE
OSC fixes

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -356,7 +356,7 @@ void MidiController::OnTransportAdvanced(float amount)
       {
          playTime = gTime + (note->mTimestampMs - firstNoteTimestampMs);
          if (playTime <= lastPlayTime)
-            playTime += .01f; //hack to handle note on/off in the same frame
+            playTime += .01; //hack to handle note on/off in the same frame
       }
       lastPlayTime = playTime;
       PlayNoteOutput(playTime, note->mPitch + mNoteOffset, MIN(127, note->mVelocity * mVelocityMult), voiceIdx, ModulationParameters(mModulation.GetPitchBend(voiceIdx), mModulation.GetModWheel(voiceIdx), mModulation.GetPressure(voiceIdx), 0));

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -336,6 +336,7 @@ void MidiController::OnTransportAdvanced(float amount)
    mQueuedMessageMutex.lock();
 
    double firstNoteTimestampMs = -1;
+   double lastPlayTime = -1;
    for (auto note = mQueuedNotes.begin(); note != mQueuedNotes.end(); ++note)
    {
       int voiceIdx = -1;
@@ -354,7 +355,10 @@ void MidiController::OnTransportAdvanced(float amount)
       else
       {
          playTime = gTime + (note->mTimestampMs - firstNoteTimestampMs);
+         if (playTime <= lastPlayTime)
+            playTime += .01f; //hack to handle note on/off in the same frame
       }
+      lastPlayTime = playTime;
       PlayNoteOutput(playTime, note->mPitch + mNoteOffset, MIN(127, note->mVelocity * mVelocityMult), voiceIdx, ModulationParameters(mModulation.GetPitchBend(voiceIdx), mModulation.GetModWheel(voiceIdx), mModulation.GetPressure(voiceIdx), 0));
 
       for (auto i = mListeners[mControllerPage].begin(); i != mListeners[mControllerPage].end(); ++i)

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -152,7 +152,7 @@ void OscController::oscMessageReceived(const juce::OSCMessage& msg)
          note.mVelocity = 0;
       else
          note.mVelocity = msg[1 + offset].getFloat32() * 127;
-      ofLog() << "OSCNote: P: " << note.mPitch << " V: " << note.mVelocity << "" << note.mChannel;
+      //ofLog() << "OSCNote: P: " << note.mPitch << " V: " << note.mVelocity << " ch:" << note.mChannel;
       if (mListener != nullptr)
          mListener->OnMidiNote(note);
       return;

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -135,45 +135,72 @@ void OscController::oscMessageReceived(const juce::OSCMessage& msg)
    if (msg.size() == 0 || (!msg[0].isFloat32() && !msg[0].isInt32()))
       return;
 
-   int mapIndex = FindControl(address);
-
-   bool isNew = false;
-   if (mapIndex == -1) //create a new map entry
+   // Handle note data and output these as notes instead of CC's.
+   if (address.rfind("/note", 0) == 0 && msg.size() >= 2 && ((msg[0].isFloat32() && msg[1].isFloat32()) || (msg[0].isInt32() && msg[1].isFloat32() && msg[2].isFloat32())))
    {
-      isNew = true;
-      mapIndex = AddControl(address, msg[0].isFloat32());
-   }
-
-   MidiControl control;
-   control.mControl = mOscMap[mapIndex].mControl;
-   control.mDeviceName = "osccontroller";
-   control.mChannel = 1;
-   mOscMap[mapIndex].mLastChangedTime = gTime;
-   if (mOscMap[mapIndex].mIsFloat)
-   {
-      assert(msg[0].isFloat32());
-      mOscMap[mapIndex].mFloatValue = msg[0].getFloat32();
-      control.mValue = mOscMap[mapIndex].mFloatValue * 127;
-   }
-   else
-   {
-      assert(msg[0].isInt32());
-      mOscMap[mapIndex].mIntValue = msg[0].getInt32();
-      control.mValue = mOscMap[mapIndex].mIntValue;
-   }
-
-   if (isNew)
-   {
-      MidiController* midiController = dynamic_cast<MidiController*>(mListener);
-      if (midiController)
+      MidiNote note;
+      note.mDeviceName = "osccontroller";
+      note.mChannel = 1;
+      int offset = 0;
+      if (msg.size() >= 3 && msg[0].isInt32())
       {
-         auto& layoutControl = midiController->GetLayoutControl(control.mControl, kMidiMessage_Control);
-         layoutControl.mConnectionType = mOscMap[mapIndex].mIsFloat ? kControlType_Slider : kControlType_Direct;
+         note.mChannel = msg[0].getInt32();
+         offset = 1;
       }
+      note.mPitch = msg[0 + offset].getFloat32();
+      if (msg[1 + offset].getFloat32() < 1 / 127)
+         note.mVelocity = 0;
+      else
+         note.mVelocity = msg[1 + offset].getFloat32() * 127;
+      ofLog() << "OSCNote: P: " << note.mPitch << " V: " << note.mVelocity << "" << note.mChannel;
+      if (mListener != nullptr)
+         mListener->OnMidiNote(note);
+      return;
    }
 
-   if (mListener != nullptr)
-      mListener->OnMidiControl(control);
+   for (int i = 0; i < msg.size(); ++i)
+   {
+      auto calculated_address = (i > 0) ? address + " " + std::to_string(i + 1) : address;
+      int mapIndex = FindControl(calculated_address);
+
+      bool isNew = false;
+      if (mapIndex == -1) //create a new map entry
+      {
+         isNew = true;
+         mapIndex = AddControl(calculated_address, msg[i].isFloat32());
+      }
+
+      MidiControl control;
+      control.mControl = mOscMap[mapIndex].mControl;
+      control.mDeviceName = "osccontroller";
+      control.mChannel = 1;
+      mOscMap[mapIndex].mLastChangedTime = gTime;
+      if (mOscMap[mapIndex].mIsFloat)
+      {
+         assert(msg[i].isFloat32());
+         mOscMap[mapIndex].mFloatValue = msg[i].getFloat32();
+         control.mValue = mOscMap[mapIndex].mFloatValue * 127;
+      }
+      else
+      {
+         assert(msg[i].isInt32());
+         mOscMap[mapIndex].mIntValue = msg[i].getInt32();
+         control.mValue = mOscMap[mapIndex].mIntValue;
+      }
+
+      if (isNew)
+      {
+         MidiController* midiController = dynamic_cast<MidiController*>(mListener);
+         if (midiController)
+         {
+            auto& layoutControl = midiController->GetLayoutControl(control.mControl, kMidiMessage_Control);
+            layoutControl.mConnectionType = mOscMap[mapIndex].mIsFloat ? kControlType_Slider : kControlType_Direct;
+         }
+      }
+
+      if (mListener != nullptr)
+         mListener->OnMidiControl(control);
+   }
 }
 
 int OscController::FindControl(std::string address)


### PR DESCRIPTION
Fix that the OSC controller ignored any arguments beyond the first. This bug would make it impossible to use widgets like the `xy`, `range`, `rgb`, `multixy` and others.

Made it possible to receive note data through OSC using addresses that start with `/note`.  By default the notes will be seen as coming from channel 1 but if you use `preArgs` in Open Stage Control one can set the channel to something else by specifying an integer preArg indicating the channel like the following:
![image](https://user-images.githubusercontent.com/211381/162257146-e2ff2690-0d01-4207-9c14-e8c80c3b54b7.png)
The above will send the notes to channel 4 which you then can filter with the midicontroller's channel filter (not that two osccontrollers modules work at the same time but I think that is a different issue).