### PR TITLE
fixed up some behavior to restore midicontroller "hotbind" functionality

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -481,7 +481,7 @@ private:
 #endif
 
       int keyCode = key.getTextCharacter();
-      if (keyCode < 32)
+      if (keyCode < 32 || key.getModifiers().isAltDown())
          keyCode = key.getKeyCode();
       bool isRepeat = true;
       if (find(mPressedKeys.begin(), mPressedKeys.end(), keyCode) == mPressedKeys.end())

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -967,7 +967,7 @@ void ModularSynth::KeyPressed(int key, bool isRepeat)
       {
          gHoveredUIControl->ResetToOriginal();
       }
-      else if (key != ' ' && key != OF_KEY_TAB && key != '`' && key < CHAR_MAX && juce::CharacterFunctions::isPrintable((char)key))
+      else if (key != ' ' && key != OF_KEY_TAB && key != '`' && key < CHAR_MAX && juce::CharacterFunctions::isPrintable((char)key) && (GetKeyModifiers() & kModifier_Alt) == false)
       {
          gHoveredUIControl->AttemptTextInput();
       }
@@ -1021,7 +1021,7 @@ void ModularSynth::KeyPressed(int key, bool isRepeat)
 
    mZoomer.OnKeyPressed(key);
 
-   if (key < CHAR_MAX && CharacterFunctions::isDigit((char)key) && (GetKeyModifiers() == kModifier_Alt))
+   if (CharacterFunctions::isDigit((char)key) && (GetKeyModifiers() & kModifier_Alt))
    {
       int num = key - '0';
       assert(num >= 0 && num <= 9);
@@ -1256,7 +1256,7 @@ void ModularSynth::MouseDragged(int intX, int intY, int button, const juce::Mous
       modal->NotifyMouseMoved(x, y);
    }
 
-   if (GetKeyModifiers() == kModifier_Alt && !mHasDuplicatedDuringDrag)
+   if ((GetKeyModifiers() & kModifier_Alt) && !mHasDuplicatedDuringDrag)
    {
       std::vector<IDrawableModule*> newGroupSelectedModules;
       std::map<IDrawableModule*, IDrawableModule*> oldToNewModuleMap;

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -545,7 +545,7 @@ midicontroller~get midi input from external devices. to get a nice display in th
 ~messagetype~type of midi message
 ~control~pitch or control to refer to
 ~channel~which channel to pay attention to
-~path~path to the control that should be affected
+~path~path to the control that should be affected. you can also enter "hover" here, to affect whichever control the mouse is hovering over.
 ~controltype~how this control should modify the target.\n -slider: set the value interpolated between "midi off" and "midi on" to the slider's value\n -set: set the specified value directly when this button is pressed\n -release: set the specified value directly when this button is released\n -toggle: toggle the control's value to on/off when this button is pressed\n -direct: set the control to the literal midi input value
 ~value~the value to set
 ~midi off~the lower end of the midi range. send this value when the targeted control is off. if "scale" is enabled, this also controls the lower end of the slider range, and you can set midi off to be higher than midi on to reverse a slider's direction.


### PR DESCRIPTION
to use "hotbind":
- set a midicontroller knob's mapping target to "hotbind1", "hotbind2", etc
- hover over a control and press alt/option + 1 (or whichever number "hotbind[x]" you want)
- the midicontroller knob now controls that target

you can use this functionality to rapidly map controls without much fiddling