### PR TITLE
Fix the next and previous sample buttons in the sampleplayer pads on windows. Fixes #791.

### DIFF
--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -1126,7 +1126,7 @@ void DrumPlayer::DrumHit::LoadNextSample(int direction)
       if (file.getFileName()[0] != '.')
       {
          files.add(file);
-         if (mSample.GetReadPath() == file.getFullPathName())
+         if (mSample.GetReadPath() == file.getFullPathName().replace(GetPathSeparator(), "/"))
             currentIndex = i;
          ++i;
       }


### PR DESCRIPTION
It seems the file iterations returns paths with backslashes (`\`) while most of bespoke only uses forward slashes (`/`). This change should fix that.