### PR TITLE
Preset cleanup.

### DIFF
--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -32,16 +32,6 @@
 std::vector<IUIControl*> Presets::sPresetHighlightControls;
 
 Presets::Presets()
-: mGrid(nullptr)
-, mDrawSetPresetsCountdown(0)
-, mBlending(false)
-, mBlendTime(0)
-, mBlendTimeSlider(nullptr)
-, mRandomizeButton(nullptr)
-, mCurrentPreset(0)
-, mCurrentPresetSlider(nullptr)
-, mModuleCable(nullptr)
-, mUIControlCable(nullptr)
 {
 }
 

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -79,8 +79,6 @@ private:
    void SetPreset(int idx);
    void Store(int idx);
    void UpdateGridValues();
-   void Save();
-   void Load();
    void SetGridSize(float w, float h);
    bool IsConnectedToPath(std::string path) const;
    void RandomizeTargets();
@@ -99,7 +97,6 @@ private:
       Preset(std::string path, float val)
       : mControlPath(path)
       , mValue(val)
-      , mHasLFO(false)
       {}
       Preset(IUIControl* control, Presets* presets);
       bool operator==(const Preset& other) const
@@ -109,11 +106,11 @@ private:
                 mHasLFO == other.mHasLFO;
       }
       std::string mControlPath;
-      float mValue;
-      bool mHasLFO;
+      float mValue = 0;
+      bool mHasLFO = false;
       LFOSettings mLFOSettings;
-      int mGridCols;
-      int mGridRows;
+      int mGridCols = 0;
+      int mGridRows = 0;
       std::vector<float> mGridContents;
       std::string mString;
    };
@@ -132,7 +129,6 @@ private:
 
    UIGrid* mGrid;
    std::vector<PresetCollection> mPresetCollection;
-   ClickButton* mSaveButton;
    ClickButton* mRandomizeButton;
    int mDrawSetPresetsCountdown;
    std::vector<IDrawableModule*> mPresetModules;
@@ -140,7 +136,7 @@ private:
    bool mBlending;
    float mBlendTime;
    FloatSlider* mBlendTimeSlider;
-   float mBlendProgress;
+   float mBlendProgress = 0;
    std::vector<ControlRamp> mBlendRamps;
    ofMutex mRampMutex;
    int mCurrentPreset;

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -106,12 +106,12 @@ private:
                 mHasLFO == other.mHasLFO;
       }
       std::string mControlPath;
-      float mValue = 0;
-      bool mHasLFO = false;
+      float mValue{ 0 };
+      bool mHasLFO{ false };
       LFOSettings mLFOSettings;
-      int mGridCols = 0;
-      int mGridRows = 0;
-      std::vector<float> mGridContents;
+      int mGridCols{ 0 };
+      int mGridRows{ 0 };
+      std::vector<float> mGridContents{};
       std::string mString;
    };
 
@@ -123,26 +123,26 @@ private:
 
    struct ControlRamp
    {
-      IUIControl* mUIControl;
+      IUIControl* mUIControl{ nullptr };
       Ramp mRamp;
    };
 
-   UIGrid* mGrid;
+   UIGrid* mGrid{ nullptr };
    std::vector<PresetCollection> mPresetCollection;
-   ClickButton* mRandomizeButton;
-   int mDrawSetPresetsCountdown;
-   std::vector<IDrawableModule*> mPresetModules;
-   std::vector<IUIControl*> mPresetControls;
-   bool mBlending;
-   float mBlendTime;
-   FloatSlider* mBlendTimeSlider;
-   float mBlendProgress = 0;
+   ClickButton* mRandomizeButton{ nullptr };
+   int mDrawSetPresetsCountdown{ 0 };
+   std::vector<IDrawableModule*> mPresetModules{};
+   std::vector<IUIControl*> mPresetControls{};
+   bool mBlending{ false };
+   float mBlendTime{ 0 };
+   FloatSlider* mBlendTimeSlider{ nullptr };
+   float mBlendProgress{ 0 };
    std::vector<ControlRamp> mBlendRamps;
    ofMutex mRampMutex;
-   int mCurrentPreset;
-   IntSlider* mCurrentPresetSlider;
-   PatchCableSource* mModuleCable;
-   PatchCableSource* mUIControlCable;
+   int mCurrentPreset{ 0 };
+   IntSlider* mCurrentPresetSlider{ nullptr };
+   PatchCableSource* mModuleCable{ nullptr };
+   PatchCableSource* mUIControlCable{ nullptr };
    bool mShiftHeld{ false };
 };
 


### PR DESCRIPTION
- Removed unused saving and loading of a json preset file.
- Resize mPresetCollection when the grid is resized if needed. 
- Made sure all variables are initialized and added some protection when loading values that could be saved uninitialized. 
- Stopped MSVC from grumbling over potential arithmetic overflows by doing explicit casting.

I'm almost positive the explicit casting is unnecessary since the values won't get high enough to overflow but I'd rather be save than sorry.

I don't actually know if the loading value range checks fix any loading issues currently around since I don't have a good way to see what is going on during load (yet) and I don't actually think I have a savestate that exposes this particular issue. What prompted me to touch this code however is that the assert (https://github.com/BespokeSynth/BespokeSynth/blob/main/Source/Presets.cpp#L588) during saving was triggered many times while testing things with a preset in debug mode.