### PR TITLE
Fix freeverb.

### DIFF
--- a/Source/FreeverbEffect.cpp
+++ b/Source/FreeverbEffect.cpp
@@ -39,9 +39,9 @@ FreeverbEffect::FreeverbEffect()
    //mFreeverb.setmode(GetParameter(KMode));
    //mFreeverb.setroomsize(GetParameter(KRoomSize));
    mFreeverb.setdamp(50);
-   mFreeverb.setwet(.5f);
-   mFreeverb.setdry(1);
-   //mFreeverb.setwidth(GetParameter(KWidth));
+   mFreeverb.setwet(.5);
+   mFreeverb.setdry(.5);
+   mFreeverb.setwidth(50);
    mFreeverb.update();
 
    mFreeze = false;
@@ -63,7 +63,7 @@ void FreeverbEffect::CreateUIControls()
    mDampSlider = new FloatSlider(this, "damp", 5, 20, 85, 15, &mDamp, 0, 100);
    mWetSlider = new FloatSlider(this, "wet", 5, 36, 85, 15, &mWet, 0, 1);
    mDrySlider = new FloatSlider(this, "dry", 5, 52, 85, 15, &mDry, 0, 1);
-   mWidthSlider = new FloatSlider(this, "width", 5, 68, 85, 15, &mVerbWidth, 0, 1);
+   mWidthSlider = new FloatSlider(this, "width", 5, 68, 85, 15, &mVerbWidth, 0, 100);
 }
 
 void FreeverbEffect::ProcessAudio(double time, ChannelBuffer* buffer)

--- a/Source/FreeverbEffect.cpp
+++ b/Source/FreeverbEffect.cpp
@@ -40,7 +40,7 @@ FreeverbEffect::FreeverbEffect()
    //mFreeverb.setroomsize(GetParameter(KRoomSize));
    mFreeverb.setdamp(50);
    mFreeverb.setwet(.5);
-   mFreeverb.setdry(.5);
+   mFreeverb.setdry(1);
    mFreeverb.setwidth(50);
    mFreeverb.update();
 


### PR DESCRIPTION
Change the range of the width slide to be 0-100 instead of 0-1.
Change the initial freeverb values to half dry/wet and half width (similar to how dampening is set to half).

This also fixes #836.