### PR TITLE
Logging and Loading fixes!

### DIFF
--- a/Source/ADSR.cpp
+++ b/Source/ADSR.cpp
@@ -256,7 +256,7 @@ void ::ADSR::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ADSR: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    float dummy;
    in >> dummy;

--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -445,7 +445,7 @@ void ADSRDisplay::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ADSRDisplay: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAdsr->LoadState(in);
 }

--- a/Source/Beats.cpp
+++ b/Source/Beats.cpp
@@ -209,11 +209,11 @@ void Beats::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Beats: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int numColumns;
    in >> numColumns;
-   LoadStateValidate(numColumns == (int)mBeatColumns.size());
+   LoadStateValidate(numColumns == (int)mBeatColumns.size(), "Beats: numColumns(" + ofToString(numColumns) + ") == mBeatColumns.size()(" + ofToString(mBeatColumns.size()) + ")");
    for (size_t i = 0; i < mBeatColumns.size(); ++i)
       mBeatColumns[i]->LoadState(in);
 }

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -259,6 +259,8 @@ target_sources(BespokeSynth PRIVATE
     LockFreeQueue.h
     LoopStorer.cpp
     LoopStorer.h
+    Logger.cpp
+    Logger.h
     Looper.cpp
     Looper.h
     LooperGranulator.cpp

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -713,7 +713,7 @@ void Canvas::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Canvas: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mNumCols;
    in >> mNumRows;

--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -313,7 +313,7 @@ void CanvasElement::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kCESaveStateRev);
+   LoadStateValidate(rev <= kCESaveStateRev, "CavnasElement: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kCESaveStateRev) + ")");
 
    if (rev < 1)
    {
@@ -443,7 +443,7 @@ void NoteCanvasElement::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kNCESaveStateRev);
+   LoadStateValidate(rev <= kNCESaveStateRev, "NoteCanvasElement: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kNCESaveStateRev) + ")");
 
    in >> mVelocity;
 }
@@ -597,7 +597,7 @@ void SampleCanvasElement::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSCESaveStateRev);
+   LoadStateValidate(rev <= kSCESaveStateRev, "SampleCanvasElement: rev(" + ofToString(rev) + ") <= kSCESaveStateRev(" + ofToString(kSCESaveStateRev) + ")");
 
    bool hasSample;
    in >> hasSample;
@@ -752,7 +752,7 @@ void EventCanvasElement::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kECESaveStateRev);
+   LoadStateValidate(rev <= kECESaveStateRev, "EventCanvasElement: rev(" + ofToString(rev) + ") <= kECESaveStateRev(" + ofToString(kECESaveStateRev) + ")");
 
    in >> mValue;
    if (rev < 1)

--- a/Source/ChannelBuffer.cpp
+++ b/Source/ChannelBuffer.cpp
@@ -184,7 +184,7 @@ void ChannelBuffer::Load(FileStreamIn& in, int& readLength, LoadMode loadMode)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ChannelBuffer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> readLength;
    if (loadMode == LoadMode::kSetBufferSize)

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -232,7 +232,7 @@ void Checkbox::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "CheckBox: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    float var;
    in >> var;

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -361,7 +361,7 @@ void Chorder::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Chorder: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mChordGrid->LoadState(in);
 }

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -173,7 +173,7 @@ void CircleSequencer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "CircleSequencer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int numRings;
    in >> numRings;

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -1332,7 +1332,7 @@ void CodeEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "CodeEntry: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    std::string var;
    in >> var;

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -343,7 +343,7 @@ void ControlSequencer::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev >= 422)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= kSaveStateRev, "Beats: ControlSequencer(" + ofToString(mLoadRev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    IDrawableModule::LoadState(in);
@@ -351,7 +351,7 @@ void ControlSequencer::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev <= 421)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= kSaveStateRev, "Beats: ControlSequencer(" + ofToString(mLoadRev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    mGrid->LoadState(in);

--- a/Source/Curve.cpp
+++ b/Source/Curve.cpp
@@ -197,7 +197,7 @@ void Curve::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Curve: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mNumCurvePoints;
    for (int i = 0; i < mNumCurvePoints; ++i)

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -285,7 +285,7 @@ void CurveLooper::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "CurveLooper: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    if (rev >= 1)
       mAdsr.LoadState(in);

--- a/Source/DelayEffect.cpp
+++ b/Source/DelayEffect.cpp
@@ -258,7 +258,7 @@ void DelayEffect::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "DelayEffect: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mDelayBuffer.LoadState(in);
 }

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -505,7 +505,7 @@ void DropdownList::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "DropdownList: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    if (rev < 1)
    {

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -1201,7 +1201,7 @@ void DrumPlayer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "DrumPlayer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    for (int i = 0; i < NUM_DRUM_HITS; ++i)
    {

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -259,7 +259,7 @@ void EnvelopeModulator::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "EnvelopeModulator: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAdsr.LoadState(in);
 }

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -443,7 +443,7 @@ void EventCanvas::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "EventCanvas: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int size;
    in >> size;

--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -149,7 +149,7 @@ FileStreamIn& FileStreamIn::operator>>(std::string& var)
    }
 
    if (TheSynth->IsLoadingModule())
-      LoadStateValidate(len < 99999); //probably garbage beyond this point
+      LoadStateValidate(len < 99999, "FileStreamIn: len(" + ofToString(len) + ") < 99999"); //probably garbage beyond this point
    else
       assert(len < 99999); //probably garbage beyond this point
 
@@ -179,6 +179,11 @@ void FileStreamIn::Peek(void* buffer, int size)
    auto pos = mStream->getPosition();
    mStream->read(buffer, size);
    mStream->setPosition(pos);
+}
+
+int FileStreamIn::bytesRemaining() const
+{
+   return int(mStream->getNumBytesRemaining());
 }
 
 bool FileStreamIn::Eof() const

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -73,6 +73,7 @@ public:
    void ReadGeneric(void* buffer, int size);
    void Peek(void* buffer, int size);
    int GetFilePosition() const;
+   int bytesRemaining() const;
    bool OpenedOk() const;
    bool Eof() const;
    static bool s32BitMode;

--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -541,7 +541,7 @@ void LFOSettings::LoadState(FileStreamIn& in)
    {
       isDataRevved = true;
       in >> rev;
-      LoadStateValidate(rev <= kSaveStateRev);
+      LoadStateValidate(rev <= kSaveStateRev, "LFOSettings: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
       in >> temp;
    }
    mInterval = (NoteInterval)temp;

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -566,7 +566,7 @@ void FubbleModule::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "FubbleModule: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAxisH.mCurve.LoadState(in);
    mAxisV.mCurve.LoadState(in);

--- a/Source/GlobalControls.cpp
+++ b/Source/GlobalControls.cpp
@@ -156,5 +156,5 @@ void GlobalControls::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "GlobalControls: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 }

--- a/Source/GridController.cpp
+++ b/Source/GridController.cpp
@@ -93,7 +93,7 @@ void GridControlTarget::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "GridControlTarget: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 }
 
 //----------------

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -375,7 +375,7 @@ void GridModule::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "GridModule: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    if (rev >= 1)
    {

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -241,7 +241,7 @@ void GridSliders::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "GridSliders: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int size;
    in >> size;

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -95,7 +95,7 @@ public:
    std::vector<UIGrid*> GetUIGrids() const;
    void AddChild(IDrawableModule* child);
    void RemoveChild(IDrawableModule* child);
-   IDrawableModule* FindChild(const char* name) const;
+   IDrawableModule* FindChild(const char* name, bool fail = true) const;
    void GetDimensions(float& width, float& height) override;
    virtual void GetModuleDimensions(float& width, float& height)
    {

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -355,7 +355,7 @@ void KeyboardDisplay::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "KeyboardDisplay: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/Logger.cpp
+++ b/Source/Logger.cpp
@@ -1,0 +1,71 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  Logging.cpp
+//
+//  Created by Noxy Nixie on 8th of May 2022.
+//
+
+#include "Logger.h"
+
+#include <iomanip>
+#include <ctime>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include "juce_core/juce_core.h"
+#include "SynthGlobals.h"
+
+namespace Bespoke
+{
+   Logger::Logger(std::string logFile, LogLevel maxLevel)
+   : maxLogLevel(maxLevel)
+   {
+      juce::File(ofToDataPath("logs")).createDirectory();
+      file.open(ofToDataPath("logs/" + logFile), std::ofstream::app);
+   }
+
+   Logger::~Logger()
+   {
+      file.flush();
+      file.close();
+   }
+
+   void Logger::Log(std::string message, LogLevel level /* = LogLevel::Info */, bool toCout /* = true */)
+   {
+      if (level < maxLogLevel)
+         return;
+      std::time_t t = std::time(nullptr);
+      std::tm tm = *std::localtime(&t);
+      std::stringstream output;
+      std::lock_guard<std::mutex> lock(logMutex);
+      output << "[" << std::put_time(&tm, "%FT%T%z") << "] "
+             << ofToString(gTime / 1000, 8) << " "
+             << LogLevelToString(level) << " "
+             << message << std::endl;
+
+      file << output.str() << std::flush;
+      if (!toCout)
+         return;
+      if (level > LogLevel::Warning)
+         std::cerr << output.str() << std::flush;
+      else
+         std::cout << output.str() << std::flush;
+   }
+}

--- a/Source/Logger.h
+++ b/Source/Logger.h
@@ -1,0 +1,79 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  Logging.h
+//
+//  Created by Noxy Nixie on 8th of May 2022.
+//
+
+#pragma once
+
+#ifndef __Bespoke__Logger__
+#define __Bespoke__Logger__
+
+#include <string>
+#include <memory>
+#include <fstream>
+#include "juce_core/juce_core.h"
+
+namespace Bespoke
+{
+   enum class LogLevel
+   {
+      Debug,
+      Info,
+      Warning,
+      Error,
+      Fatal
+   };
+
+   class Logger
+   {
+   public:
+      Logger(std::string logFile = "BespokeSynth.log", LogLevel maxLevel = LogLevel::Info);
+      ~Logger();
+
+      void Log(std::string message, LogLevel level = LogLevel::Info, bool toCout = true);
+      static std::string LogLevelToString(LogLevel level)
+      {
+         switch (level)
+         {
+            case LogLevel::Debug:
+               return "DEBUG:  ";
+            case LogLevel::Info:
+               return "INFO:   ";
+            case LogLevel::Warning:
+               return "WARNING:";
+            case LogLevel::Error:
+               return "ERROR:  ";
+            case LogLevel::Fatal:
+               return "FATAL:  ";
+         }
+         return "UNKNOWN:";
+      }
+      void setMaxLogLevel(LogLevel level) { maxLogLevel = level; }
+
+   private:
+      LogLevel maxLogLevel;
+      std::ofstream file;
+      std::mutex logMutex;
+   };
+
+}
+
+#endif /* defined(__Bespoke__Logger__) */

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -296,7 +296,7 @@ void LoopStorer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "LoopStorer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mCurrentBufferIdx;
    mQueuedSwapBufferIdx = -1;

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1344,7 +1344,7 @@ void Looper::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Looper: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mLoopLength;
    if (rev >= 1)

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -842,7 +842,7 @@ void LooperRecorder::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "LooperRecorder: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mBaseTempo;
    in >> mSpeed;

--- a/Source/MidiCapturer.cpp
+++ b/Source/MidiCapturer.cpp
@@ -54,7 +54,7 @@ void MidiCapturerDummyController::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "MidiCapturerDummyController: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 }
 
 MidiCapturer::MidiCapturer()

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2459,7 +2459,7 @@ void MidiController::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "MidiController: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    bool hasNonstandardController;
    in >> hasNonstandardController;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -14,6 +14,7 @@
 #include "EffectFactory.h"
 #include "ModuleContainer.h"
 #include "Minimap.h"
+#include "Logger.h"
 
 #ifdef BESPOKE_LINUX
 #include <climits>
@@ -133,6 +134,7 @@ public:
    bool IsModalFocusItem(IDrawableModule* item) const;
 
    void LogEvent(std::string event, LogEventType type);
+   void Log(std::string message, Bespoke::LogLevel level = Bespoke::LogLevel::Info, bool toCout = true);
    void SetNextDrawTooltip(std::string tooltip) { mNextDrawTooltip = tooltip; }
 
    bool LoadLayoutFromFile(std::string jsonFile, bool makeDefaultLayout = true);
@@ -352,6 +354,7 @@ private:
    };
    std::list<LogEventItem> mEvents;
    std::list<std::string> mErrors;
+   std::unique_ptr<Bespoke::Logger> mLogger;
 
    NamedMutex mAudioThreadMutex;
 

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -163,7 +163,7 @@ void ModulatorCurve::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ModulatorCurve: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAdsr.LoadState(in);
 }

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -343,7 +343,7 @@ void Monome::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Monome: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mPendingDeviceDesc;
 }

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -247,7 +247,7 @@ void MultitapDelay::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "MultitapeDelay: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mDelayBuffer.LoadState(in);
 }

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -228,7 +228,7 @@ void MultitrackRecorder::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "MultitrackRecorder: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mWidth;
 

--- a/Source/NoteCounter.cpp
+++ b/Source/NoteCounter.cpp
@@ -223,7 +223,7 @@ void NoteCounter::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "NoteCounter: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -440,7 +440,7 @@ void NoteLooper::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "NoteLooper: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mWidth;
    in >> mHeight;
@@ -451,7 +451,7 @@ void NoteLooper::LoadState(FileStreamIn& in)
 
    int numPatterns;
    in >> numPatterns;
-   LoadStateValidate(numPatterns == mSavedPatterns.size());
+   LoadStateValidate(numPatterns == mSavedPatterns.size(), "NoteLooper: numPatterns(" + ofToString(numPatterns) + ") == mSavedPatterns.size()(" + ofToString(mSavedPatterns.size()) + ")");
    for (size_t i = 0; i < mSavedPatterns.size(); ++i)
    {
       int numNotes;

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -1162,7 +1162,7 @@ void NoteStepSequencer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "NoteStepSequencer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mGrid->LoadState(in);
    mVelocityGrid->LoadState(in);

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -637,7 +637,7 @@ void NoteTable::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "NoteTable: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mGrid->LoadState(in);
    GridUpdated(mGrid, 0, 0, 0, 0);

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -255,7 +255,7 @@ void OscController::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "OscController: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int mapSize;
    in >> mapSize;

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -730,6 +730,7 @@ void PatchCableSource::LoadState(FileStreamIn& in)
          }
          catch (UnknownUIControlException& e)
          {
+            bsLog() << "PatchCableSource::LoadState UnknownUIControlException: " << e.what();
          }
       }
       mPatchCables[i] = new PatchCable(this);

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -603,20 +603,20 @@ void PlaySequencer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "PlaySequencer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mGrid->LoadState(in);
 
    int numPatterns;
    in >> numPatterns;
-   LoadStateValidate(numPatterns == mSavedPatterns.size());
+   LoadStateValidate(numPatterns == mSavedPatterns.size(), "PlaySequencer: numPatterns(" + ofToString(numPatterns) + ") == mSavedPatterns.size()(" + ofToString(mSavedPatterns.size()) + ")");
    for (size_t i = 0; i < mSavedPatterns.size(); ++i)
    {
       in >> mSavedPatterns[i].mNumMeasures;
       in >> mSavedPatterns[i].mHasSequence;
       int size;
       in >> size;
-      LoadStateValidate(size == (int)mSavedPatterns[i].mData.size());
+      LoadStateValidate(size == (int)mSavedPatterns[i].mData.size(), "PlaySequencer: size(" + ofToString(size) + ") == mSavedPatterns[i(" + ofToString(i) + ")].mData.size()(" + ofToString(mSavedPatterns[i].mData.size()) + ")");
       for (int j = 0; j < size; ++j)
          in >> mSavedPatterns[i].mData[j];
    }

--- a/Source/Polyrhythms.cpp
+++ b/Source/Polyrhythms.cpp
@@ -169,11 +169,11 @@ void Polyrhythms::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Polyrhythms: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int size;
    in >> size;
-   LoadStateValidate(size == (int)mRhythmLines.size());
+   LoadStateValidate(size == (int)mRhythmLines.size(), "Polyrhythms: size(" + ofToString(size) + ") == mRhythmLines.size()(" + ofToString(mRhythmLines.size()) + ")");
    for (size_t i = 0; i < mRhythmLines.size(); ++i)
       mRhythmLines[i]->mGrid->LoadState(in);
 }

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -348,7 +348,7 @@ void Prefab::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Prefab: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mPrefabName;
 }

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -608,7 +608,7 @@ void Presets::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev == kSaveStateRev, "Presets: rev(" + ofToString(rev) + ") == kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int collSize;
    in >> collSize;

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -287,7 +287,7 @@ void PulseSequence::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "PulseSequencer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mVelocityGrid->LoadState(in);
    GridUpdated(mVelocityGrid, 0, 0, 0, 0);

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -260,7 +260,7 @@ void PulseTrain::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "PulseTrain: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mVelocityGrid->LoadState(in);
    GridUpdated(mVelocityGrid, 0, 0, 0, 0);

--- a/Source/Pumper.cpp
+++ b/Source/Pumper.cpp
@@ -205,7 +205,7 @@ void Pumper::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Pumper: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAdsr.LoadState(in);
 

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -390,7 +390,7 @@ void RadioButton::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Beats: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    float var;
    in >> var;

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -379,7 +379,7 @@ void RadioSequencer::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev >= 422)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= kSaveStateRev, "RadioSequencer: mLoadRev(" + ofToString(mLoadRev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    IDrawableModule::LoadState(in);
@@ -387,7 +387,7 @@ void RadioSequencer::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev <= 421)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= kSaveStateRev, "RadioSequencer: mLoadRev(" + ofToString(mLoadRev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    int size;

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -260,7 +260,7 @@ void SampleBrowser::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SampleBrowser: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    std::string currentDirectory;
    in >> currentDirectory;

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -311,7 +311,7 @@ void SampleCanvas::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SampleCanvas: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    float w, h;
    in >> w;

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -301,7 +301,7 @@ void SampleCapturer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SampleCapturer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int readLength;
    for (int i = 0; i < mSamples.size(); ++i)

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1472,7 +1472,7 @@ void SamplePlayer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SamplePlayer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    bool hasSample;
    in >> hasSample;

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -335,7 +335,7 @@ void Sampler::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Sampler: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in.Read(mSampleData, MAX_SAMPLER_LENGTH);
 

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -494,7 +494,7 @@ void SamplerGrid::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SampleGrid: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    //LoadStateValidate(false); //TODO(Ryan) temp hack fix because samplergrid was loading funny
 

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -791,7 +791,7 @@ void Scale::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev >= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Scale: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int inton;
    in >> inton;

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1508,7 +1508,7 @@ void ScriptModule::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev >= 421)
    {
       in >> rev;
-      LoadStateValidate(rev <= kSaveStateRev);
+      LoadStateValidate(rev <= kSaveStateRev, "ScriptModule: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    if (rev >= 2)
@@ -1523,7 +1523,7 @@ void ScriptModule::LoadState(FileStreamIn& in)
    if (ModularSynth::sLoadingFileSaveStateRev == 420)
    {
       in >> rev;
-      LoadStateValidate(rev <= kSaveStateRev);
+      LoadStateValidate(rev <= kSaveStateRev, "ScriptModule: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
    }
 
    float w, h;

--- a/Source/ScriptStatus.cpp
+++ b/Source/ScriptStatus.cpp
@@ -151,7 +151,7 @@ void ScriptStatus::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ScriptStatus: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -421,7 +421,7 @@ void SeaOfGrain::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "SeaOfGrain: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mHasRecordedInput = false;
    if (rev > 0)

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -1229,7 +1229,7 @@ void IntSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kIntSliderSaveStateRev);
+   LoadStateValidate(rev <= kIntSliderSaveStateRev, "IntSlider: rev(" + ofToString(rev) + ") <= kIntSliderSaveStateRev(" + ofToString(kIntSliderSaveStateRev) + ")");
 
    float var;
    in >> var;

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -1101,7 +1101,7 @@ void StepSequencer::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "StepSequencer: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mGrid->LoadState(in);
 

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -39,6 +39,8 @@
 #include "IPulseReceiver.h"
 #include "exprtk/exprtk.hpp"
 #include "UserPrefs.h"
+#include "Logger.h"
+#include <memory>
 
 #include "juce_audio_formats/juce_audio_formats.h"
 #include "juce_gui_basics/juce_gui_basics.h"
@@ -748,10 +750,10 @@ uint32_t JenkinsHash(const char* key)
    return hash;
 }
 
-void LoadStateValidate(bool assertion)
+void LoadStateValidate(bool assertion, std::string message)
 {
    if (!assertion)
-      throw LoadStateException();
+      throw LoadStateException("Assertion failed: " + message);
 }
 
 float GetLeftPanGain(float pan)
@@ -11481,6 +11483,13 @@ ofLog::~ofLog()
    DBG(output);
    if (mSendToBespokeConsole)
       TheSynth->LogEvent(output, kLogEventType_Verbose);
+}
+
+bsLog::~bsLog()
+{
+   TheSynth->Log(mMessage, mLogLevel, mSendToCout);
+   if (mSendToBespokeConsole)
+      TheSynth->LogEvent(mMessage, kLogEventType_Verbose);
 }
 
 #ifdef BESPOKE_DEBUG_ALLOCATIONS

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -703,7 +703,7 @@ void TextEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "TextEntry: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    std::string var;
    in >> var;

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -695,7 +695,7 @@ void Transport::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "Transport: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    if (rev == 0) //load as float instead of double
    {

--- a/Source/UIGrid.cpp
+++ b/Source/UIGrid.cpp
@@ -522,7 +522,7 @@ void UIGrid::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "UIGrid: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    int cols = MAX_GRID_SIZE;
    int rows = MAX_GRID_SIZE;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -403,17 +403,11 @@ void VSTPlugin::CreateParameterSliders()
       mParameterSliders[i].mValue = parameters[i]->getValue();
       juce::String name = parameters[i]->getName(32);
       std::string label(name.getCharPointer());
-      try
+      int append = 0;
+      while (FindUIControl(label.c_str(), false))
       {
-         int append = 0;
-         while (FindUIControl(label.c_str()))
-         {
-            ++append;
-            label = name.toStdString() + ofToString(append);
-         }
-      }
-      catch (UnknownUIControlException& e)
-      {
+         ++append;
+         label = name.toStdString() + ofToString(append);
       }
       mParameterSliders[i].mSlider = new FloatSlider(this, label.c_str(), -1, -1, 200, 15, &mParameterSliders[i].mValue, 0, 1);
       mParameterSliders[i].mParameter = parameters[i];
@@ -1063,7 +1057,7 @@ void VSTPlugin::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "VSTPlugin: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    bool hasPlugin;
    in >> hasPlugin;

--- a/Source/ValueStream.cpp
+++ b/Source/ValueStream.cpp
@@ -184,5 +184,5 @@ void ValueStream::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "ValueStream: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 }

--- a/Source/VelocityCurve.cpp
+++ b/Source/VelocityCurve.cpp
@@ -151,7 +151,7 @@ void VelocityCurve::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev, "VelocityCurve: rev(" + ofToString(rev) + ") <= kSaveStateRev(" + ofToString(kSaveStateRev) + ")");
 
    mAdsr.LoadState(in);
 }


### PR DESCRIPTION
- Added logging (Initially for debugging loading issues but will probably be used in other places).
- Made a bunch of loading related exceptions more verbose. 
- Fixed a saving bug were the name was used instead of the type for child modules. 
- Added a hacky workaround to fix the loading of savestates were child modules were saved with their name instead of type. 
- Fixed crashes where the loading of a corrupted save would attempt to load invalid control or module names. 
- Fixed loading crash where the end of the file is reached unexpectedly. 
- Fixed a bug where the loading of VST plugins would throw many exceptions for no good reason. 
- Don't crash out when child count is incorrect in an attempt to load more.

Fixes #748, mostly fixes #203, potentially fixes #312.

#203 files have other issues that I can't resolve the loading of (these were saved with multiple prefabs having the same exact name, I can't think of a good and reliable way to resolve this). I can't verify if this fixes #312 since the file is not provided.

There is still a lot of work to do to fix other loading issues (one of which is already in a PR: #834) but it is time I pushed this out as it already contains some critical fixes.

I really hope you like how I did the logging as I've gone over so many different ways of logging and they all boil down to what you need and want.

I ended up making `bsLog()` even though I suspect that suggestion was kind of a joke.

I attempted to make all the fixes so that it does not require a `kSaveStateRev` increment and thus in theory savestates from this PR should be loadable (provided they don't suffer from the fixed bugs) in 1.1.0.