### PR TITLE
add aesthetic touch to cables, to fade them out in the middle

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2807,7 +2807,7 @@ void ControlLayoutElement::Setup(MidiController* owner, MidiMessageType type, in
       mControlCable = new PatchCableSource(owner, kConnectionType_UIControl);
       owner->AddPatchCableSource(mControlCable);
       ofColor color = mControlCable->GetColor();
-      color.a *= .2f;
+      color.a *= .25f;
       mControlCable->SetColor(color);
    }
 }

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -208,7 +208,7 @@ void PatchCable::Render()
       {
          ofSetLineWidth(lineWidth);
 
-         for (int half=0; half<2; ++half)
+         for (int half = 0; half < 2; ++half)
          {
             if (!UserPrefs.fade_cable_middle.Get())
                ofSetColor(lineColorAlphaed);
@@ -243,7 +243,7 @@ void PatchCable::Render()
                ofSetColor(color);
                ofSetLineWidth(3);
 
-               for (int half=0; half<2; ++half)
+               for (int half = 0; half < 2; ++half)
                {
                   if (!UserPrefs.fade_cable_middle.Get())
                      ofSetColor(color);
@@ -285,7 +285,7 @@ void PatchCable::Render()
                {
                   ofSetLineWidth(lineWidth * (4 + ofClamp(1 - elapsed * .7f, 0, 1) * 5 + cos((gTime - event.mTime) * PI * 8 / TheTransport->MsPerBar()) * .3f));
 
-                  for (int half=0; half<2; ++half)
+                  for (int half = 0; half < 2; ++half)
                   {
                      if (!UserPrefs.fade_cable_middle.Get())
                         ofSetColor(lineColor);
@@ -348,7 +348,7 @@ void PatchCable::Render()
                drawColor.set(lineColorAlphaed.g, lineColorAlphaed.r, lineColorAlphaed.b, lineColorAlphaed.a);
             ofVec2f offset((ch - (vizBuff->NumChannels() - 1) * .5f) * 2 * dy, (ch - (vizBuff->NumChannels() - 1) * .5f) * 2 * -dx);
 
-            for (int half=0; half<2; ++half)
+            for (int half = 0; half < 2; ++half)
             {
                if (!UserPrefs.fade_cable_middle.Get())
                   ofSetColor(drawColor);
@@ -412,7 +412,7 @@ void PatchCable::Render()
       else
       {
          ofSetLineWidth(lineWidth);
-         for (int half=0; half<2; ++half)
+         for (int half = 0; half < 2; ++half)
          {
             if (!UserPrefs.fade_cable_middle.Get())
                ofSetColor(lineColorAlphaed);

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -318,6 +318,7 @@ public:
    UserPrefTextEntryInt max_input_channels{ "max_input_channels", 16, 1, 1024, 5, UserPrefCategory::General };
 
    UserPrefBool draw_background_lissajous{ "draw_background_lissajous", true, UserPrefCategory::Graphics };
+   UserPrefBool fade_cable_middle{ "fade_cable_middle", true, UserPrefCategory::Graphics };
    UserPrefFloat lissajous_r{ "lissajous_r", 0.408f, 0, 1, UserPrefCategory::Graphics };
    UserPrefFloat lissajous_g{ "lissajous_g", 0.245f, 0, 1, UserPrefCategory::Graphics };
    UserPrefFloat lissajous_b{ "lissajous_b", 0.418f, 0, 1, UserPrefCategory::Graphics };


### PR DESCRIPTION
I took this idea from bitwig grid's cables. I think it looks nice, and does a good job of reducing the feel of spaghetti and clutter. it can be disabled in the settings.