### PR TITLE
visual tweaks

### DIFF
--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -153,6 +153,7 @@ void MacroSlider::Mapping::CreateUIControls()
    mTargetCable = new PatchCableSource(mOwner, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    mTargetCable->SetManualPosition(110, 39 + mIndex * kMappingSpacing);
+   mTargetCable->SetOverrideCableDir(ofVec2f(1, 0));
    mOwner->AddPatchCableSource(mTargetCable);
 }
 

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -134,7 +134,7 @@ void NoteStepSequencer::CreateUIControls()
    FLOATSLIDER(mRandomizeVelocityDensitySlider, "rand vel density", &mRandomizeVelocityDensity, 0, 1);
    ENDUIBLOCK0();
 
-   mGrid = new UIGrid("notegrid", 5, 55, 200, 80, 8, 24, this);
+   mGrid = new UIGrid("notegrid", 5, 55, 210, 80, 8, 24, this);
    mVelocityGrid = new UIGrid("velocitygrid", 5, 117, 200, 45, 8, 1, this);
    mLoopResetPointSlider = new IntSlider(this, "loop reset", -1, -1, 100, 15, &mLoopResetPoint, 0, mLength);
 
@@ -330,13 +330,6 @@ void NoteStepSequencer::DrawModule()
 
    for (int i = 0; i < mGrid->GetCols(); ++i)
    {
-      if (mVels[i] == 0 || i >= mLength)
-      {
-         ofSetColor(0, 0, 0, 100);
-         ofFill();
-         ofRect(gridX + boxWidth * i, gridY, boxWidth, gridH);
-      }
-
       const float kPlayHighlightDurationMs = 250;
       if (mLastStepPlayTime[i] != -1)
       {
@@ -671,6 +664,14 @@ void NoteStepSequencer::Step(double time, float velocity, int pulseFlags)
 
    mGrid->SetHighlightCol(time, mArpIndex);
    mVelocityGrid->SetHighlightCol(time, mArpIndex);
+
+   bool isPowerOfTwo = (mLength & (mLength - 1)) == 0;
+   int majorColSize = 4;
+   bool isAligned = !mHasExternalPulseSource || (pulseFlags & kPulseFlag_SyncToTransport) || (pulseFlags & kPulseFlag_Align);
+   if (isPowerOfTwo && majorColSize < mLength && isAligned)
+      mGrid->SetMajorColSize(majorColSize);
+   else
+      mGrid->SetMajorColSize(-1);
 
    UpdateLights();
    UpdateGridControllerLights(false);

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -210,7 +210,7 @@ void PatchCable::Render()
 
          for (int half = 0; half < 2; ++half)
          {
-            if (!UserPrefs.fade_cable_middle.Get())
+            if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                ofSetColor(lineColorAlphaed);
             else if (half == 0)
                ofSetColorGradient(lineColorAlphaed, ofColor::clear, cable.start, cableFadeOut);
@@ -227,7 +227,7 @@ void PatchCable::Render()
             ofVertex(cable.plug.x, cable.plug.y);
             ofEndShape();
 
-            if (!UserPrefs.fade_cable_middle.Get())
+            if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                break;
          }
 
@@ -245,7 +245,7 @@ void PatchCable::Render()
 
                for (int half = 0; half < 2; ++half)
                {
-                  if (!UserPrefs.fade_cable_middle.Get())
+                  if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                      ofSetColor(color);
                   else if (half == 0)
                      ofSetColorGradient(color, ofColor::clear, cable.start, cableFadeOut);
@@ -262,7 +262,7 @@ void PatchCable::Render()
                   ofVertex(cable.plug.x, cable.plug.y);
                   ofEndShape();
 
-                  if (!UserPrefs.fade_cable_middle.Get())
+                  if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                      break;
                }
 
@@ -287,7 +287,7 @@ void PatchCable::Render()
 
                   for (int half = 0; half < 2; ++half)
                   {
-                     if (!UserPrefs.fade_cable_middle.Get())
+                     if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                         ofSetColor(lineColor);
                      else if (half == 0)
                         ofSetColorGradient(lineColor, ofColor::clear, cable.start, cableFadeOut);
@@ -302,7 +302,7 @@ void PatchCable::Render()
                      }
                      ofEndShape();
 
-                     if (!UserPrefs.fade_cable_middle.Get())
+                     if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                         break;
                   }
 
@@ -351,7 +351,7 @@ void PatchCable::Render()
 
             for (int half = 0; half < 2; ++half)
             {
-               if (!UserPrefs.fade_cable_middle.Get())
+               if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                   ofSetColor(drawColor);
                else if (half == 0)
                   ofSetColorGradient(drawColor, ofColor::clear, cable.start, cableFadeOut);
@@ -373,7 +373,7 @@ void PatchCable::Render()
                ofVertex(cable.plug.x + offset.x, cable.plug.y + offset.y);
                ofEndShape();
 
-               if (!UserPrefs.fade_cable_middle.Get())
+               if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                   break;
             }
          }
@@ -417,7 +417,7 @@ void PatchCable::Render()
 
          for (int half = 0; half < 2; ++half)
          {
-            if (!UserPrefs.fade_cable_middle.Get())
+            if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                ofSetColor(lineColorAlphaed);
             else if (half == 0)
                ofSetColorGradient(lineColorAlphaed, ofColor::clear, cable.start, cableFadeOut);
@@ -434,7 +434,7 @@ void PatchCable::Render()
             ofVertex(cable.plug.x, cable.plug.y);
             ofEndShape();
 
-            if (!UserPrefs.fade_cable_middle.Get())
+            if (!UserPrefs.fade_cable_middle.Get() || wireLength < 100)
                break;
          }
 

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -451,7 +451,7 @@ ofVec2f PatchCableSource::GetCableStartDir(int index, ofVec2f dest) const
       }
 
       if (mHoverIndex == -1 && mPatchCables.size() > 1)
-         ret = ret * .5f;  //soften if there are multiple cables
+         ret = ret * .5f; //soften if there are multiple cables
 
       return ret;
    }

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -430,19 +430,30 @@ ofVec2f PatchCableSource::GetCableStartDir(int index, ofVec2f dest) const
          }
       }
 
+      ofVec2f ret(0, 0);
       switch (dir)
       {
          case Direction::kDown:
-            return ofVec2f(0, 1);
+            ret = ofVec2f(0, 1);
+            break;
          case Direction::kRight:
-            return ofVec2f(1, 0);
+            ret = ofVec2f(1, 0);
+            break;
          case Direction::kLeft:
-            return ofVec2f(-1, 0);
+            ret = ofVec2f(-1, 0);
+            break;
          case Direction::kUp:
-            return ofVec2f(0, -1);
-         default:
-            return ofVec2f(0, 0);
+            ret = ofVec2f(0, -1);
+            break;
+         case Direction::kNone:
+            ret = ofVec2f(0, 0);
+            break;
       }
+
+      if (mHoverIndex == -1 && mPatchCables.size() > 1)
+         ret = ret * .5f;  //soften if there are multiple cables
+
+      return ret;
    }
 }
 

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -354,12 +354,15 @@ void PatchCableSource::Render()
          }
       }
 
-      if (mSide == Side::kBottom)
-         cableY += kPatchCableSpacing;
-      else if (mSide == Side::kLeft)
-         cableX -= kPatchCableSpacing;
-      else if (mSide == Side::kRight)
-         cableX += kPatchCableSpacing;
+      if (mHoverIndex != -1)
+      {
+         if (mSide == Side::kBottom)
+            cableY += kPatchCableSpacing;
+         else if (mSide == Side::kLeft)
+            cableX -= kPatchCableSpacing;
+         else if (mSide == Side::kRight)
+            cableX += kPatchCableSpacing;
+      }
    }
 
    ofPopStyle();
@@ -370,12 +373,15 @@ ofVec2f PatchCableSource::GetCableStart(int index) const
    float cableX = mX;
    float cableY = mY;
 
-   if (mSide == Side::kBottom)
-      cableY += kPatchCableSpacing * index;
-   else if (mSide == Side::kLeft)
-      cableX -= kPatchCableSpacing * index;
-   else if (mSide == Side::kRight)
-      cableX += kPatchCableSpacing * index;
+   if (mHoverIndex != -1)
+   {
+      if (mSide == Side::kBottom)
+         cableY += kPatchCableSpacing * index;
+      else if (mSide == Side::kLeft)
+         cableX -= kPatchCableSpacing * index;
+      else if (mSide == Side::kRight)
+         cableX += kPatchCableSpacing * index;
+   }
 
    return ofVec2f(cableX, cableY);
 }
@@ -406,7 +412,7 @@ ofVec2f PatchCableSource::GetCableStartDir(int index, ofVec2f dest) const
          case Side::kNone: dir = Direction::kNone; break;
       }
 
-      if (mPatchCables.size() > 0 && index < mPatchCables.size() - 1) //not the top of the cable stack
+      if (mHoverIndex != -1 && mPatchCables.size() > 0 && index < mPatchCables.size() - 1) //not the top of the cable stack
       {
          if (mSide == Side::kBottom)
          {


### PR DESCRIPTION
- only fade patch cable middles if they're above a certain length
- add visual markers to notesequencer steps
- only show multiple bubbles for cables with multiple outputs when they're hovered, instead of always