### PR TITLE
Use relative path to share/BespokeSynth in Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "libs/JUCE"]
+	path = libs/JUCE
+	url = https://github.com/juce-framework/JUCE
 [submodule "libs/pybind11"]
 	path = libs/pybind11
 	url = https://github.com/pybind/pybind11

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "libs/JUCE"]
-	path = libs/JUCE
-	url = https://github.com/juce-framework/JUCE
 [submodule "libs/pybind11"]
 	path = libs/pybind11
 	url = https://github.com/pybind/pybind11

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -90,6 +90,8 @@ std::string ofToFactoryPath(const std::string& subdir)
 #if BESPOKE_LINUX
    if (!resDir.isDirectory())
       resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentApplicationFile).getChildFile("../../share/BespokeSynth").getChildFile(subdir);
+   else 
+      resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
 #endif
 #endif
    if (!resDir.isDirectory())

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -89,9 +89,11 @@ std::string ofToFactoryPath(const std::string& subdir)
    auto resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentExecutableFile).getSiblingFile(subdir);
 #if BESPOKE_LINUX
    if (!resDir.isDirectory())
+   {
       resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentApplicationFile).getChildFile("../../share/BespokeSynth").getChildFile(subdir);
-   else 
-      resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
+      if (!resDir.isDirectory())
+         resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
+   }
 #endif
 #endif
    if (!resDir.isDirectory())

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -89,7 +89,7 @@ std::string ofToFactoryPath(const std::string& subdir)
    auto resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentExecutableFile).getSiblingFile(subdir);
 #if BESPOKE_LINUX
    if (!resDir.isDirectory())
-      resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
+      resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentApplicationFile).getChildFile("../../share/BespokeSynth").getChildFile(subdir);
 #endif
 #endif
    if (!resDir.isDirectory())

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -89,11 +89,9 @@ std::string ofToFactoryPath(const std::string& subdir)
    auto resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentExecutableFile).getSiblingFile(subdir);
 #if BESPOKE_LINUX
    if (!resDir.isDirectory())
-   {
       resDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentApplicationFile).getChildFile("../../share/BespokeSynth").getChildFile(subdir);
-      if (!resDir.isDirectory())
-         resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
-   }
+   else 
+      resDir = juce::File{ juce::CharPointer_UTF8{ Bespoke::CMAKE_INSTALL_PREFIX } }.getChildFile("share/BespokeSynth").getChildFile(subdir);
 #endif
 #endif
    if (!resDir.isDirectory())


### PR DESCRIPTION
at least AppImage requires relative paths in apps
this PR can be discussed if it breaks smth in some unusual cases, but as we use hardcoded paths for the `<prefix>/bin` and `<prefix>/share` - it shouldn't