### PR TITLE
collection of fixes and features

### DIFF
--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -114,6 +114,8 @@ private:
    static DisplayMode sDisplayMode;
    EnvelopeEditor* mEditor{ nullptr };
    double mOverrideDrawTime{ -1 };
+   std::array<double, 10> mDrawTimeHistory{ };
+   int mDrawTimeHistoryIndex{ 0 };
 };
 
 

--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -114,7 +114,7 @@ private:
    static DisplayMode sDisplayMode;
    EnvelopeEditor* mEditor{ nullptr };
    double mOverrideDrawTime{ -1 };
-   std::array<double, 10> mDrawTimeHistory{ };
+   std::array<double, 10> mDrawTimeHistory{};
    int mDrawTimeHistoryIndex{ 0 };
 };
 

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -70,6 +70,7 @@ public:
    void LoadState(FileStreamIn& in);
 
    void RadioButtonUpdated(RadioButton* list, int oldVal);
+   void ButtonClicked(ClickButton* button);
 
 private:
    RadioButton* mSelector{ nullptr };
@@ -91,6 +92,7 @@ private:
    std::vector<Sample*> mSamples;
    float mPan{ 0 };
    FloatSlider* mPanSlider{ nullptr };
+   ClickButton* mDeleteButton{ nullptr };
 };
 
 class Beats : public IAudioSource, public IDrawableModule, public IFloatSliderListener, public IIntSliderListener, public IDropdownListener, public ITimeListener, public IButtonListener, public IRadioButtonListener
@@ -113,6 +115,7 @@ public:
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
+   bool MouseMoved(float x, float y) override;
 
    void CheckboxUpdated(Checkbox* checkbox) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
@@ -140,6 +143,7 @@ private:
    ChannelBuffer mWriteBuffer;
    std::array<BeatColumn*, 4> mBeatColumns;
    int mRows;
+   int mHighlightColumn{ -1 };
 };
 
 #endif /* defined(__modularSynth__Beats__) */

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -105,13 +105,22 @@ void DropdownList::CalculateWidth()
    mMaxItemWidth = mWidth;
    for (int i = 0; i < mElements.size(); ++i)
    {
-      int width = GetStringWidth(mElements[i].mLabel) + 15;
+      int width = GetStringWidth(mElements[i].mLabel) + (mDrawTriangle ? 15 : 3);
       if (width > mMaxItemWidth)
          mMaxItemWidth = width;
    }
 
    if (mAutoCalculateWidth)
       mWidth = MIN(mMaxItemWidth, 180);
+}
+
+void DropdownList::SetWidth(int width)
+{
+   if (width != mWidth)
+   {
+      mWidth = width;
+      CalculateWidth();
+   }
 }
 
 std::string DropdownList::GetLabel(int val) const
@@ -159,7 +168,7 @@ void DropdownList::Render()
    ofSetColor(textColor);
 
    ofPushMatrix();
-   ofClipWindow(mX, mY, w - 12, h, true);
+   ofClipWindow(mX, mY, w - (mDrawTriangle ? 12 : 0), h, true);
    DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
    ofPopMatrix();
    if (mDrawTriangle)

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -115,7 +115,7 @@ public:
       CalculateWidth();
    }
    void DrawLabel(bool draw) { mDrawLabel = draw; }
-   void SetWidth(int width) { mWidth = width; }
+   void SetWidth(int width);
    void SetDrawTriangle(bool draw) { mDrawTriangle = draw; }
    void GetPopupDimensions(float& width, float& height) { mModalList.GetDimensions(width, height); }
    void SetMaxPerColumn(int max)

--- a/Source/EQEffect.cpp
+++ b/Source/EQEffect.cpp
@@ -49,7 +49,6 @@ void EQEffect::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
    mMultiSlider = new UIGrid("uigrid", 5, 25, 80, 50, NUM_EQ_FILTERS, 1, this);
-   AddUIControl(mMultiSlider);
    mEvenButton = new ClickButton(this, "even", 5, 5);
 
    mMultiSlider->SetGridMode(UIGrid::kMultislider);

--- a/Source/MidiClockIn.cpp
+++ b/Source/MidiClockIn.cpp
@@ -163,7 +163,7 @@ void MidiClockIn::OnMidi(const juce::MidiMessage& message)
    }
    if (message.isSongPositionPointer())
    {
-      ofLog() << "midi position pointer " << ofToString(message.getSongPositionPointerMidiBeat());
+      //ofLog() << "midi position pointer " << ofToString(message.getSongPositionPointerMidiBeat());
 
       if (mEnabled)
          TheTransport->SetMeasureTime(message.getSongPositionPointerMidiBeat() / TheTransport->GetTimeSigTop() + mStartOffsetMs / TheTransport->MsPerBar());

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2852,8 +2852,6 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(std::string spawnCommand, flo
       DoAutosave();
 
    std::string moduleType = tokens[0];
-   if (name == "")
-      name = moduleType;
 
    moduleType = ModuleFactory::FixUpTypeName(moduleType);
 
@@ -2904,6 +2902,9 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(std::string spawnCommand, flo
             effectToSetUp += " ";
       }
    }
+
+   if (name == "")
+      name = moduleType;
 
    ofxJSONElement dummy;
    dummy["type"] = moduleType;

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -29,11 +29,11 @@
 #include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
-#include "Checkbox.h"
 #include "Slider.h"
 #include "ModulationChain.h"
+#include "DropdownList.h"
 
-class Monophonify : public NoteEffectBase, public IDrawableModule, public IFloatSliderListener
+class Monophonify : public NoteEffectBase, public IDrawableModule, public IFloatSliderListener, public IDropdownListener
 {
 public:
    Monophonify();
@@ -48,8 +48,8 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
    void CheckboxUpdated(Checkbox* checkbox) override;
-   //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
@@ -63,7 +63,7 @@ private:
       height = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
-   int GetMostRecentPitch() const;
+   int GetMostRecentCurrentlyHeldPitch() const;
 
    double mHeldNotes[128];
    int mInitialPitch{ -1 };
@@ -73,8 +73,15 @@ private:
    float mHeight{ 20 };
    int mVoiceIdx{ 0 };
 
-   bool mRequireHeldNote{ false };
-   Checkbox* mRequireHeldNoteCheckbox{ nullptr };
+   enum class PortamentoMode
+   {
+      kAlways,
+      kRetriggerHeld,
+      kBendHeld
+   };
+
+   PortamentoMode mPortamentoMode{ PortamentoMode::kAlways };
+   DropdownList* mPortamentoModeSelector{ nullptr };
    float mGlideTime{ 0 };
    FloatSlider* mGlideSlider{ nullptr };
    ModulationChain mPitchBend;

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -193,13 +193,13 @@ private:
    ClickButton* mRandomizeLengthButton;
    ClickButton* mRandomizeVelocityButton;
    float mRandomizePitchChance;
-   float mRandomizePitchRange;
+   int mRandomizePitchVariety;
    float mRandomizeLengthChance;
    float mRandomizeLengthRange;
    float mRandomizeVelocityChance;
    float mRandomizeVelocityDensity;
    FloatSlider* mRandomizePitchChanceSlider;
-   FloatSlider* mRandomizePitchRangeSlider;
+   IntSlider* mRandomizePitchVarietySlider;
    FloatSlider* mRandomizeLengthChanceSlider;
    FloatSlider* mRandomizeLengthRangeSlider;
    FloatSlider* mRandomizeVelocityChanceSlider;

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -245,7 +245,7 @@ void NoteTable::DrawModule()
       {
          mToneDropdowns[i]->SetShowing(mShowColumnControls);
          mToneDropdowns[i]->SetPosition(gridX + boxWidth * i, controlYPos);
-         mToneDropdowns[i]->SetWidth(boxWidth);
+         mToneDropdowns[i]->SetWidth(std::min(boxWidth, 30.0f));
          mToneDropdowns[i]->Draw();
       }
       else

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -72,9 +72,9 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
 
    char* mLabels[OSC_OUTPUT_MAX_PARAMS];
-   std::list<TextEntry*> mLabelEntry{ nullptr };
+   std::list<TextEntry*> mLabelEntry{ };
    float mParams[OSC_OUTPUT_MAX_PARAMS];
-   std::list<FloatSlider*> mSliders{ nullptr };
+   std::list<FloatSlider*> mSliders{ };
 
    std::string mOscOutAddress{ "127.0.0.1" };
    TextEntry* mOscOutAddressEntry{ nullptr };

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -72,9 +72,9 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
 
    char* mLabels[OSC_OUTPUT_MAX_PARAMS];
-   std::list<TextEntry*> mLabelEntry{ };
+   std::list<TextEntry*> mLabelEntry{};
    float mParams[OSC_OUTPUT_MAX_PARAMS];
-   std::list<FloatSlider*> mSliders{ };
+   std::list<FloatSlider*> mSliders{};
 
    std::string mOscOutAddress{ "127.0.0.1" };
    TextEntry* mOscOutAddressEntry{ nullptr };

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -71,9 +71,9 @@ void RadioSequencer::CreateUIControls()
    mGrid->SetMajorColSize(4);
    mGrid->SetListener(this);
 
-   /*mIntervalSelector->AddLabel("8", kInterval_8);
-    mIntervalSelector->AddLabel("4", kInterval_4);
-    mIntervalSelector->AddLabel("2", kInterval_2);*/
+   mIntervalSelector->AddLabel("8", kInterval_8);
+   mIntervalSelector->AddLabel("4", kInterval_4);
+   mIntervalSelector->AddLabel("2", kInterval_2);
    mIntervalSelector->AddLabel("1n", kInterval_1n);
    mIntervalSelector->AddLabel("2n", kInterval_2n);
    mIntervalSelector->AddLabel("4n", kInterval_4n);

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -119,6 +119,9 @@ globalcontrols~interface controls, intended to allow you to use midi controllers
 ~lissajous r~amount of red in background lissajous curve
 ~lissajous g~amount of green in background lissajous curve
 ~lissajous b~amount of blue in background lissajous curve
+~background r~amount of red in background color
+~background g~amount of green in background color
+~background b~amount of blue in background color
 
 
 
@@ -139,6 +142,26 @@ eventcanvas~schedule values to set over time
 
 comment~a box to display some text, to explain a section of a patch
 ~comment~type text here
+
+
+
+clockout~sends out clock pulses to synchronize external midi devices
+~device~device to target
+~send start~send a signal to reset the gear to the start of its sequence
+~multiplier~tempo multiplier for how the gear should respond to the signals
+
+
+
+clockin~reads in clock pulses from external midi devices to control bespoke's transport
+~device~device to receive from
+~rounding~precision to round incoming tempo data
+~start offset ms~offset in milliseconds to tweak synchronization between bespoke and gear
+~smoothing~how much to smooth incoming tempo
+
+
+
+abletonlink~synchronizes transport with software and devices that support ableton link
+~offset ms~offset in milliseconds to tweak synchronization
 
 
 
@@ -219,6 +242,7 @@ velocitytocv~take a note's velocity and convert it to a modulation value
 valuesetter~set a specified value on a targeted control
 ~value~value to set
 ~set~click here to send the value (or, send a pulse to this module for the same result)
+~slider~value to set
 
 
 
@@ -521,6 +545,9 @@ notechain~trigger a note, followed by a pulse to trigger another note after a de
 
 notecanvas~looping note roll
 ~quantize~quantize selected notes to interval
+~save midi~export canvas contents to a midi file
+~load midi~import canvas contents from a midi file
+~loadtrack~which track number to import when using "load midi"
 ~play~play notes on canvas
 ~rec~record input notes to canvas
 ~free rec~enable record mode, and extend canvas if we reach the end
@@ -606,6 +633,7 @@ drumsequencer~step sequencer intended for drums. hold shift when dragging on the
 ~r den~density of the randomizer output. the higher this is, the busier the random output will be.
 ~r amt~the chance that each step will change when being randomized. low values will only change a small amount of the sequence, high values will replace more of the sequence.
 ~r lock*~lock this row so it doesn't get randomized
+~random*~randomize this row
 
 
 
@@ -920,6 +948,7 @@ butterworth~filter using the butterworth formula
 
 compressor~try to keep volume at a certain level
 ~mix~amount of compression. lower this value for a "parallel compression" effect. you should use this mix slider instead of the effectchain's mix slider, to compensate for lookahead.
+~drive~rescale input to affect how much compression affects it
 ~threshold~threshold where gain should start to be reduced
 ~ratio~how much gain reduction to apply when the single passes the threshold
 ~attack~speed to apply gain reduction
@@ -1366,6 +1395,8 @@ drumplayer~sample player intended for drum playback
 ~test *~play this sample
 ~random *~choose a random sample from the selected hitcategory
 ~grab *~grab this sample
+~prev *~choose the previous sample from the selected hitcategory
+~next *~choose the next sample from the selected hitcategory
 
 
 
@@ -1376,6 +1407,7 @@ beats~multi-loop player, for mixing sample layers together
 ~double*~enable this to play at double speed
 ~bars*~how many measures long are the samples in this slot?
 ~selector*~which sample should we play in this slot? drag samples onto here to add them to this slot.
+~delete *~remove the current sample from the list
 
 
 
@@ -1404,6 +1436,11 @@ vibrato~add rhythmic oscillating pitch bend to notes
 
 
 
+velocitytochance~use a note's velocity to determine the chance that the note plays
+~full velocity~set velocity to full for notes that pass through
+
+
+
 velocitystepsequencer~adjusts the velocity of incoming notes based upon a sequence
 ~interval~speed to advance sequence
 ~len~length of sequence
@@ -1420,6 +1457,10 @@ velocitysetter~set a note's velocity to this value
 
 velocityscaler~scale a note's velocity to be higher or lower
 ~scale~amount to multiply velocity by
+
+
+
+velocitycurve~adjust velocity based upon a curve mapping
 
 
 
@@ -1487,7 +1528,7 @@ pressure~add pressure modulation to notes
 
 
 portamento~only allows one note to play at a time, and uses pitch bend to glide between notes
-~require held~if enabled, only glide to a new note if an old note is held. otherwise, always glide, based upon the prior input note.
+~mode~always: always glide to new notes\nretrigger held: bend to notes if the prior note is held, and retrigger\nbend held: bend to notes if the prior note is held, without retriggering
 ~glide~time to glide, in milliseconds
 
 
@@ -1548,6 +1589,11 @@ noterouter~allows you to control where notes are routed to using a UI control. t
 
 noteexpression~control where notes are routed based upon evaluated expressions. the variable "p" represents pitch, and "v" represents velocity
 ~expression*~expression to evaluate for this cable. example expression to route notes with pitch greater than 80 and velocity less than 60:\n"p > 80 && v < 60"
+
+
+
+noteecho~output incoming notes at specified delays
+~delay *~amount of time to delay this output, in measures
 
 
 
@@ -1658,7 +1704,7 @@ mpetweaker~adjust incoming MPE modulation values
 
 
 
-mpesmoother~[no tooltip]
+mpesmoother~smooth out MPE parameters
 ~pitch~amount to smooth incoming pitchbend
 ~pressure~amount to smooth incoming pressure
 ~modwheel~amount to smooth incoming modwheel
@@ -1829,6 +1875,8 @@ scale~controls the global scale used by various modules
 ~PPO~pitches per octave
 ~tuning~what frequency does the pitch defined in "note" represent?
 ~note~the pitch that maps to the frequency defined in "tuning"
+~load SCL~load SCL file to determine scale
+~load KBM~load KBM file to determine keyboard mapping
 
 
 


### PR DESCRIPTION
- tooltip documentation
- change how ADSR playback draws
- add ability to remove samples from `beats` module
- adjust how dropdown width is calculated
- fix crash when spawning `basiceq` effect
- fix issue where directly spawning `effectchain` effects from quickspawn was giving the `effectchain` the name of the effect
- add `portamento` glide mode
- change how `notesequencer` pitch randomization works, to make it sound more musical by default
- fix crash when spawning `oscoutput`
- add modes to allow `radiosequencer` to run slower