### PR TITLE
reorder save format so module revision number comes before base `SaveState()` call

### DIFF
--- a/Source/Beats.cpp
+++ b/Source/Beats.cpp
@@ -219,6 +219,8 @@ void Beats::SetUpFromSaveData()
 
 void Beats::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mBeatColumns.size();

--- a/Source/Beats.cpp
+++ b/Source/Beats.cpp
@@ -217,29 +217,22 @@ void Beats::SetUpFromSaveData()
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Beats::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mBeatColumns.size();
    for (size_t i = 0; i < mBeatColumns.size(); ++i)
       mBeatColumns[i]->SaveState(out);
 }
 
-void Beats::LoadState(FileStreamIn& in)
+void Beats::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int numColumns;
    in >> numColumns;

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -132,7 +132,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/CanvasControls.h
+++ b/Source/CanvasControls.h
@@ -61,7 +61,7 @@ public:
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
-   bool CanSaveState() const override { return false; }
+   bool CanModuleTypeSaveState() const override { return false; }
 
 private:
    //IDrawableModule

--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -440,7 +440,7 @@ void NoteCanvasElement::LoadState(FileStreamIn& in)
 
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kNCESaveStateRev);
+   LoadStateValidate(rev <= kNCESaveStateRev);
 
    in >> mVelocity;
 }

--- a/Source/ChannelBuffer.cpp
+++ b/Source/ChannelBuffer.cpp
@@ -181,7 +181,7 @@ void ChannelBuffer::Load(FileStreamIn& in, int& readLength, LoadMode loadMode)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    in >> readLength;
    if (loadMode == LoadMode::kSetBufferSize)

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -232,7 +232,7 @@ void Checkbox::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    float var;
    in >> var;

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -343,6 +343,8 @@ void Chorder::SetUpFromSaveData()
 
 void Chorder::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mChordGrid->SaveState(out);

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -341,27 +341,20 @@ void Chorder::SetUpFromSaveData()
    mChordGrid->SetRequireShiftForMultislider(true);
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void Chorder::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mChordGrid->SaveState(out);
 }
 
-void Chorder::LoadState(FileStreamIn& in)
+void Chorder::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mChordGrid->LoadState(in);
 }

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -65,7 +65,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -150,6 +150,8 @@ void CircleSequencer::SetUpFromSaveData()
 
 void CircleSequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mCircleSequencerRings.size();

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -148,32 +148,25 @@ void CircleSequencer::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void CircleSequencer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mCircleSequencerRings.size();
    for (size_t i = 0; i < mCircleSequencerRings.size(); ++i)
       mCircleSequencerRings[i]->SaveState(out);
 }
 
-void CircleSequencer::LoadState(FileStreamIn& in)
+void CircleSequencer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int numRings;
    in >> numRings;

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -97,7 +97,8 @@ public:
    void TextEntryComplete(TextEntry* entry) override {}
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -1311,7 +1311,7 @@ void CodeEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    std::string var;
    in >> var;

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -320,15 +320,8 @@ void ControlSequencer::SetUpFromSaveData()
    }
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void ControlSequencer::SaveState(FileStreamOut& out)
 {
-   out << kSaveStateRev;
-
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);
@@ -336,22 +329,22 @@ void ControlSequencer::SaveState(FileStreamOut& out)
    out << mGrid->GetHeight();
 }
 
-void ControlSequencer::LoadState(FileStreamIn& in)
+void ControlSequencer::LoadState(FileStreamIn& in, int rev)
 {
-   mLoadRev = -1;
+   mLoadRev = rev;
 
-   if (ModularSynth::sLoadingFileSaveStateRev >= 422)
+   if (ModularSynth::sLoadingFileSaveStateRev == 422)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= GetModuleSaveStateRev());
    }
 
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (ModularSynth::sLoadingFileSaveStateRev <= 421)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= GetModuleSaveStateRev());
    }
 
    mGrid->LoadState(in);

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -322,6 +322,8 @@ void ControlSequencer::SetUpFromSaveData()
 
 void ControlSequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -87,7 +87,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    static std::list<ControlSequencer*> sControlSequencers;
 

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -264,27 +264,20 @@ void CurveLooper::SetUpFromSaveData()
    mHeight = mModuleSaveData.GetInt("height");
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void CurveLooper::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mAdsr.SaveState(out);
 }
 
-void CurveLooper::LoadState(FileStreamIn& in)
+void CurveLooper::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    if (rev >= 1)
       mAdsr.LoadState(in);

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -266,6 +266,8 @@ void CurveLooper::SetUpFromSaveData()
 
 void CurveLooper::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAdsr.SaveState(out);

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -66,7 +66,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/DelayEffect.cpp
+++ b/Source/DelayEffect.cpp
@@ -28,6 +28,7 @@
 #include "Transport.h"
 #include "Profiler.h"
 #include "UIControlMacros.h"
+#include "ModularSynth.h"
 
 #include "juce_core/juce_core.h"
 
@@ -221,27 +222,20 @@ void DelayEffect::DropdownUpdated(DropdownList* list, int oldVal)
 {
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void DelayEffect::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mDelayBuffer.SaveState(out);
 }
 
-void DelayEffect::LoadState(FileStreamIn& in)
+void DelayEffect::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mDelayBuffer.LoadState(in);
 }

--- a/Source/DelayEffect.cpp
+++ b/Source/DelayEffect.cpp
@@ -224,6 +224,8 @@ void DelayEffect::DropdownUpdated(DropdownList* list, int oldVal)
 
 void DelayEffect::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mDelayBuffer.SaveState(out);

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -66,7 +66,8 @@ public:
    void DropdownUpdated(DropdownList* list, int oldVal) override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -1176,6 +1176,8 @@ void DrumPlayer::SetUpFromSaveData()
 
 void DrumPlayer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    for (int i = 0; i < NUM_DRUM_HITS; ++i)

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -1174,16 +1174,9 @@ void DrumPlayer::SetUpFromSaveData()
    //LoadKit(0);
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void DrumPlayer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    for (int i = 0; i < NUM_DRUM_HITS; ++i)
    {
@@ -1195,13 +1188,13 @@ void DrumPlayer::SaveState(FileStreamOut& out)
    }
 }
 
-void DrumPlayer::LoadState(FileStreamIn& in)
+void DrumPlayer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    for (int i = 0; i < NUM_DRUM_HITS; ++i)
    {

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -97,7 +97,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    struct StoredDrumKit

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -171,27 +171,20 @@ void EnvelopeModulator::SetUpFromSaveData()
    mTargetCable->SetTarget(TheSynth->FindUIControl(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void EnvelopeModulator::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mAdsr.SaveState(out);
 }
 
-void EnvelopeModulator::LoadState(FileStreamIn& in)
+void EnvelopeModulator::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mAdsr.LoadState(in);
 }

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -173,6 +173,8 @@ void EnvelopeModulator::SetUpFromSaveData()
 
 void EnvelopeModulator::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAdsr.SaveState(out);

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -81,7 +81,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    void OnClicked(int x, int y, bool right) override;

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -416,6 +416,8 @@ void EventCanvas::SaveLayout(ofxJSONElement& moduleInfo)
 
 void EventCanvas::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mControlCables.size();

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -414,16 +414,9 @@ void EventCanvas::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["canvasheight"] = mCanvas->GetHeight();
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void EventCanvas::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
@@ -437,13 +430,13 @@ void EventCanvas::SaveState(FileStreamOut& out)
    mCanvas->SaveState(out);
 }
 
-void EventCanvas::LoadState(FileStreamIn& in)
+void EventCanvas::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int size;
    in >> size;

--- a/Source/EventCanvas.h
+++ b/Source/EventCanvas.h
@@ -75,7 +75,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -544,6 +544,8 @@ void FubbleModule::SetUpFromSaveData()
 
 void FubbleModule::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAxisH.mCurve.SaveState(out);

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -542,16 +542,9 @@ void FubbleModule::SetUpFromSaveData()
    Resize(mModuleSaveData.GetInt("width"), mModuleSaveData.GetInt("height"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 3;
-}
-
 void FubbleModule::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mAxisH.mCurve.SaveState(out);
    mAxisV.mCurve.SaveState(out);
@@ -560,13 +553,13 @@ void FubbleModule::SaveState(FileStreamOut& out)
    out << mRecordStartOffset;
 }
 
-void FubbleModule::LoadState(FileStreamIn& in)
+void FubbleModule::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mAxisH.mCurve.LoadState(in);
    mAxisV.mCurve.LoadState(in);

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -67,7 +67,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 3; }
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/GlobalControls.cpp
+++ b/Source/GlobalControls.cpp
@@ -136,23 +136,16 @@ std::vector<IUIControl*> GlobalControls::ControlsToNotSetDuringLoadState() const
    return ignore;
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void GlobalControls::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 }
 
-void GlobalControls::LoadState(FileStreamIn& in)
+void GlobalControls::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 }

--- a/Source/GlobalControls.cpp
+++ b/Source/GlobalControls.cpp
@@ -138,6 +138,8 @@ std::vector<IUIControl*> GlobalControls::ControlsToNotSetDuringLoadState() const
 
 void GlobalControls::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 }
 

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -48,7 +48,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 
 private:

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -337,16 +337,9 @@ void GridModule::CheckboxUpdated(Checkbox* checkbox)
       mGrid->SetMomentary(mMomentary);
 }
 
-namespace
-{
-   const int kSaveStateRev = 4;
-}
-
 void GridModule::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mGrid->SaveState(out);
    out << mGrid->GetWidth();
@@ -364,13 +357,13 @@ void GridModule::SaveState(FileStreamOut& out)
       out << overlay;
 }
 
-void GridModule::LoadState(FileStreamIn& in)
+void GridModule::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    if (rev >= 1)
    {

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -339,6 +339,8 @@ void GridModule::CheckboxUpdated(Checkbox* checkbox)
 
 void GridModule::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -96,7 +96,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 4; }
 
 private:
    //IDrawableModule

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -215,6 +215,8 @@ void GridSliders::SetUpFromSaveData()
 
 void GridSliders::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mControlCables.size();

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -213,16 +213,9 @@ void GridSliders::SetUpFromSaveData()
 {
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void GridSliders::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mControlCables.size();
    for (auto cable : mControlCables)
@@ -234,13 +227,13 @@ void GridSliders::SaveState(FileStreamOut& out)
    }
 }
 
-void GridSliders::LoadState(FileStreamIn& in)
+void GridSliders::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int size;
    in >> size;

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -61,7 +61,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -1170,7 +1170,7 @@ void IDrawableModule::LoadState(FileStreamIn& in, int rev)
       if (baseRev >= 2)
       {
          float rawValue;
-         in >> rawValue;   //we don't use this here, but it'll likely be useful in the future if an option is renamed/removed and we need to port the old data
+         in >> rawValue; //we don't use this here, but it'll likely be useful in the future if an option is renamed/removed and we need to port the old data
       }
       UpdateOldControlName(uicontrolname);
 

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -168,8 +168,7 @@ public:
    virtual std::vector<IUIControl*> ControlsToIgnoreInSaveState() const;
    virtual void UpdateOldControlName(std::string& oldName) {}
    virtual bool LoadOldControl(FileStreamIn& in, std::string& oldName) { return false; }
-   virtual bool CanSaveState() const { return true; }
-   virtual size_t GetExpectedSaveStateNumChildren() const { return mChildren.size(); }
+   virtual bool CanModuleTypeSaveState() const { return true; }
    virtual bool HasDebugDraw() const { return false; }
    virtual bool HasPush2OverrideControls() const { return false; }
    virtual void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const {}

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -160,7 +160,9 @@ public:
    virtual bool IsSaveable() { return true; }
    ModuleSaveData& GetSaveData() { return mModuleSaveData; }
    virtual void SaveState(FileStreamOut& out);
-   virtual void LoadState(FileStreamIn& in);
+   virtual void LoadState(FileStreamIn& in, int rev);
+   int LoadModuleSaveStateRev(FileStreamIn& in);
+   virtual int GetModuleSaveStateRev() const { return -1; }
    virtual void PostLoadState() {}
    virtual std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const;
    virtual std::vector<IUIControl*> ControlsToIgnoreInSaveState() const;

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -28,6 +28,7 @@
 #include "Scale.h"
 #include "ModuleContainer.h"
 #include "FileStream.h"
+#include "ModularSynth.h"
 
 namespace
 {
@@ -331,31 +332,24 @@ void KeyboardDisplay::SetUpFromSaveData()
    mShowScale = mModuleSaveData.GetBool("show_scale");
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void KeyboardDisplay::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mWidth;
    out << mHeight;
 }
 
-void KeyboardDisplay::LoadState(FileStreamIn& in)
+void KeyboardDisplay::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -334,6 +334,8 @@ void KeyboardDisplay::SetUpFromSaveData()
 
 void KeyboardDisplay::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mWidth;

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -50,7 +50,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -267,6 +267,8 @@ void LoopStorer::SetUpFromSaveData()
 
 void LoopStorer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mCurrentBufferIdx;

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -265,16 +265,9 @@ void LoopStorer::SetUpFromSaveData()
       transportListenerInfo->mInterval = mQuantization;
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void LoopStorer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mCurrentBufferIdx;
 
@@ -290,13 +283,13 @@ void LoopStorer::SaveState(FileStreamOut& out)
    }
 }
 
-void LoopStorer::LoadState(FileStreamIn& in)
+void LoopStorer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mCurrentBufferIdx;
    mQueuedSwapBufferIdx = -1;

--- a/Source/LoopStorer.h
+++ b/Source/LoopStorer.h
@@ -73,7 +73,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1322,29 +1322,22 @@ void Looper::SetUpFromSaveData()
    mDecay = mModuleSaveData.GetFloat("decay");
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Looper::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mLoopLength;
    out << mBufferTempo;
    mBuffer->Save(out, mLoopLength);
 }
 
-void Looper::LoadState(FileStreamIn& in)
+void Looper::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mLoopLength;
    if (rev >= 1)

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1324,6 +1324,8 @@ void Looper::SetUpFromSaveData()
 
 void Looper::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mLoopLength;

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -120,7 +120,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    void DoShiftMeasure();

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -789,6 +789,8 @@ void LooperRecorder::SetUpFromSaveData()
 
 void LooperRecorder::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mBaseTempo;

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -787,29 +787,22 @@ void LooperRecorder::SetUpFromSaveData()
    SetOutputTarget(TheSynth->FindAudioReceiver(mModuleSaveData.GetString("outputtarget")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void LooperRecorder::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mBaseTempo;
    out << mSpeed;
    mRecordBuffer.SaveState(out);
 }
 
-void LooperRecorder::LoadState(FileStreamIn& in)
+void LooperRecorder::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mBaseTempo;
    in >> mSpeed;

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -98,7 +98,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    void SyncLoopLengths();

--- a/Source/M185Sequencer.cpp
+++ b/Source/M185Sequencer.cpp
@@ -240,9 +240,9 @@ void M185Sequencer::SaveState(FileStreamOut& out)
    out << mHasExternalPulseSource;
 }
 
-void M185Sequencer::LoadState(FileStreamIn& in)
+void M185Sequencer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    for (auto& step : mSteps)
    {

--- a/Source/M185Sequencer.cpp
+++ b/Source/M185Sequencer.cpp
@@ -228,6 +228,8 @@ void M185Sequencer::SetUpFromSaveData()
 
 void M185Sequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    for (auto& step : mSteps)

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -56,7 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/MidiCapturer.cpp
+++ b/Source/MidiCapturer.cpp
@@ -54,7 +54,7 @@ void MidiCapturerDummyController::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 }
 
 MidiCapturer::MidiCapturer()

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2435,6 +2435,8 @@ void MidiController::SaveLayout(ofxJSONElement& moduleInfo)
 
 void MidiController::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    bool hasNonstandardController = (mNonstandardController != nullptr);

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2433,16 +2433,9 @@ void MidiController::SaveLayout(ofxJSONElement& moduleInfo)
    moduleInfo["connections"] = mConnectionsJson;
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void MidiController::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    bool hasNonstandardController = (mNonstandardController != nullptr);
    out << hasNonstandardController;
@@ -2450,16 +2443,16 @@ void MidiController::SaveState(FileStreamOut& out)
       mNonstandardController->SaveState(out);
 }
 
-void MidiController::LoadState(FileStreamIn& in)
+void MidiController::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    bool hasNonstandardController;
    in >> hasNonstandardController;

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -357,7 +357,8 @@ public:
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    static std::string GetDefaultTooltip(MidiMessageType type, int control);
 

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2446,7 +2446,7 @@ IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
    {
       FileStreamIn in(ofToDataPath("tmp"));
       mIsLoadingModule = true;
-      newModule->LoadState(in);
+      newModule->LoadState(in, newModule->LoadModuleSaveStateRev(in));
       mIsLoadingModule = false;
    }
 

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -273,7 +273,7 @@ public:
    static float sBackgroundB;
 
    static int sLoadingFileSaveStateRev;
-   static constexpr int kSaveStateRev = 422;
+   static constexpr int kSaveStateRev = 423;
 
 private:
    void ResetLayout();

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -144,6 +144,8 @@ void ModulatorCurve::SetUpFromSaveData()
 
 void ModulatorCurve::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAdsr.SaveState(out);

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -142,27 +142,20 @@ void ModulatorCurve::SetUpFromSaveData()
    mTargetCable->SetTarget(TheSynth->FindUIControl(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void ModulatorCurve::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mAdsr.SaveState(out);
 }
 
-void ModulatorCurve::LoadState(FileStreamIn& in)
+void ModulatorCurve::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mAdsr.LoadState(in);
 }

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -64,7 +64,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -628,7 +628,7 @@ void ModuleContainer::LoadState(FileStreamIn& in)
          if (module == nullptr)
             throw LoadStateException();
 
-         module->LoadState(in);
+         module->LoadState(in, module->LoadModuleSaveStateRev(in));
 
          for (int j = 0; j < GetModuleSeparatorLength(); ++j)
          {

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -606,6 +606,9 @@ void ModuleContainer::LoadState(FileStreamIn& in)
    bool wasLoadingState = TheSynth->IsLoadingState();
    TheSynth->SetIsLoadingState(true);
 
+   static int sModuleContainerLoadStack = 0;
+   ++sModuleContainerLoadStack;
+
    int header;
    in >> header;
    assert(header <= ModularSynth::kSaveStateRev);
@@ -680,7 +683,10 @@ void ModuleContainer::LoadState(FileStreamIn& in)
    IClickable::ClearLoadContext();
    TheSynth->SetIsLoadingState(wasLoadingState);
 
-   ModularSynth::sLoadingFileSaveStateRev = ModularSynth::kSaveStateRev; //reset to current
+   --sModuleContainerLoadStack;
+
+   if (sModuleContainerLoadStack <= 0)
+      ModularSynth::sLoadingFileSaveStateRev = ModularSynth::kSaveStateRev; //reset to current
 }
 
 //static

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -343,7 +343,7 @@ void Monome::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    in >> mPendingDeviceDesc;
 }

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -227,27 +227,20 @@ void MultitapDelay::SetUpFromSaveData()
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void MultitapDelay::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mDelayBuffer.SaveState(out);
 }
 
-void MultitapDelay::LoadState(FileStreamIn& in)
+void MultitapDelay::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mDelayBuffer.LoadState(in);
 }

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -229,6 +229,8 @@ void MultitapDelay::SetUpFromSaveData()
 
 void MultitapDelay::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mDelayBuffer.SaveState(out);

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -77,7 +77,8 @@ public:
    virtual void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -199,16 +199,9 @@ void MultitrackRecorder::SetUpFromSaveData()
       track->SetRecording(false);
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void MultitrackRecorder::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mWidth;
 
@@ -218,13 +211,13 @@ void MultitrackRecorder::SaveState(FileStreamOut& out)
       out << (std::string)track->Name();
 }
 
-void MultitrackRecorder::LoadState(FileStreamIn& in)
+void MultitrackRecorder::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mWidth;
 

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -201,6 +201,8 @@ void MultitrackRecorder::SetUpFromSaveData()
 
 void MultitrackRecorder::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mWidth;

--- a/Source/MultitrackRecorder.h
+++ b/Source/MultitrackRecorder.h
@@ -58,7 +58,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -794,9 +794,9 @@ void NoteCanvas::SaveState(FileStreamOut& out)
    mCanvas->SaveState(out);
 }
 
-void NoteCanvas::LoadState(FileStreamIn& in)
+void NoteCanvas::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    mCanvas->LoadState(in);
 }

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -789,6 +789,8 @@ void NoteCanvas::SaveLayout(ofxJSONElement& moduleInfo)
 
 void NoteCanvas::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mCanvas->SaveState(out);

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -83,7 +83,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/NoteCounter.cpp
+++ b/Source/NoteCounter.cpp
@@ -191,32 +191,25 @@ void NoteCounter::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void NoteCounter::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mWidth;
    out << mHeight;
    out << mHasExternalPulseSource;
 }
 
-void NoteCounter::LoadState(FileStreamIn& in)
+void NoteCounter::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/NoteCounter.cpp
+++ b/Source/NoteCounter.cpp
@@ -193,6 +193,8 @@ void NoteCounter::SetUpFromSaveData()
 
 void NoteCounter::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mWidth;

--- a/Source/NoteCounter.h
+++ b/Source/NoteCounter.h
@@ -64,7 +64,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -391,16 +391,9 @@ void NoteLooper::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void NoteLooper::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mWidth;
    out << mHeight;
@@ -421,16 +414,16 @@ void NoteLooper::SaveState(FileStreamOut& out)
    }
 }
 
-void NoteLooper::LoadState(FileStreamIn& in)
+void NoteLooper::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -393,6 +393,8 @@ void NoteLooper::SetUpFromSaveData()
 
 void NoteLooper::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mWidth;

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -71,7 +71,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    double GetCurPos(double time) const;

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -1141,29 +1141,22 @@ void NoteStepSequencer::SetUpFromSaveData()
    SetUpStepControls();
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void NoteStepSequencer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mGrid->SaveState(out);
    mVelocityGrid->SaveState(out);
    out << mHasExternalPulseSource;
 }
 
-void NoteStepSequencer::LoadState(FileStreamIn& in)
+void NoteStepSequencer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mGrid->LoadState(in);
    mVelocityGrid->LoadState(in);

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -1143,6 +1143,8 @@ void NoteStepSequencer::SetUpFromSaveData()
 
 void NoteStepSequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -120,7 +120,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
 
 private:
    //IDrawableModule

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -619,6 +619,8 @@ void NoteTable::SetUpFromSaveData()
 
 void NoteTable::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -617,27 +617,20 @@ void NoteTable::SetUpFromSaveData()
    SetUpColumnControls();
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void NoteTable::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mGrid->SaveState(out);
 }
 
-void NoteTable::LoadState(FileStreamIn& in)
+void NoteTable::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mGrid->LoadState(in);
    GridUpdated(mGrid, 0, 0, 0, 0);

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -91,7 +91,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
 
 private:
    //IDrawableModule

--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -255,7 +255,7 @@ void OscController::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    int mapSize;
    in >> mapSize;

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -557,6 +557,8 @@ void PlaySequencer::SetUpFromSaveData()
 
 void PlaySequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -555,16 +555,9 @@ void PlaySequencer::SetUpFromSaveData()
    mVelocityLight = mModuleSaveData.GetFloat("velocity_light");
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void PlaySequencer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mGrid->SaveState(out);
 
@@ -579,16 +572,16 @@ void PlaySequencer::SaveState(FileStreamOut& out)
    }
 }
 
-void PlaySequencer::LoadState(FileStreamIn& in)
+void PlaySequencer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mGrid->LoadState(in);
 

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -82,7 +82,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/Polyrhythms.cpp
+++ b/Source/Polyrhythms.cpp
@@ -148,6 +148,8 @@ void Polyrhythms::SetUpFromSaveData()
 
 void Polyrhythms::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mRhythmLines.size();

--- a/Source/Polyrhythms.cpp
+++ b/Source/Polyrhythms.cpp
@@ -146,29 +146,22 @@ void Polyrhythms::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Polyrhythms::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mRhythmLines.size();
    for (size_t i = 0; i < mRhythmLines.size(); ++i)
       mRhythmLines[i]->mGrid->SaveState(out);
 }
 
-void Polyrhythms::LoadState(FileStreamIn& in)
+void Polyrhythms::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int size;
    in >> size;

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -85,10 +85,11 @@ public:
    void DropdownUpdated(DropdownList* list, int oldVal) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
-   virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
-   virtual void SetUpFromSaveData() override;
-   virtual void LoadState(FileStreamIn& in) override;
-   virtual void SaveState(FileStreamOut& out) override;
+   void LoadLayout(const ofxJSONElement& moduleInfo) override;
+   void SetUpFromSaveData() override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   void SaveState(FileStreamOut& out) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -326,29 +326,23 @@ void Prefab::SetUpFromSaveData()
 {
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void Prefab::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
    out << mPrefabName;
 }
 
-void Prefab::LoadState(FileStreamIn& in)
+void Prefab::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mPrefabName;
 }

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -328,6 +328,8 @@ void Prefab::SetUpFromSaveData()
 
 void Prefab::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mPrefabName;

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -55,7 +55,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -453,6 +453,8 @@ void Presets::SetUpFromSaveData()
 
 void Presets::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << (int)mPresetCollection.size();

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -451,16 +451,9 @@ void Presets::SetUpFromSaveData()
    SetGridSize(mModuleSaveData.GetFloat("gridwidth"), mModuleSaveData.GetFloat("gridheight"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Presets::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << (int)mPresetCollection.size();
    for (auto& coll : mPresetCollection)
@@ -491,13 +484,13 @@ void Presets::SaveState(FileStreamOut& out)
       out << control->Path();
 }
 
-void Presets::LoadState(FileStreamIn& in)
+void Presets::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int collSize;
    in >> collSize;

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -67,7 +67,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 
    static std::vector<IUIControl*> sPresetHighlightControls;

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -258,28 +258,21 @@ void PulseSequence::GridUpdated(UIGrid* grid, int col, int row, float value, flo
    }
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void PulseSequence::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mVelocityGrid->SaveState(out);
    out << mHasExternalPulseSource;
 }
 
-void PulseSequence::LoadState(FileStreamIn& in)
+void PulseSequence::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mVelocityGrid->LoadState(in);
    GridUpdated(mVelocityGrid, 0, 0, 0, 0);

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -260,6 +260,8 @@ void PulseSequence::GridUpdated(UIGrid* grid, int col, int row, float value, flo
 
 void PulseSequence::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mVelocityGrid->SaveState(out);

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -82,7 +82,8 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -234,27 +234,20 @@ void PulseTrain::GridUpdated(UIGrid* grid, int col, int row, float value, float 
    }
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void PulseTrain::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mVelocityGrid->SaveState(out);
 }
 
-void PulseTrain::LoadState(FileStreamIn& in)
+void PulseTrain::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mVelocityGrid->LoadState(in);
    GridUpdated(mVelocityGrid, 0, 0, 0, 0);

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -236,6 +236,8 @@ void PulseTrain::GridUpdated(UIGrid* grid, int col, int row, float value, float 
 
 void PulseTrain::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mVelocityGrid->SaveState(out);

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -74,7 +74,8 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/Pumper.cpp
+++ b/Source/Pumper.cpp
@@ -26,6 +26,7 @@
 #include "Pumper.h"
 #include "Profiler.h"
 #include "UIControlMacros.h"
+#include "ModularSynth.h"
 
 namespace
 {
@@ -185,27 +186,20 @@ void Pumper::SyncToAdsr()
    mAttack = mAdsr.GetStageData(0).time / kAdsrTime;
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Pumper::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mAdsr.SaveState(out);
 }
 
-void Pumper::LoadState(FileStreamIn& in)
+void Pumper::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mAdsr.LoadState(in);
 

--- a/Source/Pumper.cpp
+++ b/Source/Pumper.cpp
@@ -188,6 +188,8 @@ void Pumper::SyncToAdsr()
 
 void Pumper::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAdsr.SaveState(out);

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -55,7 +55,8 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -384,7 +384,7 @@ void RadioButton::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    float var;
    in >> var;

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -347,14 +347,9 @@ void RadioSequencer::SetUpFromSaveData()
    mGrid->SetSingleColumnMode(mModuleSaveData.GetBool("one_per_column_mode"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void RadioSequencer::SaveState(FileStreamOut& out)
 {
-   out << kSaveStateRev;
+   out << GetModuleSaveStateRev();
 
    IDrawableModule::SaveState(out);
 
@@ -372,22 +367,22 @@ void RadioSequencer::SaveState(FileStreamOut& out)
    out << mGrid->GetHeight();
 }
 
-void RadioSequencer::LoadState(FileStreamIn& in)
+void RadioSequencer::LoadState(FileStreamIn& in, int rev)
 {
    mLoadRev = -1;
 
-   if (ModularSynth::sLoadingFileSaveStateRev >= 422)
+   if (ModularSynth::sLoadingFileSaveStateRev == 422)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= GetModuleSaveStateRev());
    }
 
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (ModularSynth::sLoadingFileSaveStateRev <= 421)
    {
       in >> mLoadRev;
-      LoadStateValidate(mLoadRev <= kSaveStateRev);
+      LoadStateValidate(mLoadRev <= GetModuleSaveStateRev());
    }
 
    int size;

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -369,7 +369,7 @@ void RadioSequencer::SaveState(FileStreamOut& out)
 
 void RadioSequencer::LoadState(FileStreamIn& in, int rev)
 {
-   mLoadRev = -1;
+   mLoadRev = rev;
 
    if (ModularSynth::sLoadingFileSaveStateRev == 422)
    {

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -89,7 +89,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
    bool LoadOldControl(FileStreamIn& in, std::string& oldName) override;
 
    //IPatchable

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -240,27 +240,20 @@ void SampleBrowser::SetUpFromSaveData()
 {
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void SampleBrowser::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    out << mCurrentDirectory.toStdString();
 }
 
-void SampleBrowser::LoadState(FileStreamIn& in)
+void SampleBrowser::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    std::string currentDirectory;
    in >> currentDirectory;

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -242,6 +242,8 @@ void SampleBrowser::SetUpFromSaveData()
 
 void SampleBrowser::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mCurrentDirectory.toStdString();

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -47,7 +47,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -283,31 +283,24 @@ void SampleCanvas::SetUpFromSaveData()
    mCanvas->SetNumRows(mModuleSaveData.GetInt("rows"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void SampleCanvas::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mCanvas->GetWidth();
    out << mCanvas->GetHeight();
 }
 
-void SampleCanvas::LoadState(FileStreamIn& in)
+void SampleCanvas::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    float w, h;
    in >> w;

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -285,6 +285,8 @@ void SampleCanvas::SetUpFromSaveData()
 
 void SampleCanvas::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mCanvas->GetWidth();

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -71,7 +71,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -276,28 +276,21 @@ void SampleCapturer::SetUpFromSaveData()
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void SampleCapturer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    for (int i = 0; i < mSamples.size(); ++i)
       mSamples[i].mBuffer.Save(out, mSamples[i].mBuffer.BufferSize());
 }
 
-void SampleCapturer::LoadState(FileStreamIn& in)
+void SampleCapturer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    int readLength;
    for (int i = 0; i < mSamples.size(); ++i)

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -278,6 +278,8 @@ void SampleCapturer::SetUpFromSaveData()
 
 void SampleCapturer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    for (int i = 0; i < mSamples.size(); ++i)

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -52,7 +52,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1403,6 +1403,8 @@ void SamplePlayer::SetUpFromSaveData()
 
 void SamplePlayer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    bool hasSample = (mSample != nullptr);

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1401,16 +1401,9 @@ void SamplePlayer::SetUpFromSaveData()
    Resize(mModuleSaveData.GetFloat("width"), mModuleSaveData.GetFloat("height"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void SamplePlayer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    bool hasSample = (mSample != nullptr);
    out << hasSample;
@@ -1427,13 +1420,13 @@ void SamplePlayer::SaveState(FileStreamOut& out)
    }
 }
 
-void SamplePlayer::LoadState(FileStreamIn& in)
+void SamplePlayer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    bool hasSample;
    in >> hasSample;

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -97,7 +97,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
 private:

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -314,28 +314,21 @@ void Sampler::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Sampler::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out.Write(mSampleData, MAX_SAMPLER_LENGTH);
    out << mVoiceParams.mSampleLength;
 }
 
-void Sampler::LoadState(FileStreamIn& in)
+void Sampler::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in.Read(mSampleData, MAX_SAMPLER_LENGTH);
 

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -316,6 +316,8 @@ void Sampler::CheckboxUpdated(Checkbox* checkbox)
 
 void Sampler::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out.Write(mSampleData, MAX_SAMPLER_LENGTH);

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -78,7 +78,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    void StopRecording();

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -443,6 +443,8 @@ void SamplerGrid::CheckboxUpdated(Checkbox* checkbox)
 
 void SamplerGrid::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    for (int i = 0; i < mCols * mRows; ++i)

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -441,16 +441,9 @@ void SamplerGrid::CheckboxUpdated(Checkbox* checkbox)
 {
 }
 
-namespace
-{
-   const int kSaveStateRev = 0;
-}
-
 void SamplerGrid::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    for (int i = 0; i < mCols * mRows; ++i)
    {
@@ -464,13 +457,13 @@ void SamplerGrid::SaveState(FileStreamOut& out)
    }
 }
 
-void SamplerGrid::LoadState(FileStreamIn& in)
+void SamplerGrid::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    //LoadStateValidate(false); //TODO(Ryan) temp hack fix because samplergrid was loading funny
 

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -86,7 +86,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 0; }
 
 private:
    //IDrawableModule

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -755,6 +755,8 @@ void Scale::SetUpFromSaveData()
 
 void Scale::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mIntonation;

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -753,32 +753,25 @@ void Scale::SetUpFromSaveData()
       mWantSetRandomRootAndScale = true;
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Scale::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mIntonation;
    out << mSclContents;
    out << mKbmContents;
 }
 
-void Scale::LoadState(FileStreamIn& in)
+void Scale::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev >= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev >= GetModuleSaveStateRev());
 
    int inton;
    in >> inton;

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -139,7 +139,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    struct ScaleInfo

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1470,17 +1470,11 @@ void ScriptModule::SaveLayout(ofxJSONElement& moduleInfo)
    IDrawableModule::SaveLayout(moduleInfo);
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void ScriptModule::SaveState(FileStreamOut& out)
 {
    if (!CanSaveState())
       return;
 
-   out << kSaveStateRev;
    out << (int)mExtraNoteOutputs.size();
 
    IDrawableModule::SaveState(out);
@@ -1489,14 +1483,12 @@ void ScriptModule::SaveState(FileStreamOut& out)
    out << mHeight;
 }
 
-void ScriptModule::LoadState(FileStreamIn& in)
+void ScriptModule::LoadState(FileStreamIn& in, int rev)
 {
-   int rev = -1;
-
-   if (ModularSynth::sLoadingFileSaveStateRev >= 421)
+   if (ModularSynth::sLoadingFileSaveStateRev >= 421 && ModularSynth::sLoadingFileSaveStateRev < 423)
    {
       in >> rev;
-      LoadStateValidate(rev <= kSaveStateRev);
+      LoadStateValidate(rev <= GetModuleSaveStateRev());
    }
 
    if (rev >= 2)
@@ -1506,12 +1498,12 @@ void ScriptModule::LoadState(FileStreamIn& in)
       SetNumNoteOutputs(extraNoteOutputs + 1);
    }
 
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
    if (ModularSynth::sLoadingFileSaveStateRev == 420)
    {
       in >> rev;
-      LoadStateValidate(rev <= kSaveStateRev);
+      LoadStateValidate(rev <= GetModuleSaveStateRev());
    }
 
    float w, h;

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1472,8 +1472,7 @@ void ScriptModule::SaveLayout(ofxJSONElement& moduleInfo)
 
 void ScriptModule::SaveState(FileStreamOut& out)
 {
-   if (!CanSaveState())
-      return;
+   out << GetModuleSaveStateRev();
 
    out << (int)mExtraNoteOutputs.size();
 

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -95,7 +95,8 @@ public:
    bool HasDebugDraw() const override { return true; }
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/ScriptStatus.cpp
+++ b/Source/ScriptStatus.cpp
@@ -129,28 +129,21 @@ void ScriptStatus::SaveLayout(ofxJSONElement& moduleInfo)
    IDrawableModule::SaveLayout(moduleInfo);
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void ScriptStatus::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mWidth;
    out << mHeight;
 }
 
-void ScriptStatus::LoadState(FileStreamIn& in)
+void ScriptStatus::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    in >> mWidth;
    in >> mHeight;

--- a/Source/ScriptStatus.cpp
+++ b/Source/ScriptStatus.cpp
@@ -131,6 +131,8 @@ void ScriptStatus::SaveLayout(ofxJSONElement& moduleInfo)
 
 void ScriptStatus::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mWidth;

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -50,7 +50,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -381,16 +381,9 @@ void SeaOfGrain::SetUpFromSaveData()
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void SeaOfGrain::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    out << mHasRecordedInput;
    if (mHasRecordedInput)
@@ -399,13 +392,13 @@ void SeaOfGrain::SaveState(FileStreamOut& out)
       mSample->SaveState(out);
 }
 
-void SeaOfGrain::LoadState(FileStreamIn& in)
+void SeaOfGrain::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mHasRecordedInput = false;
    if (rev > 0)

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -383,6 +383,8 @@ void SeaOfGrain::SetUpFromSaveData()
 
 void SeaOfGrain::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mHasRecordedInput;

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -84,7 +84,8 @@ public:
    virtual void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    void UpdateSample();

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -773,7 +773,7 @@ void FloatSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
          }
          else if (rev > 0)
          {
-            mLFOControl->LoadState(in);
+            mLFOControl->LoadState(in, mLFOControl->LoadModuleSaveStateRev(in));
          }
          if (shouldSetValue)
             lfo->UpdateFromSettings();
@@ -818,7 +818,7 @@ void FloatSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
          }
          else if (rev > 0)
          {
-            mLFOControl->LoadState(in);
+            mLFOControl->LoadState(in, mLFOControl->LoadModuleSaveStateRev(in));
          }
          if (shouldSetValue)
             lfo->UpdateFromSettings();
@@ -1199,7 +1199,7 @@ void IntSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kIntSliderSaveStateRev);
+   LoadStateValidate(rev <= kIntSliderSaveStateRev);
 
    float var;
    in >> var;

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -1046,16 +1046,9 @@ void StepSequencer::SetUpFromSaveData()
    mIsSetUp = true;
 }
 
-namespace
-{
-   const int kSaveStateRev = 3;
-}
-
 void StepSequencer::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 
    mGrid->SaveState(out);
 
@@ -1069,13 +1062,13 @@ void StepSequencer::SaveState(FileStreamOut& out)
    out << mGrid->GetHeight();
 }
 
-void StepSequencer::LoadState(FileStreamIn& in)
+void StepSequencer::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mGrid->LoadState(in);
 

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -1048,6 +1048,8 @@ void StepSequencer::SetUpFromSaveData()
 
 void StepSequencer::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mGrid->SaveState(out);

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -178,7 +178,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 3; }
 
 private:
    //IDrawableModule

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -703,7 +703,7 @@ void TextEntry::LoadState(FileStreamIn& in, bool shouldSetValue)
 {
    int rev;
    in >> rev;
-   LoadStateValidate(rev == kSaveStateRev);
+   LoadStateValidate(rev <= kSaveStateRev);
 
    std::string var;
    in >> var;

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -675,27 +675,20 @@ void Transport::SetUpFromSaveData()
       mWantSetRandomTempo = true;
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void Transport::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    out << mMeasureTime;
 }
 
-void Transport::LoadState(FileStreamIn& in)
+void Transport::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    if (rev == 0) //load as float instead of double
    {

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -677,6 +677,8 @@ void Transport::SetUpFromSaveData()
 
 void Transport::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    out << mMeasureTime;

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -166,7 +166,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    static bool sDoEventLookahead;
    static double sEventEarlyMs;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -1014,6 +1014,8 @@ void VSTPlugin::SetUpFromSaveData()
 
 void VSTPlugin::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    if (mPlugin)

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -799,11 +799,6 @@ std::vector<IUIControl*> VSTPlugin::ControlsToIgnoreInSaveState() const
    return ignore;
 }
 
-namespace
-{
-   const int kSaveStateRev = 2;
-}
-
 void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal)
 {
    if (list == mPresetFileSelector)
@@ -919,7 +914,7 @@ void VSTPlugin::ButtonClicked(ClickButton* button)
             juce::MemoryBlock vstProgramState;
             mPlugin->getCurrentProgramStateInformation(vstProgramState);
 
-            output.writeInt(kSaveStateRev);
+            output.writeInt(GetModuleSaveStateRev());
             output.writeInt64(vstState.getSize());
             output.write(vstState.getData(), vstState.getSize());
             output.writeInt64(vstProgramState.getSize());
@@ -1021,8 +1016,6 @@ void VSTPlugin::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    if (mPlugin)
    {
       out << true;
@@ -1053,13 +1046,13 @@ void VSTPlugin::SaveState(FileStreamOut& out)
    }
 }
 
-void VSTPlugin::LoadState(FileStreamIn& in)
+void VSTPlugin::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    bool hasPlugin;
    in >> hasPlugin;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -94,7 +94,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 2; }
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
 private:

--- a/Source/ValueStream.cpp
+++ b/Source/ValueStream.cpp
@@ -161,6 +161,8 @@ void ValueStream::SetUpFromSaveData()
 
 void ValueStream::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 }
 

--- a/Source/ValueStream.cpp
+++ b/Source/ValueStream.cpp
@@ -159,23 +159,16 @@ void ValueStream::SetUpFromSaveData()
    mHeight = mModuleSaveData.GetInt("height");
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void ValueStream::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
-
-   out << kSaveStateRev;
 }
 
-void ValueStream::LoadState(FileStreamIn& in)
+void ValueStream::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 }

--- a/Source/ValueStream.h
+++ b/Source/ValueStream.h
@@ -62,7 +62,8 @@ public:
    void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/VelocityCurve.cpp
+++ b/Source/VelocityCurve.cpp
@@ -132,6 +132,8 @@ void VelocityCurve::SetUpFromSaveData()
 
 void VelocityCurve::SaveState(FileStreamOut& out)
 {
+   out << GetModuleSaveStateRev();
+
    IDrawableModule::SaveState(out);
 
    mAdsr.SaveState(out);

--- a/Source/VelocityCurve.cpp
+++ b/Source/VelocityCurve.cpp
@@ -130,27 +130,20 @@ void VelocityCurve::SetUpFromSaveData()
    SetUpPatchCables(mModuleSaveData.GetString("target"));
 }
 
-namespace
-{
-   const int kSaveStateRev = 1;
-}
-
 void VelocityCurve::SaveState(FileStreamOut& out)
 {
    IDrawableModule::SaveState(out);
 
-   out << kSaveStateRev;
-
    mAdsr.SaveState(out);
 }
 
-void VelocityCurve::LoadState(FileStreamIn& in)
+void VelocityCurve::LoadState(FileStreamIn& in, int rev)
 {
-   IDrawableModule::LoadState(in);
+   IDrawableModule::LoadState(in, rev);
 
-   int rev;
-   in >> rev;
-   LoadStateValidate(rev <= kSaveStateRev);
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 
    mAdsr.LoadState(in);
 }

--- a/Source/VelocityCurve.h
+++ b/Source/VelocityCurve.h
@@ -51,7 +51,8 @@ public:
    virtual void SetUpFromSaveData() override;
 
    void SaveState(FileStreamOut& out) override;
-   void LoadState(FileStreamIn& in) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    //IDrawableModule


### PR DESCRIPTION
this will make it way easier to solve issues where, when a module's version changes, I need to fix up a module's basic contents (ui controls, patch cables, etc) in its `LoadState()` before the base `IDrawableModule::LoadState()` is called

most immediately, this will allow me to fix a `VSTPlugin` issue where the existence of FloatSliders for each parameter is necessary in order for state to load properly. that fix is forthcoming, after this one is merged

also, this change fixes a crash when loading older save files that contained prefabs with radiosequencers or controlsequencers inside