### PR TITLE
distinguish "value setter"-style modulators from the continuous ones

### DIFF
--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -289,7 +289,7 @@ void ADSRDisplay::UpdateSliderVisibility()
       if (sDisplayMode == kDisplaySliders)
          slidersActive = true;
       if (PatchCable::sActivePatchCable != nullptr &&
-          (PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_Modulator || PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_UIControl))
+          (PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_Modulator || PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_ValueSetter || PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_UIControl))
          slidersActive = true;
    }
    if (mASlider && mASlider->GetModulator() != nullptr && mASlider->GetModulator()->Active())

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -51,7 +51,7 @@ public:
    void CreateUIControls() override;
    void Init() override;
 
-   IUIControl* GetUIControl() const { return mUIControl; }
+   IUIControl* GetUIControl() const { return mTargets.size() == 0 ? nullptr : mTargets[0]; }
 
    //IGridListener
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
@@ -109,7 +109,7 @@ private:
    void MouseReleased() override;
 
    UIGrid* mGrid{ nullptr };
-   IUIControl* mUIControl{ nullptr };
+   std::array<IUIControl*, IDrawableModule::kMaxOutputsPerPatchCableSource> mTargets{};
    NoteInterval mInterval{ kInterval_4n };
    DropdownList* mIntervalSelector{ nullptr };
    int mLength{ 8 };

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -301,7 +301,7 @@ void EventCanvas::SyncControlCablesToCanvas()
       for (int i = oldSize; i < mControlCables.size(); ++i)
       {
          mControlCables[i] = new PatchCableSource(this, kConnectionType_UIControl);
-         mControlCables[i]->SetOverrideCableDir(ofVec2f(1, 0));
+         mControlCables[i]->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
          mControlCables[i]->SetColor(GetRowColor(i));
          AddPatchCableSource(mControlCables[i]);
       }

--- a/Source/FeedbackModule.cpp
+++ b/Source/FeedbackModule.cpp
@@ -47,7 +47,7 @@ void FeedbackModule::CreateUIControls()
 
    mFeedbackTargetCable = new PatchCableSource(this, kConnectionType_Audio);
    mFeedbackTargetCable->SetManualPosition(108, 8);
-   mFeedbackTargetCable->SetOverrideCableDir(ofVec2f(1, 0));
+   mFeedbackTargetCable->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
    mFeedbackTargetCable->SetOverrideVizBuffer(&mFeedbackVizBuffer);
    AddPatchCableSource(mFeedbackTargetCable);
 

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -296,23 +296,23 @@ void FubbleModule::DrawModule()
    if (mAxisH.GetCableSource()->GetTarget() && mAxisH.GetCableSource()->GetTarget()->GetRect().getCenter().x < GetRect().getCenter().x)
    {
       mAxisH.GetCableSource()->SetManualPosition(leftAlign, mHeight - (kBottomControlHeight + kTimelineSectionHeight) + 13);
-      mAxisH.GetCableSource()->SetOverrideCableDir(ofVec2f(-1, 0));
+      mAxisH.GetCableSource()->SetOverrideCableDir(ofVec2f(-1, 0), PatchCableSource::Side::kLeft);
    }
    else
    {
       mAxisH.GetCableSource()->SetManualPosition(rightAlign, mHeight - (kBottomControlHeight + kTimelineSectionHeight) + 13);
-      mAxisH.GetCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+      mAxisH.GetCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
    }
 
    if (mAxisV.GetCableSource()->GetTarget() && mAxisV.GetCableSource()->GetTarget()->GetRect().getCenter().x < GetRect().getCenter().x)
    {
       mAxisV.GetCableSource()->SetManualPosition(leftAlign, mHeight - (kBottomControlHeight + kTimelineSectionHeight) + 38);
-      mAxisV.GetCableSource()->SetOverrideCableDir(ofVec2f(-1, 0));
+      mAxisV.GetCableSource()->SetOverrideCableDir(ofVec2f(-1, 0), PatchCableSource::Side::kLeft);
    }
    else
    {
       mAxisV.GetCableSource()->SetManualPosition(rightAlign, mHeight - (kBottomControlHeight + kTimelineSectionHeight) + 38);
-      mAxisV.GetCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+      mAxisV.GetCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
    }
 }
 

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -53,8 +53,9 @@ void GridSliders::CreateUIControls()
 
    for (size_t i = 0; i < mControlCables.size(); ++i)
    {
-      mControlCables[i] = new PatchCableSource(this, kConnectionType_Modulator);
+      mControlCables[i] = new PatchCableSource(this, kConnectionType_ValueSetter);
       mControlCables[i]->SetManualPosition(i * 12 + 8, 28);
+      mControlCables[i]->SetManualSide(PatchCableSource::Side::kBottom);
       AddPatchCableSource(mControlCables[i]);
    }
 }
@@ -128,7 +129,8 @@ void GridSliders::OnGridButton(int x, int y, float velocity, IGridController* gr
       if (sliderIndex < mControlCables.size() && mControlCables[sliderIndex]->GetTarget())
       {
          float value = squareIndex / float(length - 1);
-         dynamic_cast<IUIControl*>(mControlCables[sliderIndex]->GetTarget())->SetFromMidiCC(value);
+         for (auto& cable : mControlCables[sliderIndex]->GetPatchCables())
+            dynamic_cast<IUIControl*>(cable->GetTarget())->SetFromMidiCC(value);
       }
    }
 }

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -272,7 +272,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
    }
 
    if (PatchCable::sActivePatchCable &&
-       (PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_Modulator && PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_UIControl) &&
+       (PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_Modulator && PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_UIControl && PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_ValueSetter) &&
        !PatchCable::sActivePatchCable->IsValidTarget(this))
    {
       dimModule = true;

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -195,6 +195,8 @@ public:
 
    bool mDrawDebug;
 
+   static constexpr int kMaxOutputsPerPatchCableSource = 32;
+
 protected:
    void Poll() override {}
    void OnClicked(int x, int y, bool right) override;

--- a/Source/IUIControl.cpp
+++ b/Source/IUIControl.cpp
@@ -136,6 +136,7 @@ void IUIControl::DrawPatchCableHover()
 {
    if (PatchCable::sActivePatchCable &&
        (PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_Modulator ||
+        PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_ValueSetter ||
         PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_UIControl ||
         PatchCable::sActivePatchCable->GetConnectionType() == kConnectionType_Grid) &&
        PatchCable::sActivePatchCable->IsValidTarget(this))
@@ -153,7 +154,7 @@ void IUIControl::DrawPatchCableHover()
 
 bool IUIControl::CanBeTargetedBy(PatchCableSource* source) const
 {
-   return source->GetConnectionType() == kConnectionType_Modulator || source->GetConnectionType() == kConnectionType_UIControl;
+   return source->GetConnectionType() == kConnectionType_Modulator || source->GetConnectionType() == kConnectionType_ValueSetter || source->GetConnectionType() == kConnectionType_UIControl;
 }
 
 void IUIControl::StartBeacon()

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -246,7 +246,7 @@ void LooperRecorder::SyncCablesToLoopers()
             looper = mLoopers[i];
          mLooperPatchCables[i]->SetTarget(looper);
          mLooperPatchCables[i]->SetManualPosition(160 + i * 12, 117);
-         mLooperPatchCables[i]->SetOverrideCableDir(ofVec2f(0, 1));
+         mLooperPatchCables[i]->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
          ofColor color = mLooperPatchCables[i]->GetColor();
          color.a *= .3f;
          mLooperPatchCables[i]->SetColor(color);

--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -153,7 +153,7 @@ void MacroSlider::Mapping::CreateUIControls()
    mTargetCable = new PatchCableSource(mOwner, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    mTargetCable->SetManualPosition(110, 39 + mIndex * kMappingSpacing);
-   mTargetCable->SetOverrideCableDir(ofVec2f(1, 0));
+   mTargetCable->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
    mOwner->AddPatchCableSource(mTargetCable);
 }
 

--- a/Source/NoteEcho.cpp
+++ b/Source/NoteEcho.cpp
@@ -48,7 +48,7 @@ void NoteEcho::CreateUIControls()
       FLOATSLIDER(mDelaySlider[i], ("delay " + ofToString(i)).c_str(), &mDelay[i], 0, 1);
       mDestinationCables[i] = new AdditionalNoteCable();
       mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
       AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
       ofRectangle rect = mDelaySlider[i]->GetRect(true);
       mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height / 2);

--- a/Source/NoteExpressionRouter.cpp
+++ b/Source/NoteExpressionRouter.cpp
@@ -54,7 +54,7 @@ void NoteExpressionRouter::CreateUIControls()
       TEXTENTRY(mExpressionWidget[i], ("expression" + ofToString(i)).c_str(), 30, mExpressionText[i]);
       mDestinationCables[i] = new AdditionalNoteCable();
       mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
       AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
       ofRectangle rect = mExpressionWidget[i]->GetRect(true);
       mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height / 2);

--- a/Source/NoteHocket.cpp
+++ b/Source/NoteHocket.cpp
@@ -212,7 +212,7 @@ void NoteHocket::SetUpFromSaveData()
       {
          mDestinationCables.push_back(new AdditionalNoteCable());
          mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-         mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+         mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
          AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
          ofRectangle rect = mWeightSlider[i]->GetRect(true);
          mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height / 2);

--- a/Source/NoteSorter.cpp
+++ b/Source/NoteSorter.cpp
@@ -48,7 +48,7 @@ void NoteSorter::CreateUIControls()
       TEXTENTRY_NUM(mPitchEntry[i], ("pitch " + ofToString(i)).c_str(), 4, &mPitch[i], -1, 127);
       mDestinationCables[i] = new AdditionalNoteCable();
       mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
       AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
       ofRectangle rect = mPitchEntry[i]->GetRect(true);
       mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height / 2);

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -189,7 +189,7 @@ void NoteStepSequencer::CreateUIControls()
    {
       mStepCables[i] = new AdditionalNoteCable();
       mStepCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mStepCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1));
+      mStepCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
       AddPatchCableSource(mStepCables[i]->GetPatchCableSource());
    }
 }

--- a/Source/NoteStepper.cpp
+++ b/Source/NoteStepper.cpp
@@ -52,7 +52,7 @@ void NoteStepper::CreateUIControls()
    {
       mDestinationCables[i] = new AdditionalNoteCable();
       mDestinationCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1));
+      mDestinationCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
       AddPatchCableSource(mDestinationCables[i]->GetPatchCableSource());
       mDestinationCables[i]->GetPatchCableSource()->SetManualPosition(10 + i * 15, mHeight - 8);
    }

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -106,7 +106,7 @@ void NoteTable::CreateUIControls()
    {
       mColumnCables[i] = new AdditionalNoteCable();
       mColumnCables[i]->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      mColumnCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1));
+      mColumnCables[i]->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
       AddPatchCableSource(mColumnCables[i]->GetPatchCableSource());
    }
 }

--- a/Source/NoteToggle.cpp
+++ b/Source/NoteToggle.cpp
@@ -39,7 +39,7 @@ void NoteToggle::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
 
-   mControlCable = new PatchCableSource(this, kConnectionType_Modulator);
+   mControlCable = new PatchCableSource(this, kConnectionType_ValueSetter);
    AddPatchCableSource(mControlCable);
 }
 
@@ -51,7 +51,13 @@ void NoteToggle::DrawModule()
 
 void NoteToggle::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
 {
-   mControlTarget = dynamic_cast<IUIControl*>(cableSource->GetTarget());
+   for (size_t i = 0; i < mTargets.size(); ++i)
+   {
+      if (i < mControlCable->GetPatchCables().size())
+         mTargets[i] = dynamic_cast<IUIControl*>(mControlCable->GetPatchCables()[i]->GetTarget());
+      else
+         mTargets[i] = nullptr;
+   }
 }
 
 void NoteToggle::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -66,8 +72,11 @@ void NoteToggle::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
          hasHeldNotes = true;
    }
 
-   if (mControlTarget)
-      mControlTarget->SetValue(hasHeldNotes ? 1 : 0);
+   for (size_t i = 0; i < mTargets.size(); ++i)
+   {
+      if (mTargets[i] != nullptr)
+         mTargets[i]->SetValue(hasHeldNotes ? 1 : 0);
+   }
 }
 
 void NoteToggle::GetModuleDimensions(float& width, float& height)

--- a/Source/NoteToggle.h
+++ b/Source/NoteToggle.h
@@ -57,5 +57,5 @@ private:
 
    std::array<bool, 128> mHeldPitches{ false };
    PatchCableSource* mControlCable;
-   IUIControl* mControlTarget;
+   std::array<IUIControl*, IDrawableModule::kMaxOutputsPerPatchCableSource> mTargets{};
 };

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -94,6 +94,7 @@ void PatchCable::Render()
           GetConnectionType() == kConnectionType_Grid ||
           GetConnectionType() == kConnectionType_Pulse ||
           GetConnectionType() == kConnectionType_Modulator ||
+          GetConnectionType() == kConnectionType_ValueSetter ||
           GetConnectionType() == kConnectionType_UIControl)
       {
          bool hasNote = false;
@@ -203,6 +204,7 @@ void PatchCable::Render()
           type == kConnectionType_Grid ||
           type == kConnectionType_Pulse ||
           type == kConnectionType_Modulator ||
+          type == kConnectionType_ValueSetter ||
           type == kConnectionType_UIControl)
       {
          ofSetLineWidth(lineWidth);
@@ -498,7 +500,7 @@ IClickable* PatchCable::GetDropTarget()
    {
       PatchCablePos cable = GetPatchCablePos();
       IClickable* potentialTarget = TheSynth->GetRootContainer()->GetModuleAt(cable.end.x, cable.end.y);
-      if (potentialTarget && (GetConnectionType() == kConnectionType_Modulator || GetConnectionType() == kConnectionType_Grid || GetConnectionType() == kConnectionType_UIControl))
+      if (potentialTarget && (GetConnectionType() == kConnectionType_Modulator || GetConnectionType() == kConnectionType_ValueSetter || GetConnectionType() == kConnectionType_Grid || GetConnectionType() == kConnectionType_UIControl))
       {
          const auto& uicontrols = (static_cast<IDrawableModule*>(potentialTarget))->GetUIControls();
          for (auto uicontrol : uicontrols)

--- a/Source/PatchCable.h
+++ b/Source/PatchCable.h
@@ -50,7 +50,8 @@ enum ConnectionType
    kConnectionType_Grid,
    kConnectionType_Special,
    kConnectionType_Pulse,
-   kConnectionType_Modulator
+   kConnectionType_Modulator,
+   kConnectionType_ValueSetter //for modulator-type that don't have a continuous connection to the control, and just set values as one-offs
 };
 
 class PatchCable : public IClickable

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -63,7 +63,7 @@ PatchCableSource::PatchCableSource(IDrawableModule* owner, ConnectionType type)
 , mDrawPass(DrawPass::kSource)
 , mParentMinimized(false)
 {
-   mAllowMultipleTargets = (mType == kConnectionType_Note || mType == kConnectionType_Pulse || mType == kConnectionType_Audio || mType == kConnectionType_Modulator);
+   mAllowMultipleTargets = (mType == kConnectionType_Note || mType == kConnectionType_Pulse || mType == kConnectionType_Audio || mType == kConnectionType_Modulator || mType == kConnectionType_ValueSetter);
    SetConnectionType(type);
 }
 
@@ -83,6 +83,12 @@ void PatchCableSource::SetConnectionType(ConnectionType type)
       mColor = IDrawableModule::GetColor(kModuleType_Audio);
    else if (mType == kConnectionType_Modulator)
       mColor = IDrawableModule::GetColor(kModuleType_Modulator);
+   else if (mType == kConnectionType_ValueSetter)
+   {
+      mColor = IDrawableModule::GetColor(kModuleType_Modulator);
+      mColor.setSaturation(mColor.getSaturation() * .6f);
+      mColor.setBrightness(mColor.getBrightness() * .7f);
+   }
    else if (mType == kConnectionType_Pulse)
       mColor = IDrawableModule::GetColor(kModuleType_Pulse);
    else
@@ -360,7 +366,7 @@ void PatchCableSource::Render()
             cableY += kPatchCableSpacing;
          else if (mSide == Side::kLeft)
             cableX -= kPatchCableSpacing;
-         else if (mSide == Side::kRight)
+         else if (mSide == Side::kRight || mSide == Side::kNone)
             cableX += kPatchCableSpacing;
       }
    }
@@ -379,7 +385,7 @@ ofVec2f PatchCableSource::GetCableStart(int index) const
          cableY += kPatchCableSpacing * index;
       else if (mSide == Side::kLeft)
          cableX -= kPatchCableSpacing * index;
-      else if (mSide == Side::kRight)
+      else if (mSide == Side::kRight || mSide == Side::kNone)
          cableX += kPatchCableSpacing * index;
    }
 
@@ -514,10 +520,12 @@ bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = fa
                 mType == kConnectionType_Note ||
                 mType == kConnectionType_Pulse ||
                 mType == kConnectionType_UIControl ||
-                mType == kConnectionType_Special)
+                mType == kConnectionType_Special ||
+                mType == kConnectionType_ValueSetter)
             {
                PatchCable* newCable = AddPatchCable(nullptr);
-               newCable->Grab();
+               if (newCable)
+                  newCable->Grab();
             }
             else if (mType == kConnectionType_Audio)
             {
@@ -580,7 +588,7 @@ int PatchCableSource::GetHoverIndex(float x, float y) const
          cableY += kPatchCableSpacing;
       else if (mSide == Side::kLeft)
          cableX -= kPatchCableSpacing;
-      else if (mSide == Side::kRight)
+      else if (mSide == Side::kRight || mSide == Side::kNone)
          cableX += kPatchCableSpacing;
    }
 
@@ -615,7 +623,7 @@ void PatchCableSource::FindValidTargets()
    TheSynth->GetAllModules(allModules);
    for (auto module : allModules)
    {
-      if ((mType == kConnectionType_Modulator || mType == kConnectionType_UIControl || mType == kConnectionType_Grid) && module != TheTitleBar)
+      if ((mType == kConnectionType_Modulator || mType == kConnectionType_ValueSetter || mType == kConnectionType_UIControl || mType == kConnectionType_Grid) && module != TheTitleBar)
       {
          for (auto uicontrol : module->GetUIControls())
          {

--- a/Source/PatchCableSource.h
+++ b/Source/PatchCableSource.h
@@ -124,10 +124,11 @@ public:
    void SetManualSide(Side side) { mManualSide = side; }
    void SetClickable(bool clickable) { mClickable = clickable; }
    bool TestHover(float x, float y) const;
-   void SetOverrideCableDir(ofVec2f dir)
+   void SetOverrideCableDir(ofVec2f dir, Side side)
    {
       mHasOverrideCableDir = true;
       mOverrideCableDir = dir;
+      mManualSide = side;
    }
    ofVec2f GetCableStart(int index) const;
    ofVec2f GetCableStartDir(int index, ofVec2f dest) const;

--- a/Source/PulseHocket.cpp
+++ b/Source/PulseHocket.cpp
@@ -173,7 +173,7 @@ void PulseHocket::SetUpFromSaveData()
       for (int i = oldNumItems; i < mNumDestinations; ++i)
       {
          mDestinationCables.push_back(new PatchCableSource(this, kConnectionType_Pulse));
-         mDestinationCables[i]->SetOverrideCableDir(ofVec2f(1, 0));
+         mDestinationCables[i]->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
          AddPatchCableSource(mDestinationCables[i]);
          ofRectangle rect = mWeightSlider[i]->GetRect(true);
          mDestinationCables[i]->SetManualPosition(rect.getMaxX() + 10, rect.y + rect.height / 2);

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -78,7 +78,7 @@ void PulseSequence::CreateUIControls()
    for (int i = 0; i < kIndividualStepCables; ++i)
    {
       mStepCables[i] = new PatchCableSource(this, kConnectionType_Pulse);
-      mStepCables[i]->SetOverrideCableDir(ofVec2f(0, 1));
+      mStepCables[i]->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
       AddPatchCableSource(mStepCables[i]);
    }
 }

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -75,7 +75,7 @@ void PulseTrain::CreateUIControls()
    for (int i = 0; i < kIndividualStepCables; ++i)
    {
       mStepCables[i] = new PatchCableSource(this, kConnectionType_Pulse);
-      mStepCables[i]->SetOverrideCableDir(ofVec2f(0, 1));
+      mStepCables[i]->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
       AddPatchCableSource(mStepCables[i]);
    }
 }

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -90,7 +90,7 @@ public:
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;
-   int GetModuleSaveStateRev() const override { return 1; }
+   int GetModuleSaveStateRev() const override { return 2; }
    bool LoadOldControl(FileStreamIn& in, std::string& oldName) override;
 
    //IPatchable

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -809,7 +809,7 @@ void ScriptModule::SetNumNoteOutputs(int num)
    {
       auto noteCable = new AdditionalNoteCable();
       noteCable->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-      noteCable->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(-1, 0));
+      noteCable->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(-1, 0), PatchCableSource::Side::kLeft);
       AddPatchCableSource(noteCable->GetPatchCableSource());
       noteCable->GetPatchCableSource()->SetManualPosition(0, 30 + 20 * (int)mExtraNoteOutputs.size());
       mExtraNoteOutputs.push_back(noteCable);

--- a/Source/Selector.cpp
+++ b/Source/Selector.cpp
@@ -47,7 +47,7 @@ void Selector::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
 
-   for (int i = 0; i < mControlCables.size(); ++i)
+   for (int i = 0; i < (int)mControlCables.size(); ++i)
    {
       mControlCables[i]->SetManualPosition(GetRect(true).width - 5, 3 + RadioButton::GetSpacing() * (i + .5f));
    }
@@ -57,38 +57,13 @@ void Selector::DrawModule()
 
 void Selector::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
 {
-   if (!fromUserClick)
-      return;
-
-   for (int i = 0; i < mControlCables.size(); ++i)
-   {
-      if (mControlCables[i] == cableSource)
-      {
-         if (i == mControlCables.size() - 1)
-         {
-            if (cableSource->GetTarget())
-            {
-               PatchCableSource* cable = new PatchCableSource(this, kConnectionType_Modulator);
-               AddPatchCableSource(cable);
-               mControlCables.push_back(cable);
-            }
-         }
-         else if (cableSource->GetTarget() == nullptr)
-         {
-            RemoveFromVector(cableSource, mControlCables);
-         }
-
-         SyncList();
-
-         break;
-      }
-   }
+   SyncList();
 }
 
 void Selector::SyncList()
 {
    mSelector->Clear();
-   for (int i = 0; i < mControlCables.size() - 1; ++i)
+   for (int i = 0; i < (int)mControlCables.size(); ++i)
    {
       std::string controlName = "";
       if (mControlCables[i]->GetTarget())
@@ -113,29 +88,30 @@ void Selector::SetIndex(int index)
 {
    mCurrentValue = index;
 
-   IUIControl* controlToEnable = nullptr;
-   for (int i = 0; i < mControlCables.size(); ++i)
+   std::vector<IUIControl*> controlsToEnable;
+   for (int i = 0; i < (int)mControlCables.size(); ++i)
    {
-      IUIControl* uicontrol = nullptr;
-      if (mControlCables[i]->GetTarget())
-         uicontrol = dynamic_cast<IUIControl*>(mControlCables[i]->GetTarget());
-      if (uicontrol)
+      for (auto* cable : mControlCables[i]->GetPatchCables())
       {
-         if (mCurrentValue == i)
-            controlToEnable = uicontrol;
-         else
-            uicontrol->SetValue(0);
+         IUIControl* uicontrol = dynamic_cast<IUIControl*>(cable->GetTarget());
+         if (uicontrol)
+         {
+            if (mCurrentValue == i)
+               controlsToEnable.push_back(uicontrol);
+            else
+               uicontrol->SetValue(0);
+         }
       }
    }
 
-   if (controlToEnable)
-      controlToEnable->SetValue(1);
+   for (auto* control : controlsToEnable)
+      control->SetValue(1);
 }
 
 namespace
 {
    const float extraW = 20;
-   const float extraH = 6 + RadioButton::GetSpacing();
+   const float extraH = 6;
 }
 
 void Selector::GetModuleDimensions(float& width, float& height)
@@ -144,46 +120,37 @@ void Selector::GetModuleDimensions(float& width, float& height)
    height = mSelector->GetRect().height + extraH;
 }
 
-void Selector::SaveLayout(ofxJSONElement& moduleInfo)
-{
-   IDrawableModule::SaveLayout(moduleInfo);
-
-   moduleInfo["uicontrols"].resize((unsigned int)mControlCables.size() - 1);
-   for (int i = 0; i < mControlCables.size() - 1; ++i)
-   {
-      std::string controlName = "";
-      if (mControlCables[i]->GetTarget())
-         controlName = mControlCables[i]->GetTarget()->Path();
-      moduleInfo["uicontrols"][i] = controlName;
-   }
-}
-
 void Selector::LoadLayout(const ofxJSONElement& moduleInfo)
 {
-   const Json::Value& controls = moduleInfo["uicontrols"];
+   mModuleSaveData.LoadInt("num_items", moduleInfo, 2, 1, 99, K(isTextField));
 
-   for (int i = 0; i < controls.size(); ++i)
-   {
-      std::string controlPath = controls[i].asString();
-      IUIControl* control = nullptr;
-      if (!controlPath.empty())
-         control = TheSynth->FindUIControl(controlPath);
-      PatchCableSource* cable = new PatchCableSource(this, kConnectionType_Modulator);
-      AddPatchCableSource(cable);
-      cable->SetTarget(control);
-      mControlCables.push_back(cable);
-   }
-
-   //add extra cable
-   PatchCableSource* cable = new PatchCableSource(this, kConnectionType_Modulator);
-   AddPatchCableSource(cable);
-   mControlCables.push_back(cable);
-
-   SyncList();
+   if (!moduleInfo["uicontrols"].isNull()) //handling for older revision loading
+      mModuleSaveData.SetInt("num_items", (int)moduleInfo["uicontrols"].size());
 
    SetUpFromSaveData();
 }
 
 void Selector::SetUpFromSaveData()
 {
+   int numItems = mModuleSaveData.GetInt("num_items");
+   int oldNumItems = (int)mControlCables.size();
+   if (numItems > oldNumItems)
+   {
+      for (int i = oldNumItems; i < numItems; ++i)
+      {
+         PatchCableSource* cable = new PatchCableSource(this, kConnectionType_ValueSetter);
+         AddPatchCableSource(cable);
+         mControlCables.push_back(cable);
+      }
+   }
+   else if (numItems < oldNumItems)
+   {
+      for (int i = oldNumItems - 1; i >= numItems; --i)
+      {
+         RemovePatchCableSource(mControlCables[i]);
+      }
+      mControlCables.resize(numItems);
+   }
+
+   SyncList();
 }

--- a/Source/Selector.h
+++ b/Source/Selector.h
@@ -36,7 +36,7 @@ class Selector : public IDrawableModule, public IRadioButtonListener, public INo
 {
 public:
    Selector();
-   ~Selector();
+   ~Selector() override;
    static IDrawableModule* Create() { return new Selector(); }
 
 
@@ -45,7 +45,6 @@ public:
    void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
-   void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
    //INoteReceiver

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -181,7 +181,7 @@ void VSTPlugin::CreateUIControls()
 
    mMidiOutCable = new AdditionalNoteCable();
    mMidiOutCable->SetPatchCableSource(new PatchCableSource(this, kConnectionType_Note));
-   mMidiOutCable->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0));
+   mMidiOutCable->GetPatchCableSource()->SetOverrideCableDir(ofVec2f(1, 0), PatchCableSource::Side::kRight);
    AddPatchCableSource(mMidiOutCable->GetPatchCableSource());
    mMidiOutCable->GetPatchCableSource()->SetManualPosition(206 - 10, 10);
 

--- a/Source/ValueSetter.cpp
+++ b/Source/ValueSetter.cpp
@@ -52,7 +52,7 @@ void ValueSetter::CreateUIControls()
    mValueSlider = new FloatSlider(this, "slider", entryRect.x, entryRect.y, entryRect.width, entryRect.height, &mValue, 0, 1);
    mValueSlider->SetShowing(false);
 
-   mControlCable = new PatchCableSource(this, kConnectionType_Modulator);
+   mControlCable = new PatchCableSource(this, kConnectionType_ValueSetter);
    AddPatchCableSource(mControlCable);
 }
 
@@ -68,7 +68,13 @@ void ValueSetter::DrawModule()
 
 void ValueSetter::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
 {
-   mTarget = dynamic_cast<IUIControl*>(mControlCable->GetTarget());
+   for (size_t i = 0; i < mTargets.size(); ++i)
+   {
+      if (i < mControlCable->GetPatchCables().size())
+         mTargets[i] = dynamic_cast<IUIControl*>(mControlCable->GetPatchCables()[i]->GetTarget());
+      else
+         mTargets[i] = nullptr;
+   }
 }
 
 void ValueSetter::OnPulse(double time, float velocity, int flags)
@@ -88,11 +94,13 @@ void ValueSetter::ButtonClicked(ClickButton* button)
 
 void ValueSetter::Go()
 {
-   if (mTarget)
+   mControlCable->AddHistoryEvent(gTime, true);
+   mControlCable->AddHistoryEvent(gTime + 15, false);
+
+   for (size_t i = 0; i < mTargets.size(); ++i)
    {
-      mTarget->SetValue(mValue);
-      mControlCable->AddHistoryEvent(gTime, true);
-      mControlCable->AddHistoryEvent(gTime + 15, false);
+      if (mTargets[i] != nullptr)
+         mTargets[i]->SetValue(mValue);
    }
 }
 

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -75,7 +75,7 @@ private:
    void Go();
 
    PatchCableSource* mControlCable{ nullptr };
-   IUIControl* mTarget{ nullptr };
+   std::array<IUIControl*, IDrawableModule::kMaxOutputsPerPatchCableSource> mTargets{};
    float mValue{ 0 };
    TextEntry* mValueEntry{ nullptr };
    FloatSlider* mValueSlider{ nullptr };


### PR DESCRIPTION
these new "value setters" can have multiple targets (without a macroslider) and can handle module duplication like the other cable types do