### PR TITLE
modulator/valuesetter fixes and improvements

### DIFF
--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -264,7 +264,7 @@ void ControlSequencer::GridUpdated(UIGrid* grid, int col, int row, float value, 
 
 void ControlSequencer::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
 {
-   bool wasEmpty = mControlCable->GetPatchCables().empty();
+   bool wasEmpty = (mTargets[0] == nullptr);
 
    for (size_t i = 0; i < mTargets.size(); ++i)
    {

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -43,10 +43,7 @@ public:
    ~CurveLooper();
    static IDrawableModule* Create() { return new CurveLooper(); }
 
-
    void CreateUIControls() override;
-
-   IUIControl* GetUIControl() const { return mUIControl; }
 
    void OnTransportAdvanced(float amount) override;
 
@@ -83,7 +80,7 @@ private:
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 
-   IUIControl* mUIControl;
+   std::array<IUIControl*, 16> mUIControls{ nullptr };
    int mLength;
    DropdownList* mLengthSelector;
    PatchCableSource* mControlCable;

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -126,8 +126,8 @@ bool EnvelopeModulator::MouseMoved(float x, float y)
 float EnvelopeModulator::Value(int samplesIn /*= 0*/)
 {
    ComputeSliders(samplesIn);
-   if (mTarget)
-      return ofClamp(Interp(mAdsr.Value(gTime + samplesIn * gInvSampleRateMs), GetMin(), GetMax()), mTarget->GetMin(), mTarget->GetMax());
+   if (mSliderTarget)
+      return ofClamp(Interp(mAdsr.Value(gTime + samplesIn * gInvSampleRateMs), GetMin(), GetMax()), mSliderTarget->GetMin(), mSliderTarget->GetMax());
    return 0;
 }
 

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -72,7 +72,7 @@ public:
    void SetRate(NoteInterval rate);
    void UpdateFromSettings();
    void SetOwner(FloatSlider* owner);
-   FloatSlider* GetOwner() { return mTarget; }
+   FloatSlider* GetOwner() { return mSliderTarget; }
    bool Enabled() const override { return mEnabled; }
    bool HasTitleBar() const override { return mPinned; }
 

--- a/Source/IModulator.h
+++ b/Source/IModulator.h
@@ -41,15 +41,16 @@ public:
    virtual bool Active() const = 0;
    virtual bool CanAdjustRange() const { return true; }
    virtual bool InitializeWithZeroRange() const { return false; }
-   float& GetMin() { return mTarget ? mTarget->GetModulatorMin() : mDummyMin; }
-   float& GetMax() { return mTarget ? mTarget->GetModulatorMax() : mDummyMax; }
+   float& GetMin() { return mSliderTarget ? mSliderTarget->GetModulatorMin() : mDummyMin; }
+   float& GetMax() { return mSliderTarget ? mSliderTarget->GetModulatorMax() : mDummyMax; }
    void OnModulatorRepatch();
    void Poll() override;
    float GetRecentChange() const;
+   void OnRemovedFrom(IUIControl* control);
 
 protected:
    void InitializeRange();
-   bool RequiresManualPolling() { return mUIControlTarget != nullptr && mTarget == nullptr; }
+   bool RequiresManualPolling() { return mUIControlTarget != nullptr && mSliderTarget == nullptr; }
 
    float mDummyMin;
    float mDummyMax;
@@ -57,7 +58,7 @@ protected:
    PatchCableSource* mTargetCable;
    FloatSlider* mMinSlider;
    FloatSlider* mMaxSlider;
-   FloatSlider* mTarget;
+   FloatSlider* mSliderTarget;
    IUIControl* mUIControlTarget;
    float mLastPollValue;
    float mSmoothedValue;

--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -77,34 +77,11 @@ void MacroSlider::SaveLayout(ofxJSONElement& moduleInfo)
    IDrawableModule::SaveLayout(moduleInfo);
 
    moduleInfo["num_mappings"] = (int)mMappings.size();
-   for (int i = 0; i < mMappings.size(); ++i)
-   {
-      std::string targetPath = "";
-      if (mMappings[i]->GetCableSource()->GetTarget())
-         targetPath = mMappings[i]->GetCableSource()->GetTarget()->Path();
-
-      moduleInfo["mappings"][i]["target"] = targetPath;
-   }
 }
 
 void MacroSlider::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadInt("num_mappings", moduleInfo, 3, 1, 100, K(isTextField));
-
-   for (auto mapping : mMappings)
-      delete mapping;
-   mMappings.clear();
-   const Json::Value& mappings = moduleInfo["mappings"];
-   for (int i = 0; i < mappings.size(); ++i)
-   {
-      std::string target = mappings[i]["target"].asString();
-      Mapping* mapping = new Mapping(this, i);
-      mapping->CreateUIControls();
-      FloatSlider* slider = dynamic_cast<FloatSlider*>(TheSynth->FindUIControl(target));
-      mapping->GetCableSource()->SetTarget(slider);
-      mapping->UpdateControl();
-      mMappings.push_back(mapping);
-   }
 
    SetUpFromSaveData();
 }
@@ -173,13 +150,13 @@ void MacroSlider::Mapping::Draw()
    mMinSlider->Draw();
    mMaxSlider->Draw();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
       float x, y, w, h;
       mMinSlider->GetPosition(x, y, K(local));
       mMinSlider->GetDimensions(w, h);
 
-      int lineX = ofMap(mTarget->GetValue(), mTarget->GetMin(), mTarget->GetMax(), x, x + w);
+      int lineX = ofLerp(x, x + w, mSliderTarget->ValToPos(mSliderTarget->GetValue(), true));
       int lineY1 = y;
       int lineY2 = y + h * 2;
       ofPushStyle();

--- a/Source/ModulatorAccum.cpp
+++ b/Source/ModulatorAccum.cpp
@@ -76,11 +76,11 @@ void ModulatorAccum::PostRepatch(PatchCableSource* cableSource, bool fromUserCli
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      mValue = mTarget->GetValue();
-      mValueSlider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mValueSlider->SetMode(mTarget->GetMode());
+      mValue = mSliderTarget->GetValue();
+      mValueSlider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mValueSlider->SetMode(mSliderTarget->GetMode());
    }
 }
 

--- a/Source/ModulatorAccum.h
+++ b/Source/ModulatorAccum.h
@@ -58,7 +58,7 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorAdd.cpp
+++ b/Source/ModulatorAdd.cpp
@@ -67,20 +67,20 @@ void ModulatorAdd::PostRepatch(PatchCableSource* cableSource, bool fromUserClick
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      //mValue1 = mTarget->GetValue();
+      //mValue1 = mSliderTarget->GetValue();
       //mValue2 = 0;
-      mValue1Slider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mValue1Slider->SetMode(mTarget->GetMode());
+      mValue1Slider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mValue1Slider->SetMode(mSliderTarget->GetMode());
    }
 }
 
 float ModulatorAdd::Value(int samplesIn)
 {
    ComputeSliders(samplesIn);
-   if (mTarget)
-      return ofClamp(mValue1 + mValue2, mTarget->GetMin(), mTarget->GetMax());
+   if (mSliderTarget)
+      return ofClamp(mValue1 + mValue2, mSliderTarget->GetMin(), mSliderTarget->GetMax());
    else
       return mValue1 + mValue2;
 }

--- a/Source/ModulatorAdd.h
+++ b/Source/ModulatorAdd.h
@@ -51,7 +51,7 @@ public:
    bool Active() const override { return mEnabled; }
    bool CanAdjustRange() const override { return false; }
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorAddCentered.cpp
+++ b/Source/ModulatorAddCentered.cpp
@@ -71,21 +71,21 @@ void ModulatorAddCentered::PostRepatch(PatchCableSource* cableSource, bool fromU
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      mValue1 = mTarget->GetValue();
+      mValue1 = mSliderTarget->GetValue();
       mValue2 = 0;
-      mValue1Slider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mValue1Slider->SetMode(mTarget->GetMode());
-      mValue2RangeSlider->SetExtents(0, mTarget->GetMax() - mTarget->GetMin());
+      mValue1Slider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mValue1Slider->SetMode(mSliderTarget->GetMode());
+      mValue2RangeSlider->SetExtents(0, mSliderTarget->GetMax() - mSliderTarget->GetMin());
    }
 }
 
 float ModulatorAddCentered::Value(int samplesIn)
 {
    ComputeSliders(samplesIn);
-   if (mTarget)
-      return ofClamp(mValue1 + mValue2 * mValue2Range, mTarget->GetMin(), mTarget->GetMax());
+   if (mSliderTarget)
+      return ofClamp(mValue1 + mValue2 * mValue2Range, mSliderTarget->GetMin(), mSliderTarget->GetMax());
    else
       return mValue1 + mValue2 * mValue2Range;
 }

--- a/Source/ModulatorAddCentered.h
+++ b/Source/ModulatorAddCentered.h
@@ -51,7 +51,7 @@ public:
    bool Active() const override { return mEnabled; }
    bool CanAdjustRange() const override { return false; }
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -80,8 +80,8 @@ void ModulatorCurve::PostRepatch(PatchCableSource* cableSource, bool fromUserCli
 {
    OnModulatorRepatch();
 
-   if (mTarget)
-      mInput = mTarget->GetValue();
+   if (mSliderTarget)
+      mInput = mSliderTarget->GetValue();
 }
 
 float ModulatorCurve::Value(int samplesIn)

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -51,7 +51,7 @@ public:
    float Value(int samplesIn = 0) override;
    bool Active() const override { return mEnabled; }
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;

--- a/Source/ModulatorExpression.cpp
+++ b/Source/ModulatorExpression.cpp
@@ -111,8 +111,8 @@ float ModulatorExpression::Value(int samplesIn)
       return mExpression.value();
    }
 
-   if (mTarget)
-      return mTarget->GetMin();
+   if (mSliderTarget)
+      return mSliderTarget->GetMin();
    return 0;
 }
 
@@ -120,10 +120,10 @@ void ModulatorExpression::PostRepatch(PatchCableSource* cableSource, bool fromUs
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      //mValue1Slider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      //mValue1Slider->SetMode(mTarget->GetMode());
+      //mValue1Slider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      //mValue1Slider->SetMode(mSliderTarget->GetMode());
    }
 }
 

--- a/Source/ModulatorGravity.h
+++ b/Source/ModulatorGravity.h
@@ -60,7 +60,7 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorMult.cpp
+++ b/Source/ModulatorMult.cpp
@@ -67,20 +67,20 @@ void ModulatorMult::PostRepatch(PatchCableSource* cableSource, bool fromUserClic
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      mValue1 = mTarget->GetValue();
+      mValue1 = mSliderTarget->GetValue();
       mValue2 = 0;
-      mValue1Slider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mValue1Slider->SetMode(mTarget->GetMode());
+      mValue1Slider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mValue1Slider->SetMode(mSliderTarget->GetMode());
    }
 }
 
 float ModulatorMult::Value(int samplesIn)
 {
    ComputeSliders(samplesIn);
-   if (mTarget)
-      return ofClamp(mValue1 * mValue2, mTarget->GetMin(), mTarget->GetMax());
+   if (mSliderTarget)
+      return ofClamp(mValue1 * mValue2, mSliderTarget->GetMin(), mSliderTarget->GetMax());
    else
       return mValue1 * mValue2;
 }

--- a/Source/ModulatorMult.h
+++ b/Source/ModulatorMult.h
@@ -51,7 +51,7 @@ public:
    bool Active() const override { return mEnabled; }
    bool CanAdjustRange() const override { return false; }
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorSmoother.cpp
+++ b/Source/ModulatorSmoother.cpp
@@ -77,11 +77,11 @@ void ModulatorSmoother::PostRepatch(PatchCableSource* cableSource, bool fromUser
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      mInput = mTarget->GetValue();
-      mInputSlider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mInputSlider->SetMode(mTarget->GetMode());
+      mInput = mSliderTarget->GetValue();
+      mInputSlider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mInputSlider->SetMode(mSliderTarget->GetMode());
    }
 }
 

--- a/Source/ModulatorSmoother.h
+++ b/Source/ModulatorSmoother.h
@@ -57,7 +57,7 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/ModulatorSubtract.cpp
+++ b/Source/ModulatorSubtract.cpp
@@ -67,20 +67,20 @@ void ModulatorSubtract::PostRepatch(PatchCableSource* cableSource, bool fromUser
 {
    OnModulatorRepatch();
 
-   if (mTarget)
+   if (mSliderTarget)
    {
-      //mValue1 = mTarget->GetValue();
+      //mValue1 = mSliderTarget->GetValue();
       //mValue2 = 0;
-      mValue1Slider->SetExtents(mTarget->GetMin(), mTarget->GetMax());
-      mValue1Slider->SetMode(mTarget->GetMode());
+      mValue1Slider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
+      mValue1Slider->SetMode(mSliderTarget->GetMode());
    }
 }
 
 float ModulatorSubtract::Value(int samplesIn)
 {
    ComputeSliders(samplesIn);
-   if (mTarget)
-      return ofClamp(mValue1 - mValue2, mTarget->GetMin(), mTarget->GetMax());
+   if (mSliderTarget)
+      return ofClamp(mValue1 - mValue2, mSliderTarget->GetMin(), mSliderTarget->GetMax());
    else
       return mValue1 - mValue2;
 }

--- a/Source/ModulatorSubtract.h
+++ b/Source/ModulatorSubtract.h
@@ -51,7 +51,7 @@ public:
    bool Active() const override { return mEnabled; }
    bool CanAdjustRange() const override { return false; }
 
-   FloatSlider* GetTarget() { return mTarget; }
+   FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -740,9 +740,8 @@ void PatchCableSource::LoadState(FileStreamIn& in)
 
    int size;
    in >> size;
-   mPatchCables.resize(size);
 
-   for (int i = 0; i < mPatchCables.size(); ++i)
+   for (int i = 0; i < size; ++i)
    {
       std::string path;
       in >> path;
@@ -761,7 +760,8 @@ void PatchCableSource::LoadState(FileStreamIn& in)
       if (TheSynth->IsDuplicatingModule() && mType == kConnectionType_Modulator)
          target = nullptr; //TODO(Ryan) make it so that when you're duplicating a group, modulators preserve connections to the new copies of controls within that group
 
-      mPatchCables[i] = new PatchCable(this);
+      mPatchCables.push_back(new PatchCable(this));
+      assert(i == (int)mPatchCables.size() - 1);
       SetPatchCableTarget(mPatchCables[i], target, false);
    }
 

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -44,11 +44,8 @@ public:
    ~Ramper();
    static IDrawableModule* Create() { return new Ramper(); }
 
-
    void CreateUIControls() override;
    void Init() override;
-
-   IUIControl* GetUIControl() const { return mUIControl; }
 
    //IDrawableModule
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -81,7 +78,7 @@ private:
 
    void Go(double time);
 
-   IUIControl* mUIControl;
+   std::array<IUIControl*, 16> mUIControls{ nullptr };
    NoteInterval mLength;
    DropdownList* mLengthSelector;
    PatchCableSource* mControlCable;

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -84,14 +84,23 @@ FloatSliderLFOControl* FloatSlider::AcquireLFO()
 
 void FloatSlider::SetLFO(FloatSliderLFOControl* lfo)
 {
-   mLFOControl = lfo;
-   mModulator = lfo;
+   if (lfo != mLFOControl)
+   {
+      SetModulator(lfo);
+      mLFOControl = lfo;
+   }
 }
 
 void FloatSlider::SetModulator(IModulator* modulator)
 {
-   mModulator = modulator;
-   mLFOControl = nullptr;
+   if (modulator != mModulator)
+   {
+      IModulator* oldModulator = mModulator;
+      mModulator = modulator;
+      mLFOControl = nullptr;
+      if (oldModulator != nullptr)
+         oldModulator->OnRemovedFrom(this);
+   }
 }
 
 void FloatSlider::Render()

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -120,6 +120,10 @@ public:
    void Halve() override;
    void ResetToOriginal() override;
    void Increment(float amount) override;
+
+   float PosToVal(float pos, bool ignoreSmooth) const;
+   float ValToPos(float val, bool ignoreSmooth) const;
+
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;
@@ -142,8 +146,6 @@ private:
    void OnClicked(int x, int y, bool right) override;
    void SetValueForMouse(int x, int y);
    float* GetModifyValue();
-   float PosToVal(float pos, bool ignoreSmooth) const;
-   float ValToPos(float val, bool ignoreSmooth) const;
    bool AdjustSmooth() const;
    void SmoothUpdated();
    void DoCompute(int samplesIn);

--- a/Source/ValueSetter.cpp
+++ b/Source/ValueSetter.cpp
@@ -88,8 +88,11 @@ void ValueSetter::OnPulse(double time, float velocity, int flags)
 
 void ValueSetter::ButtonClicked(ClickButton* button)
 {
-   if (button == mButton)
+   if (button == mButton && mLastClickTime != gTime)
+   {
+      mLastClickTime = gTime;
       Go();
+   }
 }
 
 void ValueSetter::Go()

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -80,6 +80,7 @@ private:
    TextEntry* mValueEntry{ nullptr };
    FloatSlider* mValueSlider{ nullptr };
    ClickButton* mButton{ nullptr };
+   double mLastClickTime{ 0 };
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/VinylTempoControl.cpp
+++ b/Source/VinylTempoControl.cpp
@@ -128,8 +128,8 @@ void VinylTempoControl::SaveLayout(ofxJSONElement& moduleInfo)
    IDrawableModule::SaveLayout(moduleInfo);
 
    std::string targetPath = "";
-   if (mTarget)
-      targetPath = mTarget->Path();
+   if (mSliderTarget)
+      targetPath = mSliderTarget->Path();
 
    moduleInfo["target"] = targetPath;
 }


### PR DESCRIPTION
- fix crash when duplicating valuesetter cables that have multiple targets
- when targeting a modulated control with a new modulator, automatically disconnect the old modulator
- update curvelooper and ramper to have valuesetter cables
- fix screwy state that occurred when duplicating LFOs
- fix automatic macroslider spawning not creating new connection properly
- fix infinite recursion crash when patching a valuesetter to its own "go" button