### PR TITLE
eliminate off-by-a-pixel discrepancies between mouse hover & mouse click

### DIFF
--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -347,7 +347,7 @@ void ADSRDisplay::SpawnEnvelopeEditor()
    }
 }
 
-void ADSRDisplay::OnClicked(int x, int y, bool right)
+void ADSRDisplay::OnClicked(float x, float y, bool right)
 {
    if (mASlider != nullptr && mASlider->IsShowing())
    {

--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -87,7 +87,7 @@ private:
       kAdjustViewLength
    } mAdjustMode{ AdjustParam::kAdjustNone };
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/Arpeggiator.cpp
+++ b/Source/Arpeggiator.cpp
@@ -126,7 +126,7 @@ std::string Arpeggiator::GetArpNoteDisplay(int pitch)
    return NoteName(pitch, false, true);
 }
 
-void Arpeggiator::OnClicked(int x, int y, bool right)
+void Arpeggiator::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -88,7 +88,7 @@ private:
       height = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    std::string GetArpNoteDisplay(int pitch);
    void UpdateInterval();

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -482,7 +482,7 @@ void BeatBloks::UpdateZoomExtents()
    mClipEndSlider->SetExtents(mZoomStart, mZoomEnd);
 }
 
-void BeatBloks::OnClicked(int x, int y, bool right)
+void BeatBloks::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -131,7 +131,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    Sample* mSample{ nullptr };
 

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -230,7 +230,7 @@ bool Canvas::IsRowVisible(int row) const
    return row >= mRowOffset && row < mRowOffset + GetNumVisibleRows();
 }
 
-void Canvas::OnClicked(int x, int y, bool right)
+void Canvas::OnClicked(float x, float y, bool right)
 {
    mClick = true;
    mHasDuplicatedThisDrag = false;

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -143,7 +143,7 @@ public:
    float mLoopEnd;
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/CanvasScrollbar.cpp
+++ b/Source/CanvasScrollbar.cpp
@@ -94,7 +94,7 @@ float CanvasScrollbar::GetBarEnd() const
    return 1;
 }
 
-void CanvasScrollbar::OnClicked(int x, int y, bool right)
+void CanvasScrollbar::OnClicked(float x, float y, bool right)
 {
    mClickMousePos.set(TheSynth->GetRawMouseX(), TheSynth->GetRawMouseY());
    mDragOffset.set(0, 0);

--- a/Source/CanvasScrollbar.h
+++ b/Source/CanvasScrollbar.h
@@ -63,7 +63,7 @@ public:
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/CanvasTimeline.cpp
+++ b/Source/CanvasTimeline.cpp
@@ -133,7 +133,7 @@ float CanvasTimeline::GetQuantizedForX(float posX, HoverMode clampSide)
    return measure;
 }
 
-void CanvasTimeline::OnClicked(int x, int y, bool right)
+void CanvasTimeline::OnClicked(float x, float y, bool right)
 {
    mClickMousePos.set(TheSynth->GetRawMouseX(), TheSynth->GetRawMouseY());
    mDragOffset.set(0, 0);

--- a/Source/CanvasTimeline.h
+++ b/Source/CanvasTimeline.h
@@ -57,7 +57,7 @@ public:
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -303,7 +303,7 @@ void ChaosEngine::DrawModule()
    ofPopStyle();
 }
 
-void ChaosEngine::OnClicked(int x, int y, bool right)
+void ChaosEngine::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -133,7 +133,7 @@ private:
       width = 610;
       height = 700;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    ClickButton* mChaosButton{ nullptr };
    bool mTotalChaos{ false };

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -136,7 +136,7 @@ void Checkbox::Render()
    DrawHover(mX, mY, mWidth, mHeight);
 }
 
-void Checkbox::OnClicked(int x, int y, bool right)
+void Checkbox::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/Checkbox.h
+++ b/Source/Checkbox.h
@@ -67,7 +67,7 @@ protected:
    ~Checkbox(); //protected so that it can't be created on the stack
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -159,7 +159,7 @@ void Chorder::RemoveTone(int tone)
    }
 }
 
-void Chorder::OnClicked(int x, int y, bool right)
+void Chorder::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -76,7 +76,7 @@ private:
       width = 135;
       height = 75;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
 

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -102,7 +102,7 @@ void CircleSequencer::DrawModule()
    ofPopStyle();
 }
 
-void CircleSequencer::OnClicked(int x, int y, bool right)
+void CircleSequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
    for (int i = 0; i < mCircleSequencerRings.size(); ++i)
@@ -264,7 +264,7 @@ int CircleSequencerRing::GetStepIndex(int x, int y, float& radiusOut)
    return -1;
 }
 
-void CircleSequencerRing::OnClicked(int x, int y, bool right)
+void CircleSequencerRing::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -46,7 +46,7 @@ class CircleSequencerRing
 public:
    CircleSequencerRing(CircleSequencer* owner, int index);
    void Draw();
-   void OnClicked(int x, int y, bool right);
+   void OnClicked(float x, float y, bool right);
    void MouseReleased();
    void MouseMoved(float x, float y);
    void CreateUIControls();
@@ -110,7 +110,7 @@ private:
       width = 400;
       height = 200;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool Enabled() const override { return mEnabled; }
 
    std::vector<CircleSequencerRing*> mCircleSequencerRings;

--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -162,7 +162,7 @@ bool ClickButton::ButtonLit() const
    return mClickTime + 200 > gTime;
 }
 
-void ClickButton::OnClicked(int x, int y, bool right)
+void ClickButton::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/ClickButton.h
+++ b/Source/ClickButton.h
@@ -91,7 +91,7 @@ protected:
 private:
    bool ButtonLit() const;
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    float mWidth;
    float mHeight;
    double mClickTime;

--- a/Source/ClipArranger.cpp
+++ b/Source/ClipArranger.cpp
@@ -97,7 +97,7 @@ void ClipArranger::GetModuleDimensions(float& w, float& h)
    h = 25 + mBufferHeight;
 }
 
-void ClipArranger::OnClicked(int x, int y, bool right)
+void ClipArranger::OnClicked(float x, float y, bool right)
 {
    mMouseDown = true;
 

--- a/Source/ClipArranger.h
+++ b/Source/ClipArranger.h
@@ -64,7 +64,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    float MouseXToBufferPos(float mouseX);
    int MouseXToSample(float mouseX);

--- a/Source/CodeEntry.cpp
+++ b/Source/CodeEntry.cpp
@@ -719,7 +719,7 @@ void CodeEntry::SetError(bool error, int errorLine)
    mErrorLine = errorLine;
 }
 
-void CodeEntry::OnClicked(int x, int y, bool right)
+void CodeEntry::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/CodeEntry.h
+++ b/Source/CodeEntry.h
@@ -115,7 +115,7 @@ private:
    bool IsAutocompleteShowing();
    void AcceptAutocompletion();
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
 

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -225,7 +225,7 @@ void ControlSequencer::DrawModule()
    }
 }
 
-void ControlSequencer::OnClicked(int x, int y, bool right)
+void ControlSequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -104,7 +104,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/Curve.cpp
+++ b/Source/Curve.cpp
@@ -162,7 +162,7 @@ CurvePoint* Curve::GetPoint(int index)
    return &mPoints[index];
 }
 
-void Curve::OnClicked(int x, int y, bool right)
+void Curve::OnClicked(float x, float y, bool right)
 {
    ofLog() << "curve clicked";
 }

--- a/Source/Curve.h
+++ b/Source/Curve.h
@@ -76,7 +76,7 @@ public:
    void LoadState(FileStreamIn& in);
 
 protected:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;
 

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -140,7 +140,7 @@ void CurveLooper::DrawModule()
    ofPopStyle();
 }
 
-void CurveLooper::OnClicked(int x, int y, bool right)
+void CurveLooper::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -76,7 +76,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -318,7 +318,7 @@ namespace
    }
 }
 
-void DropdownList::OnClicked(int x, int y, bool right)
+void DropdownList::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;
@@ -589,7 +589,7 @@ bool DropdownListModal::MouseMoved(float x, float y)
    return false;
 }
 
-void DropdownListModal::OnClicked(int x, int y, bool right)
+void DropdownListModal::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -80,7 +80,7 @@ public:
    void ButtonClicked(ClickButton* button) override;
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    int mWidth{ 1 };
    int mHeight{ 1 };
    int mColumnWidth{ 1 };
@@ -152,7 +152,7 @@ protected:
    ~DropdownList(); //protected so that it can't be created on the stack
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void CalcSliderVal();
    int FindItemIndex(float val) const;
    void SetValue(int value, bool forceUpdate);

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -638,7 +638,7 @@ void DrumPlayer::SetHitSample(int sampleIndex, Sample* sample)
    mDrumHits[sampleIndex].mEnvelopeLength = mDrumHits[sampleIndex].mSample.LengthInSamples() * gInvSampleRateMs;
 }
 
-void DrumPlayer::OnClicked(int x, int y, bool right)
+void DrumPlayer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -127,7 +127,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 
    ChannelBuffer mOutputBuffer;

--- a/Source/DrumSynth.cpp
+++ b/Source/DrumSynth.cpp
@@ -168,7 +168,7 @@ void DrumSynth::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
    }
 }
 
-void DrumSynth::OnClicked(int x, int y, bool right)
+void DrumSynth::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -168,7 +168,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    std::array<DrumSynthHit*, DRUMSYNTH_PADS_HORIZONTAL * DRUMSYNTH_PADS_VERTICAL> mHits;
    std::array<float, DRUMSYNTH_PADS_HORIZONTAL * DRUMSYNTH_PADS_VERTICAL> mVelocity{};

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -307,7 +307,7 @@ bool EQModule::Filter::UpdateCoefficientsIfNecessary()
    return false;
 }
 
-void EQModule::OnClicked(int x, int y, bool right)
+void EQModule::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -69,7 +69,7 @@ private:
       h = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -163,7 +163,7 @@ void EnvelopeControl::Draw()
    ofPopStyle();
 }
 
-void EnvelopeControl::OnClicked(int x, int y, bool right)
+void EnvelopeControl::OnClicked(float x, float y, bool right)
 {
    if (x > mPosition.x - pointClickRadius &&
        x < mPosition.x + mDimensions.x + pointClickRadius &&
@@ -515,7 +515,7 @@ void EnvelopeEditor::Resize(float w, float h)
    mHeight = h;
 }
 
-void EnvelopeEditor::OnClicked(int x, int y, bool right)
+void EnvelopeEditor::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -40,7 +40,7 @@ class EnvelopeControl
 public:
    EnvelopeControl(ofVec2f position, ofVec2f dimensions);
    void SetADSR(::ADSR* adsr) { mAdsr = adsr; }
-   void OnClicked(int x, int y, bool right);
+   void OnClicked(float x, float y, bool right);
    void MouseMoved(float x, float y);
    void MouseReleased();
    void Draw();
@@ -118,7 +118,7 @@ protected:
    ~EnvelopeEditor();
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void Pin();
 
    struct StageControls

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -106,7 +106,7 @@ void EnvelopeModulator::Resize(float w, float h)
    mHeight = MAX(h, 102);
 }
 
-void EnvelopeModulator::OnClicked(int x, int y, bool right)
+void EnvelopeModulator::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -85,7 +85,7 @@ public:
    int GetModuleSaveStateRev() const override { return 0; }
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    float mWidth{ 250 };
    float mHeight{ 122 };

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -346,7 +346,7 @@ ofVec2f FubbleModule::GetFubbleMouseCoord()
                   ofClamp(1 - ((mMouseY - fubbleRect.y) / fubbleRect.height), 0, 1));
 }
 
-void FubbleModule::OnClicked(int x, int y, bool right)
+void FubbleModule::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -88,7 +88,7 @@ private:
    void DrawModuleUnclipped() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -265,7 +265,7 @@ void GridModule::Resize(float w, float h)
    mGrid->SetDimensions(mGrid->GetWidth() + w - curW, mGrid->GetHeight() + h - curH);
 }
 
-void GridModule::OnClicked(int x, int y, bool right)
+void GridModule::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -104,7 +104,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -161,7 +161,7 @@ void GridSliders::DrawModule()
    }
 }
 
-void GridSliders::OnClicked(int x, int y, bool right)
+void GridSliders::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -72,7 +72,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/IClickable.cpp
+++ b/Source/IClickable.cpp
@@ -51,7 +51,7 @@ void IClickable::Draw()
    Render();
 }
 
-bool IClickable::TestClick(int x, int y, bool right, bool testOnly /* = false */)
+bool IClickable::TestClick(float x, float y, bool right, bool testOnly /* = false */)
 {
    if (!mShowing)
       return false;

--- a/Source/IClickable.h
+++ b/Source/IClickable.h
@@ -51,7 +51,7 @@ public:
       mX += moveX;
       mY += moveY;
    }
-   virtual bool TestClick(int x, int y, bool right, bool testOnly = false);
+   virtual bool TestClick(float x, float y, bool right, bool testOnly = false);
    IClickable* GetParent() const { return mParent; }
    void SetParent(IClickable* parent) { mParent = parent; }
    bool NotifyMouseMoved(float x, float y);
@@ -90,7 +90,7 @@ public:
    static std::string sPathSaveContext;
 
 protected:
-   virtual void OnClicked(int x, int y, bool right) {}
+   virtual void OnClicked(float x, float y, bool right) {}
    virtual bool MouseMoved(float x, float y) { return false; }
    virtual bool MouseScrolled(int x, int y, float scrollX, float scrollY) { return false; }
 

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -595,7 +595,7 @@ void IDrawableModule::Exit()
    }
 }
 
-bool IDrawableModule::TestClick(int x, int y, bool right, bool testOnly /*=false*/)
+bool IDrawableModule::TestClick(float x, float y, bool right, bool testOnly /*=false*/)
 {
    if (IsResizable() && mHoveringOverResizeHandle)
    {
@@ -616,7 +616,7 @@ bool IDrawableModule::TestClick(int x, int y, bool right, bool testOnly /*=false
    return false;
 }
 
-void IDrawableModule::OnClicked(int x, int y, bool right)
+void IDrawableModule::OnClicked(float x, float y, bool right)
 {
    float w, h;
    GetModuleDimensions(w, h);

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -130,7 +130,7 @@ public:
    void SetUpPatchCables(std::string targets);
    void AddPatchCableSource(PatchCableSource* source);
    void RemovePatchCableSource(PatchCableSource* source);
-   bool TestClick(int x, int y, bool right, bool testOnly = false) override;
+   bool TestClick(float x, float y, bool right, bool testOnly = false) override;
    std::string GetTypeName() const { return mTypeName; }
    ModuleType GetModuleType() const { return mModuleType; }
    virtual bool IsSingleton() const { return false; }
@@ -199,7 +199,7 @@ public:
 
 protected:
    void Poll() override {}
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    ModuleSaveData mModuleSaveData;

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -83,7 +83,7 @@ void KeyboardDisplay::PlayNote(double time, int pitch, int velocity, int voiceId
    }
 }
 
-void KeyboardDisplay::OnClicked(int x, int y, bool right)
+void KeyboardDisplay::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -62,7 +62,7 @@ private:
       height = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override
    {

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1059,7 +1059,7 @@ void Looper::GetModuleDimensions(float& width, float& height)
    height = 165;
 }
 
-void Looper::OnClicked(int x, int y, bool right)
+void Looper::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -144,7 +144,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    static const int BUFFER_X = 3;
    static const int BUFFER_Y = 3;

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -1336,7 +1336,7 @@ UIControlConnection* MidiController::GetConnectionForCableSource(const PatchCabl
    return nullptr;
 }
 
-void MidiController::OnClicked(int x, int y, bool right)
+void MidiController::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -380,7 +380,7 @@ private:
    void DrawModuleUnclipped() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    void ConnectDevice();

--- a/Source/Minimap.cpp
+++ b/Source/Minimap.cpp
@@ -244,7 +244,7 @@ void Minimap::DrawModule()
    }
 }
 
-void Minimap::OnClicked(int x, int y, bool right)
+void Minimap::OnClicked(float x, float y, bool right)
 {
    if (mGrid->TestClick(x, y, right, true))
    {

--- a/Source/Minimap.h
+++ b/Source/Minimap.h
@@ -52,7 +52,7 @@ private:
    ofRectangle CoordsToMinimap(ofRectangle& boundingBox, ofRectangle& source);
    void DrawModulesOnMinimap(ofRectangle& boundingBox);
    void RectUnion(ofRectangle& target, ofRectangle& unionRect);
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
    ofVec2f CoordsToViewport(ofRectangle& boundingBox, float x, float y);

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1672,15 +1672,15 @@ IDrawableModule* ModularSynth::GetModuleAtCursor(int offsetX /*=0*/, int offsetY
    return mModuleContainer.GetModuleAt(x, y);
 }
 
-void ModularSynth::CheckClick(IDrawableModule* clickedModule, int x, int y, bool rightButton)
+void ModularSynth::CheckClick(IDrawableModule* clickedModule, float x, float y, bool rightButton)
 {
    if (clickedModule != TheTitleBar)
       MoveToFront(clickedModule);
 
    //check to see if we clicked in the move area
    ofRectangle moduleRect = clickedModule->GetRect();
-   int modulePosX = x - moduleRect.x;
-   int modulePosY = y - moduleRect.y;
+   float modulePosX = x - moduleRect.x;
+   float modulePosY = y - moduleRect.y;
 
    if (modulePosY < 0 && clickedModule != TheTitleBar && (!clickedModule->HasEnableCheckbox() || modulePosX > 20) && modulePosX < moduleRect.width - 15)
       SetMoveModule(clickedModule, moduleRect.x - x, moduleRect.y - y, false);

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -280,7 +280,7 @@ private:
    void ResetLayout();
    void ReconnectMidiDevices();
    void DrawConsole();
-   void CheckClick(IDrawableModule* clickedModule, int x, int y, bool rightButton);
+   void CheckClick(IDrawableModule* clickedModule, float x, float y, bool rightButton);
    void UpdateUserPrefsLayout();
    void LoadStatePopupImp();
    IDrawableModule* DuplicateModule(IDrawableModule* module);

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -96,7 +96,7 @@ float ModulatorCurve::Value(int samplesIn)
    return ofLerp(GetMin(), GetMax(), val);
 }
 
-void ModulatorCurve::OnClicked(int x, int y, bool right)
+void ModulatorCurve::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -77,7 +77,7 @@ private:
    }
    bool Enabled() const override { return mEnabled; }
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    float mInput;
    EnvelopeControl mEnvelopeControl;

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -166,7 +166,7 @@ void MultitapDelay::ButtonClicked(ClickButton* button)
 {
 }
 
-void MultitapDelay::OnClicked(int x, int y, bool right)
+void MultitapDelay::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -85,7 +85,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    struct DelayTap
    {

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -404,7 +404,7 @@ void NoteStepSequencer::DrawModule()
    ofPopStyle();
 }
 
-void NoteStepSequencer::OnClicked(int x, int y, bool right)
+void NoteStepSequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -128,7 +128,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void UpdateGridControllerLights(bool force);
 
    int ButtonToStep(int button);

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -270,7 +270,7 @@ void NoteTable::DrawModule()
    ofPopStyle();
 }
 
-void NoteTable::OnClicked(int x, int y, bool right)
+void NoteTable::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -99,7 +99,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void UpdateGridControllerLights(bool force);
 
    void PlayColumn(double time, int column, int velocity, int voiceIdx, ModulationParameters modulation);

--- a/Source/PanicButton.cpp
+++ b/Source/PanicButton.cpp
@@ -35,7 +35,7 @@ PanicButton::~PanicButton()
 {
 }
 
-void PanicButton::OnClicked(int x, int y, bool right)
+void PanicButton::OnClicked(float x, float y, bool right)
 {
    TheSynth->LoadLayout(ofToDataPath("daftpunk.json"));
 }

--- a/Source/PanicButton.h
+++ b/Source/PanicButton.h
@@ -46,7 +46,7 @@ private:
       width = 300;
       height = 150;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 };
 
 #endif /* defined(__Bespoke__PanicButton__) */

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -525,7 +525,7 @@ IClickable* PatchCable::GetDropTarget()
    return nullptr;
 }
 
-bool PatchCable::TestClick(int x, int y, bool right, bool testOnly /* = false */)
+bool PatchCable::TestClick(float x, float y, bool right, bool testOnly /* = false */)
 {
    if (mHovered && !right)
    {
@@ -536,7 +536,7 @@ bool PatchCable::TestClick(int x, int y, bool right, bool testOnly /* = false */
    return false;
 }
 
-void PatchCable::OnClicked(int x, int y, bool right)
+void PatchCable::OnClicked(float x, float y, bool right)
 {
 }
 

--- a/Source/PatchCable.h
+++ b/Source/PatchCable.h
@@ -63,7 +63,7 @@ public:
    virtual ~PatchCable();
 
    void Render() override;
-   bool TestClick(int x, int y, bool right, bool testOnly = false) override;
+   bool TestClick(float x, float y, bool right, bool testOnly = false) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
    void GetDimensions(float& width, float& height) override
@@ -88,7 +88,7 @@ public:
    static PatchCable* sActivePatchCable;
 
 protected:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
 private:
    void SetTarget(IClickable* target);

--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -499,7 +499,7 @@ void PatchCableSource::MouseReleased()
       cable->MouseReleased();
 }
 
-bool PatchCableSource::TestClick(int x, int y, bool right, bool testOnly /* = false */)
+bool PatchCableSource::TestClick(float x, float y, bool right, bool testOnly /* = false */)
 {
    if (!Enabled())
       return false;
@@ -600,7 +600,7 @@ bool PatchCableSource::Enabled() const
    return mEnabled && (mAutomaticPositioning || !mOwner->Minimized());
 }
 
-void PatchCableSource::OnClicked(int x, int y, bool right)
+void PatchCableSource::OnClicked(float x, float y, bool right)
 {
 }
 

--- a/Source/PatchCableSource.h
+++ b/Source/PatchCableSource.h
@@ -149,7 +149,7 @@ public:
    void DrawSource();
    void DrawCables(bool parentMinimized);
    void Render() override;
-   bool TestClick(int x, int y, bool right, bool testOnly = false) override;
+   bool TestClick(float x, float y, bool right, bool testOnly = false) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
    void GetDimensions(float& width, float& height) override
@@ -165,7 +165,7 @@ public:
    static bool sAllowInsert;
 
 protected:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
 private:
    bool InAddCableMode() const;

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -154,7 +154,7 @@ void PlaySequencer::DrawModule()
    ofPopStyle();
 }
 
-void PlaySequencer::OnClicked(int x, int y, bool right)
+void PlaySequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -94,7 +94,7 @@ private:
       height = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    int GetStep(double time);
    void UpdateInterval();

--- a/Source/Polyrhythms.cpp
+++ b/Source/Polyrhythms.cpp
@@ -103,7 +103,7 @@ void Polyrhythms::Resize(float w, float h)
       mRhythmLines[i]->OnResize();
 }
 
-void Polyrhythms::OnClicked(int x, int y, bool right)
+void Polyrhythms::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
    for (int i = 0; i < mRhythmLines.size(); ++i)
@@ -234,7 +234,7 @@ void RhythmLine::Draw()
    mNoteSelector->Draw();
 }
 
-void RhythmLine::OnClicked(int x, int y, bool right)
+void RhythmLine::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -44,7 +44,7 @@ class RhythmLine
 public:
    RhythmLine(Polyrhythms* owner, int index);
    void Draw();
-   void OnClicked(int x, int y, bool right);
+   void OnClicked(float x, float y, bool right);
    void MouseReleased();
    void MouseMoved(float x, float y);
    void CreateUIControls();
@@ -99,7 +99,7 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 350 };

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -112,7 +112,7 @@ bool Prefab::CanAddDropModules()
    return false;
 }
 
-void Prefab::OnClicked(int x, int y, bool right)
+void Prefab::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -72,7 +72,7 @@ private:
    void DrawModuleUnclipped() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
 
    bool CanAddDropModules();

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -159,7 +159,7 @@ void Presets::UpdateGridValues()
    }
 }
 
-void Presets::OnClicked(int x, int y, bool right)
+void Presets::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -90,7 +90,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    struct Preset

--- a/Source/Producer.cpp
+++ b/Source/Producer.cpp
@@ -369,7 +369,7 @@ void Producer::DrawModule()
       mBiquad[i].Draw();
 }
 
-void Producer::OnClicked(int x, int y, bool right)
+void Producer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -94,7 +94,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    Sample* mSample;
 

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -192,7 +192,7 @@ void PulseSequence::GetModuleDimensions(float& width, float& height)
    height = 52;
 }
 
-void PulseSequence::OnClicked(int x, int y, bool right)
+void PulseSequence::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -93,7 +93,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    void Step(double time, float velocity, int flags);
 

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -176,7 +176,7 @@ void PulseTrain::GetModuleDimensions(float& width, float& height)
    height = 52;
 }
 
-void PulseTrain::OnClicked(int x, int y, bool right)
+void PulseTrain::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -85,7 +85,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    void Step(double time, float velocity, int flags);
 

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -200,7 +200,7 @@ void Push2Control::PostRender()
       RenderPush2Display();
 }
 
-void Push2Control::OnClicked(int x, int y, bool right)
+void Push2Control::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -78,7 +78,7 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    bool Initialize();
    void DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float t, float pxRatio);

--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -162,7 +162,7 @@ bool QuickSpawnMenu::MouseMoved(float x, float y)
    return false;
 }
 
-void QuickSpawnMenu::OnClicked(int x, int y, bool right)
+void QuickSpawnMenu::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/QuickSpawnMenu.h
+++ b/Source/QuickSpawnMenu.h
@@ -59,7 +59,7 @@ private:
    std::string GetModuleTypeNameAt(int x, int y);
    void UpdateDisplay();
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void GetDimensions(float& width, float& height) override
    {

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -214,7 +214,7 @@ bool RadioButton::MouseMoved(float x, float y)
    return false;
 }
 
-void RadioButton::OnClicked(int x, int y, bool right)
+void RadioButton::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/RadioButton.h
+++ b/Source/RadioButton.h
@@ -99,7 +99,7 @@ private:
    void CalcSliderVal();
    void UpdateDimensions();
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    int mWidth{ 15 };
    int mHeight{ 15 };

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -222,7 +222,7 @@ void RadioSequencer::DrawModule()
    }
 }
 
-void RadioSequencer::OnClicked(int x, int y, bool right)
+void RadioSequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -106,7 +106,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/Ramper.cpp
+++ b/Source/Ramper.cpp
@@ -113,7 +113,7 @@ void Ramper::DrawModule()
    mTargetValueSlider->Draw();
 }
 
-void Ramper::OnClicked(int x, int y, bool right)
+void Ramper::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -72,7 +72,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -145,7 +145,7 @@ double SampleCanvas::GetCurPos(double time) const
    return (((TheTransport->GetMeasure(time) % loopMeasures) + TheTransport->GetMeasurePos(time)) + mCanvas->mLoopStart) / mCanvas->GetLength();
 }
 
-void SampleCanvas::OnClicked(int x, int y, bool right)
+void SampleCanvas::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -57,7 +57,7 @@ public:
 
    void CanvasUpdated(Canvas* canvas) override;
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -220,7 +220,7 @@ void SampleCapturer::GetModuleDimensions(float& w, float& h)
    h = (int)mSamples.size() * (kBufferHeight + kBufferSpacing) + kBufferStartY;
 }
 
-void SampleCapturer::OnClicked(int x, int y, bool right)
+void SampleCapturer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -60,7 +60,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
 

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -774,7 +774,7 @@ void SamplePlayer::FillData(std::vector<float> data)
    UpdateSample(sample, true);
 }
 
-void SamplePlayer::OnClicked(int x, int y, bool right)
+void SamplePlayer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -127,7 +127,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;
    bool MouseScrolled(int x, int y, float scrollX, float scrollY) override;

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -355,7 +355,7 @@ void SamplerGrid::GetModuleDimensions(float& width, float& height)
    }
 }
 
-void SamplerGrid::OnClicked(int x, int y, bool right)
+void SamplerGrid::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -94,7 +94,7 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    bool Enabled() const override { return mEnabled; }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
 
    void InitGrid();

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -189,7 +189,7 @@ void ScriptModule::CheckIfPythonEverSuccessfullyInitialized()
    }
 }
 
-void ScriptModule::OnClicked(int x, int y, bool right)
+void ScriptModule::OnClicked(float x, float y, bool right)
 {
    if (!sHasPythonEverSuccessfullyInitialized)
    {

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -145,7 +145,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    ClickButton* mPythonInstalledConfirmButton{ nullptr };

--- a/Source/ScriptStatus.cpp
+++ b/Source/ScriptStatus.cpp
@@ -101,7 +101,7 @@ void ScriptStatus::DrawModule()
    DrawTextNormal(mStatus, 3, 35);
 }
 
-void ScriptStatus::OnClicked(int x, int y, bool right)
+void ScriptStatus::OnClicked(float x, float y, bool right)
 {
    if (ScriptModule::sHasPythonEverSuccessfullyInitialized)
    {

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -62,7 +62,7 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override
    {

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -310,7 +310,7 @@ void SeaOfGrain::ButtonClicked(ClickButton* button)
       LoadFile();
 }
 
-void SeaOfGrain::OnClicked(int x, int y, bool right)
+void SeaOfGrain::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 }

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -96,7 +96,7 @@ private:
    void DrawModule() override;
    bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    ChannelBuffer* GetSourceBuffer();
    float GetSourceStartSample();

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -298,7 +298,7 @@ void FloatSlider::DisplayLFOControl()
    }
 }
 
-void FloatSlider::OnClicked(int x, int y, bool right)
+void FloatSlider::OnClicked(float x, float y, bool right)
 {
    if (right)
    {
@@ -1016,7 +1016,7 @@ void IntSlider::CalcSliderVal()
    mSliderVal = ofMap(*mVar, mMin, mMax, 0.0f, 1.0f, K(clamp));
 }
 
-void IntSlider::OnClicked(int x, int y, bool right)
+void IntSlider::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -143,7 +143,7 @@ protected:
    ~FloatSlider(); //protected so that it can't be created on the stack
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void SetValueForMouse(int x, int y);
    float* GetModifyValue();
    bool AdjustSmooth() const;
@@ -258,7 +258,7 @@ protected:
    ~IntSlider(); //protected so that it can't be created on the stack
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -541,7 +541,7 @@ void StepSequencer::Resize(float w, float h)
    mGrid->SetDimensions(MAX(w - extraW, 185), MAX(h - extraH, 46 + 13 * mNumRows));
 }
 
-void StepSequencer::OnClicked(int x, int y, bool right)
+void StepSequencer::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
    if (mGrid->TestClick(x, y, right))

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -185,7 +185,7 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void Exit() override;
    void KeyPressed(int key, bool isRepeat) override;
 

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -241,7 +241,7 @@ void TextEntry::GetDimensions(float& width, float& height)
    height = 15;
 }
 
-void TextEntry::OnClicked(int x, int y, bool right)
+void TextEntry::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -119,7 +119,7 @@ private:
    void AcceptEntry(bool pressedEnter) override;
    void CancelEntry() override;
    void MoveCaret(int pos, bool allowSelection = true);
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    int mCharWidth;

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -294,7 +294,7 @@ void TitleBar::ListLayouts()
    mSaveLayoutButton->PositionTo(mLoadLayoutDropdown, kAnchor_Right);
 }
 
-void TitleBar::OnClicked(int x, int y, bool right)
+void TitleBar::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -145,7 +145,7 @@ private:
    void DrawModuleUnclipped() override;
    bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
    bool HiddenByZoom() const;

--- a/Source/UIGrid.cpp
+++ b/Source/UIGrid.cpp
@@ -225,7 +225,7 @@ bool UIGrid::CanAdjustMultislider() const
    return !mRequireShiftForMultislider || (GetKeyModifiers() & kModifier_Shift);
 }
 
-void UIGrid::OnClicked(int x, int y, bool right)
+void UIGrid::OnClicked(float x, float y, bool right)
 {
    if (right)
       return;

--- a/Source/UIGrid.h
+++ b/Source/UIGrid.h
@@ -117,7 +117,7 @@ protected:
    ~UIGrid(); //protected so that it can't be created on the stack
 
 private:
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
    void GetDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/VelocityCurve.cpp
+++ b/Source/VelocityCurve.cpp
@@ -95,7 +95,7 @@ void VelocityCurve::PlayNote(double time, int pitch, int velocity, int voiceIdx,
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void VelocityCurve::OnClicked(int x, int y, bool right)
+void VelocityCurve::OnClicked(float x, float y, bool right)
 {
    IDrawableModule::OnClicked(x, y, right);
 

--- a/Source/VelocityCurve.h
+++ b/Source/VelocityCurve.h
@@ -64,7 +64,7 @@ private:
    }
    bool Enabled() const override { return mEnabled; }
 
-   void OnClicked(int x, int y, bool right) override;
+   void OnClicked(float x, float y, bool right) override;
 
    EnvelopeControl mEnvelopeControl;
    ::ADSR mAdsr;


### PR DESCRIPTION
these were caused by unnecessary truncations to int