### PR TITLE
Add <memory> include

### DIFF
--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -27,6 +27,7 @@
 #define __Bespoke__TitleBar__
 
 #include <iostream>
+#include <memory>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "ClickButton.h"


### PR DESCRIPTION
This missing header caused me an error when building on Linux. Adding it solved the problem.