### PR TITLE
Create plugin parameter sliders on demand

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -512,7 +512,7 @@ void VSTPlugin::AddParameterSlider(int i)
    tmp.mName = name.c_str();
    tmp.mShowing = false;
    tmp.mInSelectorList = true;
-   
+
    mParameterSliders.push_back(tmp);
    mShowParameterDropdown->AddLabel(name.c_str(), mParameterSliders.size() - 1);
  }
@@ -537,7 +537,14 @@ void VSTPlugin::Poll()
             if (mTemporarilyDisplayedParamIndex != -1)
                mShowParameterDropdown->RemoveLabel(mTemporarilyDisplayedParamIndex);
             mTemporarilyDisplayedParamIndex = mChangeGestureParameterIndex;
-            //mShowParameterDropdown->AddLabel(mParameterSliders[mChangeGestureParameterIndex].mName, mChangeGestureParameterIndex);
+            AddParameterSlider(mChangeGestureParameterIndex);
+         }
+
+         if (mChangeGestureParameterIndex > (int)mParameterSliders.size() && mTemporarilyDisplayedParamIndex != mChangeGestureParameterIndex)
+         {
+            if (mTemporarilyDisplayedParamIndex != -1)
+               mShowParameterDropdown->RemoveLabel(mTemporarilyDisplayedParamIndex);
+            mTemporarilyDisplayedParamIndex = mChangeGestureParameterIndex;
             AddParameterSlider(mChangeGestureParameterIndex);
          }
 

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -515,7 +515,7 @@ void VSTPlugin::AddParameterSlider(int i)
 
    mParameterSliders.push_back(tmp);
    mShowParameterDropdown->AddLabel(name.c_str(), mParameterSliders.size() - 1);
- }
+}
 
 void VSTPlugin::Poll()
 {

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -467,7 +467,7 @@ void VSTPlugin::CreateParameterSliders()
 
    const auto& parameters = mPlugin->getParameters();
 
-   int numParameters = MIN(10000, parameters.size());
+   int numParameters = MIN(31, parameters.size());
    mParameterSliders.resize(numParameters);
    for (int i = 0; i < numParameters; ++i)
    {
@@ -501,6 +501,22 @@ void VSTPlugin::CreateParameterSliders()
    }
 }
 
+void VSTPlugin::AddParameterSlider(int i)
+{
+   ParameterSlider tmp{};
+   juce::String originalParamName = mPlugin->getParameters()[i]->getName(32);
+   std::string name(originalParamName.getCharPointer());
+
+   tmp.mValue = mPlugin->getParameters()[i]->getValue();
+   tmp.mParameter = mPlugin->getParameters()[i];
+   tmp.mName = name.c_str();
+   tmp.mShowing = false;
+   tmp.mInSelectorList = true;
+   
+   mParameterSliders.push_back(tmp);
+   mShowParameterDropdown->AddLabel(name.c_str(), mParameterSliders.size() - 1);
+ }
+
 void VSTPlugin::Poll()
 {
    if (mDisplayMode == kDisplayMode_Sliders)
@@ -521,7 +537,8 @@ void VSTPlugin::Poll()
             if (mTemporarilyDisplayedParamIndex != -1)
                mShowParameterDropdown->RemoveLabel(mTemporarilyDisplayedParamIndex);
             mTemporarilyDisplayedParamIndex = mChangeGestureParameterIndex;
-            mShowParameterDropdown->AddLabel(mParameterSliders[mChangeGestureParameterIndex].mName, mChangeGestureParameterIndex);
+            //mShowParameterDropdown->AddLabel(mParameterSliders[mChangeGestureParameterIndex].mName, mChangeGestureParameterIndex);
+            AddParameterSlider(mChangeGestureParameterIndex);
          }
 
          mChangeGestureParameterIndex = -1;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -115,9 +115,11 @@ private:
    std::string GetPluginFormatName() const;
    std::string GetPluginId() const;
    void CreateParameterSliders();
-   void AddParameterSlider(int index);
+   juce::String GetParameterID(int index);
+   void AddParameterSliderByID(juce::String);
    void RefreshPresetFiles();
    bool ParameterNameExists(std::string name, int checkUntilIndex) const;
+   void MapParamaters();
 
    //juce::AudioProcessorListener
    void audioProcessorParameterChanged(juce::AudioProcessor* processor, int parameterIndex, float newValue) override {}
@@ -152,12 +154,17 @@ private:
       float mValue{ 0 };
       FloatSlider* mSlider{ nullptr };
       juce::AudioProcessorParameter* mParameter{ nullptr };
+      juce::HostedAudioProcessorParameter* mHAPParameter { nullptr };
+      juce::String mID { "" };
       bool mShowing{ false };
       bool mInSelectorList{ true };
       std::string mName;
       void MakeSlider(VSTPlugin* owner);
    };
+   
+   bool mNoParamsToShow { false };
 
+   std::map<juce::String, juce::AudioProcessorParameter*> parameterForId;
    std::vector<ParameterSlider> mParameterSliders;
    int mChangeGestureParameterIndex{ -1 };
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -115,6 +115,7 @@ private:
    std::string GetPluginFormatName() const;
    std::string GetPluginId() const;
    void CreateParameterSliders();
+   void AddParameterSlider(int index);
    void RefreshPresetFiles();
    bool ParameterNameExists(std::string name, int checkUntilIndex) const;
 


### PR DESCRIPTION
Previously sliders were created for all plugin's parameters, it took a long for plugins with enormous amount of them. We just didn't display these sliders.
This PR makes adding parameter (if them over 30) only on gesture then show it's slider.