### PR TITLE
Added an option to have velocitytocv output 0 when a note is released.

### DIFF
--- a/Source/VelocityToCV.cpp
+++ b/Source/VelocityToCV.cpp
@@ -33,7 +33,7 @@
 #include "ModulationChain.h"
 
 VelocityToCV::VelocityToCV()
-: mVelocity(0)
+: mVelocity(0), mPassZero(false)
 {
 }
 
@@ -50,6 +50,7 @@ void VelocityToCV::CreateUIControls()
 
    mMinSlider = new FloatSlider(this, "min", 3, 2, 100, 15, &mDummyMin, 0, 1);
    mMaxSlider = new FloatSlider(this, "max", mMinSlider, kAnchor_Below, 100, 15, &mDummyMax, 0, 1);
+   mPassZeroCheckbox = new Checkbox(this, "0 at note off", mMaxSlider, kAnchor_Below, &mPassZero);
 }
 
 void VelocityToCV::DrawModule()
@@ -59,6 +60,7 @@ void VelocityToCV::DrawModule()
 
    mMinSlider->Draw();
    mMaxSlider->Draw();
+   mPassZeroCheckbox->Draw();
 }
 
 void VelocityToCV::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
@@ -68,7 +70,7 @@ void VelocityToCV::PostRepatch(PatchCableSource* cableSource, bool fromUserClick
 
 void VelocityToCV::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
 {
-   if (mEnabled && velocity > 0)
+   if (mEnabled && (mPassZero || velocity > 0))
    {
       mVelocity = velocity;
    }

--- a/Source/VelocityToCV.cpp
+++ b/Source/VelocityToCV.cpp
@@ -33,7 +33,8 @@
 #include "ModulationChain.h"
 
 VelocityToCV::VelocityToCV()
-: mVelocity(0), mPassZero(false)
+: mVelocity(0)
+, mPassZero(false)
 {
 }
 

--- a/Source/VelocityToCV.h
+++ b/Source/VelocityToCV.h
@@ -30,6 +30,7 @@
 #include "INoteReceiver.h"
 #include "IModulator.h"
 #include "Slider.h"
+#include "Checkbox.h"
 
 class PatchCableSource;
 
@@ -68,9 +69,11 @@ private:
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 106;
-      height = 17 * 2 + 2;
+      height = 17 * 3 + 2;
    }
    bool Enabled() const override { return mEnabled; }
 
    int mVelocity;
+   bool mPassZero;
+   Checkbox* mPassZeroCheckbox;
 };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -240,6 +240,7 @@ vinylcontrol~modulator which outputs a speed value based upon control vinyl inpu
 velocitytocv~take a note's velocity and convert it to a modulation value
 ~min~output for velocity 0
 ~max~output for velocity 127
+~0 at note off~output zero when note is released
 
 
 


### PR DESCRIPTION
I was surprised this feature didn't already exist, and it seemed simple enough, so I added it. Please let me know if any further changes are needed.