### PR TITLE
Add boundstopulse module

### DIFF
--- a/Source/BoundsToPulse.cpp
+++ b/Source/BoundsToPulse.cpp
@@ -1,0 +1,80 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2022 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+// Created by block on 8/6/2022.
+//
+
+#include "BoundsToPulse.h"
+#include "SynthGlobals.h"
+#include "ModularSynth.h"
+#include "PatchCableSource.h"
+
+BoundsToPulse::BoundsToPulse()
+: mSlider(nullptr)
+, mValue(0)
+{
+}
+
+BoundsToPulse::~BoundsToPulse()
+{
+}
+
+void BoundsToPulse::CreateUIControls()
+{
+   IDrawableModule::CreateUIControls();
+
+   mSlider = new FloatSlider(this, "input", 5, 4, 100, 15, &mValue, 0, 1);
+
+   mMinCable = new PatchCableSource(this, kConnectionType_Pulse);
+   mMaxCable = new PatchCableSource(this, kConnectionType_Pulse);
+   AddPatchCableSource(mMinCable);
+   AddPatchCableSource(mMaxCable);
+}
+
+void BoundsToPulse::DrawModule()
+{
+   if (Minimized() || IsVisible() == false)
+      return;
+
+   mSlider->Draw();
+
+   mMinCable->SetManualPosition(10, 30);
+   mMaxCable->SetManualPosition(100, 30);
+}
+
+void BoundsToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+{
+   if (!mEnabled)
+      return;
+
+   if (slider == mSlider)
+   {
+      // send the pulse through our main source *and* the relevant cable
+
+      if (mValue == slider->GetMin() && mValue < oldVal)
+      {
+         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 0.f, 0);
+         DispatchPulse(mMinCable, gTime + gBufferSizeMs, 1.f, 0);
+      }
+      else if (mValue == slider->GetMax() && oldVal < mValue)
+      {
+         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 1.f, 0);
+         DispatchPulse(mMaxCable, gTime + gBufferSizeMs, 1.f, 0);
+      }
+   }
+}

--- a/Source/BoundsToPulse.cpp
+++ b/Source/BoundsToPulse.cpp
@@ -68,7 +68,7 @@ void BoundsToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal)
 
       if (mValue == slider->GetMin() && mValue < oldVal)
       {
-         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 0.f, 0);
+         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 1.f, 0);
          DispatchPulse(mMinCable, gTime + gBufferSizeMs, 1.f, 0);
       }
       else if (mValue == slider->GetMax() && oldVal < mValue)

--- a/Source/BoundsToPulse.h
+++ b/Source/BoundsToPulse.h
@@ -1,0 +1,70 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2022 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+// Created by block on 8/6/2022.
+//
+
+#pragma once
+
+#include <iostream>
+#include "IAudioReceiver.h"
+#include "INoteSource.h"
+#include "Slider.h"
+#include "Checkbox.h"
+#include "IDrawableModule.h"
+#include "RadioButton.h"
+#include "ClickButton.h"
+#include "INoteReceiver.h"
+#include "Transport.h"
+#include "BiquadFilter.h"
+#include "PeakTracker.h"
+#include "Scale.h"
+#include "IAudioSource.h"
+#include "EnvOscillator.h"
+#include "IPulseReceiver.h"
+
+class BoundsToPulse : public IDrawableModule, public IFloatSliderListener, public IPulseSource
+{
+public:
+   BoundsToPulse();
+   virtual ~BoundsToPulse();
+   static IDrawableModule* Create() { return new BoundsToPulse(); }
+
+   void CreateUIControls() override;
+
+   void SetEnabled(bool enabled) override { mEnabled = enabled; }
+
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+
+   float GetValue() const { return mValue; }
+   FloatSlider* GetSlider() { return mSlider; }
+
+private:
+   void DrawModule() override;
+   void GetModuleDimensions(float& width, float& height) override
+   {
+      width = 110;
+      height = 40;
+   }
+
+   FloatSlider* mSlider;
+   float mValue;
+
+   PatchCableSource* mMinCable{};
+   PatchCableSource* mMaxCable{};
+};

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -314,6 +314,8 @@ target_sources(BespokeSynth PRIVATE
     ModulatorAdd.h
     ModulatorAddCentered.cpp
     ModulatorAddCentered.h
+    BoundsToPulse.cpp
+    BoundsToPulse.h
     ModulatorCurve.cpp
     ModulatorCurve.h
     ModulatorExpression.cpp

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -254,6 +254,7 @@
 #include "VelocityToChance.h"
 #include "NoteEcho.h"
 #include "VelocityCurve.h"
+#include "BoundsToPulse.h"
 
 #include <juce_core/juce_core.h>
 
@@ -454,6 +455,7 @@ ModuleFactory::ModuleFactory()
    REGISTER(VelocityToChance, velocitytochance, kModuleCategory_Note);
    REGISTER(NoteEcho, noteecho, kModuleCategory_Note);
    REGISTER(VelocityCurve, velocitycurve, kModuleCategory_Note);
+   REGISTER(BoundsToPulse, boundstopulse, kModuleCategory_Pulse);
 
    //REGISTER_EXPERIMENTAL(MidiPlayer, midiplayer, kModuleCategory_Instrument);
    REGISTER_HIDDEN(Autotalent, autotalent, kModuleCategory_Audio);

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -232,6 +232,11 @@ audiotopulse~sends a pulse when the audio level surpasses a specified threshold
 
 
 
+boundstopulse~sends a pulse when its input slider hits its max or min limit
+~input~the slider to check bounds on
+
+
+
 vinylcontrol~modulator which outputs a speed value based upon control vinyl input audio. provide it with a stereo signal from control vinyl (like you'd use to control serato) patched in from an "input" module.
 ~control~enable/disable transport control. when you enable it, it will use the current speed as the reference speed (so, the output will output a value of 1 until you change the vinyl's speed)
 


### PR DESCRIPTION
boundstopulse creates a pulse when its input slider hits the min or max value.

I personally used this with a notetoggle input to make two separate pulses with the on and off note signal for a [walkie-talkie beep sound](https://user-images.githubusercontent.com/15617441/183276492-a3236e55-2df9-4324-a0ea-964e6568b52c.mp4), but this may also be able to find uses with LFOs and noise gates to toggle various things when those are hit/released.
