### PR TITLE
workaround fix to speed up loading tracktion f'em

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -476,7 +476,7 @@ void VSTPlugin::CreateParameterSliders()
       std::string name(originalParamName.getCharPointer());
       try
       {
-         int append = 0;
+         int append = i;
          while (ParameterNameExists(name, i) || FindUIControl(name.c_str()))
          {
             ++append;


### PR DESCRIPTION
also fixes any other plugins that don't report parameter names. f'em has tens of thousands of parameters named "" (empty string), and the code I had to generate unique names is very slow in this case. this small tweak works around it (by giving a much higher chance of starting with a unique name after a collision)