### PR TITLE
add timestamps to all control updates for sample-accurate actions, plus queue UI-triggered notes to happen on audio thread

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "libs/link"]
 	path = libs/link
 	url = https://github.com/Ableton/link.git
+[submodule "libs/readerwriterqueue"]
+	path = libs/readerwriterqueue
+	url = https://github.com/cameron314/readerwriterqueue.git

--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -58,8 +58,8 @@ public:
    }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    bool CanBeTargetedBy(PatchCableSource* source) const override { return false; }
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/AbletonLink.cpp
+++ b/Source/AbletonLink.cpp
@@ -145,10 +145,10 @@ void AbletonLink::DrawModule()
    DrawTextNormal("peers: " + ofToString(mNumPeers) + "\ntempo: " + ofToString(mTempo) + "\nbeat: " + ofToString(mLastReceivedBeat), 3, 40);
 }
 
-void AbletonLink::CheckboxUpdated(Checkbox* checkbox)
+void AbletonLink::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void AbletonLink::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void AbletonLink::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }

--- a/Source/AbletonLink.h
+++ b/Source/AbletonLink.h
@@ -52,8 +52,8 @@ public:
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/Amplifier.h
+++ b/Source/Amplifier.h
@@ -47,7 +47,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Arpeggiator.cpp
+++ b/Source/Arpeggiator.cpp
@@ -142,7 +142,7 @@ bool Arpeggiator::MouseMoved(float x, float y)
    return false;
 }
 
-void Arpeggiator::CheckboxUpdated(Checkbox* checkbox)
+void Arpeggiator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -150,7 +150,7 @@ void Arpeggiator::CheckboxUpdated(Checkbox* checkbox)
       mChord.clear();
       mChordMutex.unlock();
 
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
    }
 }
 
@@ -276,17 +276,17 @@ void Arpeggiator::UpdateInterval()
       transportListenerInfo->mInterval = mInterval;
 }
 
-void Arpeggiator::ButtonClicked(ClickButton* button)
+void Arpeggiator::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void Arpeggiator::DropdownUpdated(DropdownList* list, int oldVal)
+void Arpeggiator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
       UpdateInterval();
 }
 
-void Arpeggiator::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Arpeggiator::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mArpStepSlider)
    {

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -66,15 +66,15 @@ public:
    void OnScaleChanged() override;
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/AudioLevelToCV.cpp
+++ b/Source/AudioLevelToCV.cpp
@@ -51,8 +51,8 @@ void AudioLevelToCV::CreateUIControls()
    mReleaseSlider->SetMode(FloatSlider::kSquare);
 
    //update mAttackFactor and mReleaseFactor
-   FloatSliderUpdated(mAttackSlider, 0);
-   FloatSliderUpdated(mReleaseSlider, 0);
+   FloatSliderUpdated(mAttackSlider, 0, gTime);
+   FloatSliderUpdated(mReleaseSlider, 0, gTime);
 
    GetPatchCableSource()->SetEnabled(false);
 
@@ -129,7 +129,7 @@ float AudioLevelToCV::Value(int samplesIn)
    return ofMap(mModulationBuffer[samplesIn], 0, 1, GetMin(), GetMax(), K(clamp));
 }
 
-void AudioLevelToCV::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void AudioLevelToCV::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mAttackSlider)
       mAttackFactor = powf(.01f, 1.0f / (mAttack * gSampleRateMs));

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -54,7 +54,7 @@ public:
    bool Active() const override { return mEnabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -47,7 +47,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/AudioRouter.cpp
+++ b/Source/AudioRouter.cpp
@@ -131,7 +131,7 @@ void AudioRouter::GetModuleDimensions(float& width, float& height)
    height = 8 + h;
 }
 
-void AudioRouter::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void AudioRouter::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mRouteSelector)
    {

--- a/Source/AudioRouter.h
+++ b/Source/AudioRouter.h
@@ -52,7 +52,7 @@ public:
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
    //IRadioButtonListener
-   void RadioButtonUpdated(RadioButton* button, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* button, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/AudioSend.cpp
+++ b/Source/AudioSend.cpp
@@ -118,7 +118,7 @@ void AudioSend::DrawModule()
    mCrossfadeCheckbox->Draw();
 }
 
-void AudioSend::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void AudioSend::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/AudioSend.h
+++ b/Source/AudioSend.h
@@ -54,7 +54,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    int GetNumTargets() override { return 2; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -54,7 +54,7 @@ public:
    bool Active() const override { return mEnabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/AudioToPulse.cpp
+++ b/Source/AudioToPulse.cpp
@@ -54,7 +54,7 @@ void AudioToPulse::CreateUIControls()
    mReleaseSlider->SetMode(FloatSlider::kSquare);
 
    //update mReleaseFactor
-   FloatSliderUpdated(mReleaseSlider, 0);
+   FloatSliderUpdated(mReleaseSlider, 0, gTime);
 
    GetPatchCableSource()->SetConnectionType(kConnectionType_Pulse);
 }
@@ -132,7 +132,7 @@ void AudioToPulse::Process(double time)
    GetBuffer()->Reset();
 }
 
-void AudioToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void AudioToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mReleaseSlider)
       mReleaseFactor = powf(.01f, 1.0f / (mRelease * gSampleRateMs));

--- a/Source/AudioToPulse.h
+++ b/Source/AudioToPulse.h
@@ -48,7 +48,7 @@ public:
 
    void Process(double time) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/Autotalent.cpp
+++ b/Source/Autotalent.cpp
@@ -951,7 +951,7 @@ void Autotalent::DrawModule()
    ofLine(x, 90, x, 90 - ofMap(mConfidence, 0, 1, 0, 50));
 }
 
-void Autotalent::ButtonClicked(ClickButton* button)
+void Autotalent::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mSetFromScaleButton)
    {

--- a/Source/Autotalent.h
+++ b/Source/Autotalent.h
@@ -59,15 +59,15 @@ public:
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
    //IRadioButtonListener
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/BandVocoder.cpp
+++ b/Source/BandVocoder.cpp
@@ -253,7 +253,7 @@ void BandVocoder::CalcFilters()
    }
 }
 
-void BandVocoder::CheckboxUpdated(Checkbox* checkbox)
+void BandVocoder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -265,7 +265,7 @@ void BandVocoder::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void BandVocoder::IntSliderUpdated(IntSlider* slider, int oldVal)
+void BandVocoder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumBandsSlider)
    {
@@ -273,7 +273,7 @@ void BandVocoder::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void BandVocoder::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void BandVocoder::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mFBaseSlider || slider == mFRangeSlider || slider == mQSlider || slider == mSpacingStyleSlider)
    {

--- a/Source/BandVocoder.h
+++ b/Source/BandVocoder.h
@@ -57,9 +57,9 @@ public:
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -397,7 +397,7 @@ void BeatBloks::DropdownClicked(DropdownList* list)
 {
 }
 
-void BeatBloks::DropdownUpdated(DropdownList* list, int oldVal)
+void BeatBloks::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -405,7 +405,7 @@ void BeatBloks::UpdateSample()
 {
 }
 
-void BeatBloks::ButtonClicked(ClickButton* button)
+void BeatBloks::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mWriteButton)
    {
@@ -916,7 +916,7 @@ BeatBloks::Blok* BeatBloks::RemoveBlokAt(int x)
    return nullptr;
 }
 
-void BeatBloks::CheckboxUpdated(Checkbox* checkbox)
+void BeatBloks::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mPlayCheckbox)
    {
@@ -936,7 +936,7 @@ void BeatBloks::GetModuleDimensions(float& width, float& height)
    height = mRemixBufferY + mBufferH + 45;
 }
 
-void BeatBloks::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void BeatBloks::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mClipStartSlider)
    {
@@ -966,7 +966,7 @@ void BeatBloks::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void BeatBloks::IntSliderUpdated(IntSlider* slider, int oldVal)
+void BeatBloks::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -70,16 +70,16 @@ public:
    bool MouseMoved(float x, float y) override;
 
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IFloatSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IDropdownListener
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Beats.cpp
+++ b/Source/Beats.cpp
@@ -95,14 +95,14 @@ void Beats::DropdownClicked(DropdownList* list)
 {
 }
 
-void Beats::DropdownUpdated(DropdownList* list, int oldVal)
+void Beats::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void Beats::RadioButtonUpdated(RadioButton* list, int oldVal)
+void Beats::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
    for (BeatColumn* column : mBeatColumns)
-      column->RadioButtonUpdated(list, oldVal);
+      column->RadioButtonUpdated(list, oldVal, time);
 }
 
 void Beats::OnTimeEvent(double time)
@@ -174,13 +174,13 @@ bool Beats::MouseMoved(float x, float y)
    return false;
 }
 
-void Beats::ButtonClicked(ClickButton* button)
+void Beats::ButtonClicked(ClickButton* button, double time)
 {
    for (BeatColumn* column : mBeatColumns)
-      column->ButtonClicked(button);
+      column->ButtonClicked(button, time);
 }
 
-void Beats::CheckboxUpdated(Checkbox* checkbox)
+void Beats::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -192,11 +192,11 @@ void Beats::GetModuleDimensions(float& width, float& height)
       height = MAX(height, 132 + 15 * (mBeatColumns[i]->GetNumSamples() + 1));
 }
 
-void Beats::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Beats::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void Beats::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Beats::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
@@ -422,7 +422,7 @@ void BeatColumn::AddBeat(Sample* sample)
    mSamples.push_back(newSample);
 }
 
-void BeatColumn::RadioButtonUpdated(RadioButton* list, int oldVal)
+void BeatColumn::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
    if (list == mSelector)
    {
@@ -431,7 +431,7 @@ void BeatColumn::RadioButtonUpdated(RadioButton* list, int oldVal)
    }
 }
 
-void BeatColumn::ButtonClicked(ClickButton* button)
+void BeatColumn::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mDeleteButton)
    {

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -69,8 +69,8 @@ public:
    void SaveState(FileStreamOut& out);
    void LoadState(FileStreamIn& in);
 
-   void RadioButtonUpdated(RadioButton* list, int oldVal);
-   void ButtonClicked(ClickButton* button);
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time);
+   void ButtonClicked(ClickButton* button, double time);
 
 private:
    RadioButton* mSelector{ nullptr };
@@ -117,13 +117,13 @@ public:
    bool CanDropSample() const override { return true; }
    bool MouseMoved(float x, float y) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
 
    //ITimeListener
    void OnTimeEvent(double time) override;

--- a/Source/BiquadFilterEffect.cpp
+++ b/Source/BiquadFilterEffect.cpp
@@ -185,11 +185,11 @@ void BiquadFilterEffect::ResetFilter()
    Clear();
 }
 
-void BiquadFilterEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void BiquadFilterEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void BiquadFilterEffect::RadioButtonUpdated(RadioButton* list, int oldVal)
+void BiquadFilterEffect::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
    if (list == mTypeSelector)
    {
@@ -213,14 +213,14 @@ bool BiquadFilterEffect::MouseMoved(float x, float y)
       GetPosition(thisx, thisy);
       x += thisx;
       y += thisy;
-      mFSlider->SetValue(x * 2 + 150);
-      mQSlider->SetValue(y / 100.0f);
+      mFSlider->SetValue(x * 2 + 150, NextBufferTime());
+      mQSlider->SetValue(y / 100.0f, NextBufferTime());
    }
 
    return false;
 }
 
-void BiquadFilterEffect::CheckboxUpdated(Checkbox* checkbox)
+void BiquadFilterEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -229,7 +229,7 @@ void BiquadFilterEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void BiquadFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void BiquadFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mFSlider || slider == mQSlider || slider == mGSlider)
       mCoefficientsHaveChanged = true;

--- a/Source/BiquadFilterEffect.cpp
+++ b/Source/BiquadFilterEffect.cpp
@@ -213,8 +213,8 @@ bool BiquadFilterEffect::MouseMoved(float x, float y)
       GetPosition(thisx, thisy);
       x += thisx;
       y += thisy;
-      mFSlider->SetValue(x * 2 + 150, NextBufferTime());
-      mQSlider->SetValue(y / 100.0f, NextBufferTime());
+      mFSlider->SetValue(x * 2 + 150, NextBufferTime(false));
+      mQSlider->SetValue(y / 100.0f, NextBufferTime(false));
    }
 
    return false;

--- a/Source/BiquadFilterEffect.h
+++ b/Source/BiquadFilterEffect.h
@@ -60,10 +60,10 @@ public:
 
    bool MouseMoved(float x, float y) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& info) override;
    void SetUpFromSaveData() override;

--- a/Source/BitcrushEffect.cpp
+++ b/Source/BitcrushEffect.cpp
@@ -101,14 +101,14 @@ float BitcrushEffect::GetEffectAmount()
    return ofClamp((mCrush - 1) / 24.0f + ((int)mDownsample - 1) / 40.0f, 0, 1);
 }
 
-void BitcrushEffect::CheckboxUpdated(Checkbox* checkbox)
+void BitcrushEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void BitcrushEffect::IntSliderUpdated(IntSlider* slider, int oldVal)
+void BitcrushEffect::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void BitcrushEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void BitcrushEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }

--- a/Source/BitcrushEffect.h
+++ b/Source/BitcrushEffect.h
@@ -47,9 +47,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "bitcrush"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/BoundsToPulse.cpp
+++ b/Source/BoundsToPulse.cpp
@@ -30,8 +30,16 @@ BoundsToPulse::BoundsToPulse()
 {
 }
 
+void BoundsToPulse::Init()
+{
+   IDrawableModule::Init();
+
+   TheTransport->AddAudioPoller(this);
+}
+
 BoundsToPulse::~BoundsToPulse()
 {
+   TheTransport->RemoveAudioPoller(this);
 }
 
 void BoundsToPulse::CreateUIControls()
@@ -46,6 +54,12 @@ void BoundsToPulse::CreateUIControls()
    AddPatchCableSource(mMaxCable);
 }
 
+void BoundsToPulse::OnTransportAdvanced(float amount)
+{
+   for (int i = 0; i < gBufferSize; ++i)
+      ComputeSliders(i);
+}
+
 void BoundsToPulse::DrawModule()
 {
    if (Minimized() || IsVisible() == false)
@@ -57,7 +71,7 @@ void BoundsToPulse::DrawModule()
    mMaxCable->SetManualPosition(100, 30);
 }
 
-void BoundsToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void BoundsToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (!mEnabled)
       return;
@@ -68,13 +82,13 @@ void BoundsToPulse::FloatSliderUpdated(FloatSlider* slider, float oldVal)
 
       if (mValue == slider->GetMin() && mValue < oldVal)
       {
-         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 1.f, 0);
-         DispatchPulse(mMinCable, gTime + gBufferSizeMs, 1.f, 0);
+         DispatchPulse(GetPatchCableSource(), time, 1.f, 0);
+         DispatchPulse(mMinCable, time, 1.f, 0);
       }
       else if (mValue == slider->GetMax() && oldVal < mValue)
       {
-         DispatchPulse(GetPatchCableSource(), gTime + gBufferSizeMs, 1.f, 0);
-         DispatchPulse(mMaxCable, gTime + gBufferSizeMs, 1.f, 0);
+         DispatchPulse(GetPatchCableSource(), time, 1.f, 0);
+         DispatchPulse(mMaxCable, time, 1.f, 0);
       }
    }
 }

--- a/Source/BoundsToPulse.h
+++ b/Source/BoundsToPulse.h
@@ -37,19 +37,23 @@
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "IPulseReceiver.h"
+#include "IAudioPoller.h"
 
-class BoundsToPulse : public IDrawableModule, public IFloatSliderListener, public IPulseSource
+class BoundsToPulse : public IDrawableModule, public IFloatSliderListener, public IPulseSource, public IAudioPoller
 {
 public:
    BoundsToPulse();
    virtual ~BoundsToPulse();
    static IDrawableModule* Create() { return new BoundsToPulse(); }
 
+   void Init() override;
    void CreateUIControls() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void OnTransportAdvanced(float amount) override;
+
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    float GetValue() const { return mValue; }
    FloatSlider* GetSlider() { return mSlider; }

--- a/Source/ButterworthFilterEffect.cpp
+++ b/Source/ButterworthFilterEffect.cpp
@@ -122,11 +122,11 @@ void ButterworthFilterEffect::ResetFilter()
       mButterworth[i].Clear();
 }
 
-void ButterworthFilterEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void ButterworthFilterEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void ButterworthFilterEffect::CheckboxUpdated(Checkbox* checkbox)
+void ButterworthFilterEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -134,7 +134,7 @@ void ButterworthFilterEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void ButterworthFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ButterworthFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mFSlider || slider == mQSlider)
       mCoefficientsHaveChanged = true;

--- a/Source/ButterworthFilterEffect.h
+++ b/Source/ButterworthFilterEffect.h
@@ -54,9 +54,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "butterworth"; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& info) override;
    void SetUpFromSaveData() override;

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -395,6 +395,8 @@ target_sources(BespokeSynth PRIVATE
     NoteLooper.h
     NoteOctaver.cpp
     NoteOctaver.h
+    NoteOutputQueue.cpp
+    NoteOutputQueue.h
     NotePanAlternator.cpp
     NotePanAlternator.h
     NotePanRandom.cpp
@@ -825,6 +827,7 @@ target_link_libraries(BespokeSynth PRIVATE
     $<$<STREQUAL:${BESPOKE_SYSTEM_TUNING_LIBRARY},OFF>:tuning-library>
     oddsound-mts
     Ableton::Link
+    readerwriterqueue
 
     juce::juce_audio_basics
     juce::juce_audio_devices

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -129,8 +129,8 @@ public:
    ofVec2f RescaleForZoom(float x, float y) const;
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    void KeyPressed(int key, bool isRepeat) override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/CanvasControls.cpp
+++ b/Source/CanvasControls.cpp
@@ -122,30 +122,30 @@ void CanvasControls::GetModuleDimensions(float& width, float& height)
    height = 92;
 }
 
-void CanvasControls::CheckboxUpdated(Checkbox* checkbox)
+void CanvasControls::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (auto* element : mCanvas->GetElements())
    {
       if (element->GetHighlighted())
-         element->CheckboxUpdated(checkbox->Name(), checkbox->GetValue() > 0);
+         element->CheckboxUpdated(checkbox->Name(), checkbox->GetValue() > 0, time);
    }
 }
 
-void CanvasControls::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void CanvasControls::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (auto* element : mCanvas->GetElements())
    {
       if (element->GetHighlighted())
-         element->FloatSliderUpdated(slider->Name(), oldVal, slider->GetValue());
+         element->FloatSliderUpdated(slider->Name(), oldVal, slider->GetValue(), time);
    }
 }
 
-void CanvasControls::IntSliderUpdated(IntSlider* slider, int oldVal)
+void CanvasControls::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    for (auto* element : mCanvas->GetElements())
    {
       if (element->GetHighlighted())
-         element->IntSliderUpdated(slider->Name(), oldVal, slider->GetValue());
+         element->IntSliderUpdated(slider->Name(), oldVal, slider->GetValue(), time);
    }
 }
 
@@ -158,7 +158,7 @@ void CanvasControls::TextEntryComplete(TextEntry* entry)
    }
 }
 
-void CanvasControls::ButtonClicked(ClickButton* button)
+void CanvasControls::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mRemoveElementButton)
    {
@@ -189,7 +189,7 @@ void CanvasControls::ButtonClicked(ClickButton* button)
    for (auto* element : elements)
    {
       if (element->GetHighlighted())
-         element->ButtonClicked(button->Name());
+         element->ButtonClicked(button->Name(), time);
    }
 }
 

--- a/Source/CanvasControls.h
+++ b/Source/CanvasControls.h
@@ -52,12 +52,12 @@ public:
 
    void AllowDragModeSelection(bool allow);
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -265,34 +265,34 @@ void CanvasElement::AddElementUIControl(IUIControl* control)
    control->SetShowing(false);
 }
 
-void CanvasElement::CheckboxUpdated(std::string label, bool value)
+void CanvasElement::CheckboxUpdated(std::string label, bool value, double time)
 {
    for (auto* control : mUIControls)
    {
       if (control->Name() == label)
-         control->SetValue(value);
+         control->SetValue(value, time);
    }
 }
 
-void CanvasElement::FloatSliderUpdated(std::string label, float oldVal, float newVal)
+void CanvasElement::FloatSliderUpdated(std::string label, float oldVal, float newVal, double time)
 {
    for (auto* control : mUIControls)
    {
       if (control->Name() == label)
-         control->SetValue(newVal);
+         control->SetValue(newVal, time);
    }
 }
 
-void CanvasElement::IntSliderUpdated(std::string label, int oldVal, float newVal)
+void CanvasElement::IntSliderUpdated(std::string label, int oldVal, float newVal, double time)
 {
    for (auto* control : mUIControls)
    {
       if (control->Name() == label)
-         control->SetValue(newVal);
+         control->SetValue(newVal, time);
    }
 }
 
-void CanvasElement::ButtonClicked(std::string label)
+void CanvasElement::ButtonClicked(std::string label, double time)
 {
 }
 
@@ -485,14 +485,14 @@ void SampleCanvasElement::SetSample(Sample* sample)
    mSample = sample;
 }
 
-void SampleCanvasElement::CheckboxUpdated(std::string label, bool value)
+void SampleCanvasElement::CheckboxUpdated(std::string label, bool value, double time)
 {
-   CanvasElement::CheckboxUpdated(label, value);
+   CanvasElement::CheckboxUpdated(label, value, time);
 }
 
-void SampleCanvasElement::ButtonClicked(std::string label)
+void SampleCanvasElement::ButtonClicked(std::string label, double time)
 {
-   CanvasElement::ButtonClicked(label);
+   CanvasElement::ButtonClicked(label, time);
    if (label == "split")
    {
       ChannelBuffer* firstHalf = new ChannelBuffer(mSample->Data()->BufferSize() / 2);
@@ -702,21 +702,21 @@ void EventCanvasElement::SetUIControl(IUIControl* control)
       mValue = 1;
 }
 
-void EventCanvasElement::Trigger()
+void EventCanvasElement::Trigger(double time)
 {
    if (mUIControl)
    {
       if (mIsCheckbox)
-         mUIControl->SetValue(1);
+         mUIControl->SetValue(1, time);
       else
-         mUIControl->SetValue(mValue);
+         mUIControl->SetValue(mValue, time);
    }
 }
 
-void EventCanvasElement::TriggerEnd()
+void EventCanvasElement::TriggerEnd(double time)
 {
    if (mUIControl && mIsCheckbox)
-      mUIControl->SetValue(0);
+      mUIControl->SetValue(0, time);
 }
 
 float EventCanvasElement::GetEnd() const

--- a/Source/CanvasElement.h
+++ b/Source/CanvasElement.h
@@ -61,10 +61,10 @@ public:
    virtual bool IsResizable() const { return true; }
    virtual CanvasElement* CreateDuplicate() const = 0;
 
-   virtual void CheckboxUpdated(std::string label, bool value);
-   virtual void FloatSliderUpdated(std::string label, float oldVal, float newVal);
-   virtual void IntSliderUpdated(std::string label, int oldVal, float newVal);
-   virtual void ButtonClicked(std::string label);
+   virtual void CheckboxUpdated(std::string label, bool value, double time);
+   virtual void FloatSliderUpdated(std::string label, float oldVal, float newVal, double time);
+   virtual void IntSliderUpdated(std::string label, int oldVal, float newVal, double time);
+   virtual void ButtonClicked(std::string label, double time);
 
    virtual void SaveState(FileStreamOut& out);
    virtual void LoadState(FileStreamIn& in);
@@ -142,8 +142,8 @@ public:
 
    CanvasElement* CreateDuplicate() const override;
 
-   void CheckboxUpdated(std::string label, bool value) override;
-   void ButtonClicked(std::string label) override;
+   void CheckboxUpdated(std::string label, bool value, double time) override;
+   void ButtonClicked(std::string label, double time) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in) override;
@@ -172,8 +172,8 @@ public:
 
    void SetUIControl(IUIControl* control);
    void SetValue(float value) { mValue = value; }
-   void Trigger();
-   void TriggerEnd();
+   void Trigger(double time);
+   void TriggerEnd(double time);
 
    bool IsResizable() const override { return mIsCheckbox; }
    float GetEnd() const override;

--- a/Source/CanvasScrollbar.h
+++ b/Source/CanvasScrollbar.h
@@ -49,8 +49,8 @@ public:
    }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    void KeyPressed(int key, bool isRepeat) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/CanvasTimeline.h
+++ b/Source/CanvasTimeline.h
@@ -43,8 +43,8 @@ public:
    }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    void KeyPressed(int key, bool isRepeat) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/Capo.cpp
+++ b/Source/Capo.cpp
@@ -53,10 +53,10 @@ void Capo::DrawModule()
    mDiatonicCheckbox->Draw();
 }
 
-void Capo::CheckboxUpdated(Checkbox* checkbox)
+void Capo::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void Capo::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -102,11 +102,10 @@ int Capo::TransformPitch(int pitch)
    }
 }
 
-void Capo::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Capo::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mCapoSlider && mEnabled && mRetrigger)
    {
-      double time = gTime + gBufferSizeMs;
       for (int pitch = 0; pitch < 128; ++pitch)
       {
          if (mInputNotes[pitch].mOn)

--- a/Source/Capo.h
+++ b/Source/Capo.h
@@ -47,9 +47,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -160,7 +160,7 @@ void ChaosEngine::UpdateProgression(int beat)
       mBeatsLeftToChordChange = TheTransport->GetTimeSigTop() - beat;
    mProgressionMutex.unlock();
 
-   mNoteOutput.Flush(gTime);
+   mNoteOutput.Flush(NextBufferTime());
    if (mPlayChord)
    {
       std::vector<int> pitches = GetCurrentChordPitches();

--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -683,7 +683,7 @@ ChaosEngine::ProgressionChord::ProgressionChord(const ofxJSONElement& chordInfo,
    }
 }
 
-void ChaosEngine::DropdownUpdated(DropdownList* list, int oldVal)
+void ChaosEngine::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mSongDropdown)
    {
@@ -726,11 +726,11 @@ void ChaosEngine::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void ChaosEngine::ButtonClicked(ClickButton* button)
+void ChaosEngine::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mChaosButton)
    {
-      mChaosArrivalTime = gTime + ofRandom(2000, 3000);
+      mChaosArrivalTime = time + ofRandom(2000, 3000);
    }
    if (button == mReadSongsButton)
    {
@@ -767,11 +767,11 @@ void ChaosEngine::ButtonClicked(ClickButton* button)
    }
 }
 
-void ChaosEngine::CheckboxUpdated(Checkbox* checkbox)
+void ChaosEngine::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void ChaosEngine::RadioButtonUpdated(RadioButton* list, int oldVal)
+void ChaosEngine::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
    if (list == mSectionDropdown)
    {
@@ -789,7 +789,7 @@ void ChaosEngine::RadioButtonUpdated(RadioButton* list, int oldVal)
    }
 }
 
-void ChaosEngine::IntSliderUpdated(IntSlider* slider, int oldVal)
+void ChaosEngine::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mDegreeSlider)
    {

--- a/Source/ChaosEngine.cpp
+++ b/Source/ChaosEngine.cpp
@@ -160,7 +160,7 @@ void ChaosEngine::UpdateProgression(int beat)
       mBeatsLeftToChordChange = TheTransport->GetTimeSigTop() - beat;
    mProgressionMutex.unlock();
 
-   mNoteOutput.Flush(NextBufferTime());
+   mNoteOutput.Flush(NextBufferTime(false));
    if (mPlayChord)
    {
       std::vector<int> pitches = GetCurrentChordPitches();

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -62,11 +62,11 @@ public:
       mChordProgressionIdx = -1;
    }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -143,7 +143,7 @@ void Checkbox::OnClicked(float x, float y, bool right)
 
    *mVar = !(*mVar);
    CalcSliderVal();
-   mOwner->CheckboxUpdated(this, NextBufferTime());
+   mOwner->CheckboxUpdated(this, NextBufferTime(false));
 }
 
 void Checkbox::CalcSliderVal()

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -143,7 +143,7 @@ void Checkbox::OnClicked(float x, float y, bool right)
 
    *mVar = !(*mVar);
    CalcSliderVal();
-   mOwner->CheckboxUpdated(this);
+   mOwner->CheckboxUpdated(this, NextBufferTime());
 }
 
 void Checkbox::CalcSliderVal()
@@ -158,7 +158,7 @@ bool Checkbox::MouseMoved(float x, float y)
    return false;
 }
 
-void Checkbox::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void Checkbox::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
    slider = ofClamp(slider, 0, 1);
    mSliderVal = slider;
@@ -167,7 +167,7 @@ void Checkbox::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
    {
       *mVar = on;
       mLastSetValue = *mVar;
-      mOwner->CheckboxUpdated(this);
+      mOwner->CheckboxUpdated(this, time);
    }
 }
 
@@ -176,14 +176,14 @@ float Checkbox::GetValueForMidiCC(float slider) const
    return slider > .5f ? 1 : 0;
 }
 
-void Checkbox::SetValue(float value)
+void Checkbox::SetValue(float value, double time)
 {
    bool on = value > 0.5f;
    if (*mVar != on)
    {
       *mVar = on;
       CalcSliderVal();
-      mOwner->CheckboxUpdated(this);
+      mOwner->CheckboxUpdated(this, time);
    }
 }
 
@@ -237,5 +237,5 @@ void Checkbox::LoadState(FileStreamIn& in, bool shouldSetValue)
    float var;
    in >> var;
    if (shouldSetValue)
-      SetValueDirect(var);
+      SetValueDirect(var, gTime);
 }

--- a/Source/Checkbox.h
+++ b/Source/Checkbox.h
@@ -46,9 +46,9 @@ public:
    bool MouseMoved(float x, float y) override;
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return 2; }

--- a/Source/ChordHolder.cpp
+++ b/Source/ChordHolder.cpp
@@ -50,25 +50,25 @@ void ChordHolder::DrawModule()
    mOnlyPlayWhenPulsedCheckbox->Draw();
 }
 
-void ChordHolder::Stop()
+void ChordHolder::Stop(double time)
 {
    for (int i = 0; i < 128; ++i)
    {
       if (mNotePlaying[i] && !mNoteInputHeld[i])
       {
-         PlayNoteOutput(gTime + gBufferSizeMs, i, 0, -1);
+         PlayNoteOutput(time, i, 0, -1);
          mNotePlaying[i] = false;
       }
    }
 }
 
-void ChordHolder::ButtonClicked(ClickButton* button)
+void ChordHolder::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mStopButton)
-      Stop();
+      Stop(time);
 }
 
-void ChordHolder::CheckboxUpdated(Checkbox* checkbox)
+void ChordHolder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -79,7 +79,7 @@ void ChordHolder::CheckboxUpdated(Checkbox* checkbox)
       }
       else
       {
-         Stop();
+         Stop(time);
       }
    }
 }

--- a/Source/ChordHolder.h
+++ b/Source/ChordHolder.h
@@ -50,8 +50,8 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
@@ -66,7 +66,7 @@ private:
    }
    bool Enabled() const override { return mEnabled; }
 
-   void Stop();
+   void Stop(double time);
 
    std::array<bool, 128> mNoteInputHeld{ false };
    std::array<bool, 128> mNotePlaying{ false };

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -138,7 +138,7 @@ void Chorder::AddTone(int tone, float velocity)
       {
          int chordtone = tone + TheScale->GetToneFromPitch(i);
          int outPitch = TheScale->MakeDiatonic(TheScale->GetPitchFromTone(chordtone));
-         PlayChorderNote(gTime + gBufferSizeMs, outPitch, mVelocity * velocity, -1, ModulationParameters());
+         PlayChorderNote(NextBufferTime(), outPitch, mVelocity * velocity, -1, ModulationParameters());
       }
    }
 }
@@ -154,7 +154,7 @@ void Chorder::RemoveTone(int tone)
       {
          int chordtone = tone + TheScale->GetToneFromPitch(i);
          int outPitch = TheScale->MakeDiatonic(TheScale->GetPitchFromTone(chordtone));
-         PlayChorderNote(gTime + gBufferSizeMs, outPitch, 0, -1, ModulationParameters());
+         PlayChorderNote(NextBufferTime(), outPitch, 0, -1, ModulationParameters());
       }
    }
 }
@@ -187,11 +187,11 @@ void Chorder::OnScaleChanged()
    mChordGrid->SetGrid(mDiatonic ? TheScale->NumTonesInScale() : TheScale->GetPitchesPerOctave(), 3);
 }
 
-void Chorder::CheckboxUpdated(Checkbox* checkbox)
+void Chorder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      mNoteOutput.Flush(gTime + gBufferSizeMs);
+      mNoteOutput.Flush(time);
       std::memset(mHeldCount, 0, TOTAL_NUM_NOTES * sizeof(int));
       std::memset(mInputNotes, 0, TOTAL_NUM_NOTES * sizeof(bool));
    }
@@ -204,7 +204,7 @@ void Chorder::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void Chorder::DropdownUpdated(DropdownList* dropdown, int oldVal)
+void Chorder::DropdownUpdated(DropdownList* dropdown, int oldVal, double time)
 {
    if (dropdown == mChordDropdown || dropdown == mInversionDropdown)
    {

--- a/Source/Chorder.cpp
+++ b/Source/Chorder.cpp
@@ -138,7 +138,7 @@ void Chorder::AddTone(int tone, float velocity)
       {
          int chordtone = tone + TheScale->GetToneFromPitch(i);
          int outPitch = TheScale->MakeDiatonic(TheScale->GetPitchFromTone(chordtone));
-         PlayChorderNote(NextBufferTime(), outPitch, mVelocity * velocity, -1, ModulationParameters());
+         PlayChorderNote(NextBufferTime(false), outPitch, mVelocity * velocity, -1, ModulationParameters());
       }
    }
 }
@@ -154,7 +154,7 @@ void Chorder::RemoveTone(int tone)
       {
          int chordtone = tone + TheScale->GetToneFromPitch(i);
          int outPitch = TheScale->MakeDiatonic(TheScale->GetPitchFromTone(chordtone));
-         PlayChorderNote(NextBufferTime(), outPitch, 0, -1, ModulationParameters());
+         PlayChorderNote(NextBufferTime(false), outPitch, 0, -1, ModulationParameters());
       }
    }
 }

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -54,8 +54,8 @@ public:
 
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* dropdown, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* dropdown, int oldVal, double time) override;
 
    void OnScaleChanged() override;
 

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -124,15 +124,15 @@ bool CircleSequencer::MouseMoved(float x, float y)
    return false;
 }
 
-void CircleSequencer::CheckboxUpdated(Checkbox* checkbox)
+void CircleSequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void CircleSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void CircleSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void CircleSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void CircleSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -311,10 +311,10 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
 
    double remainderMs;
    int oldStep = TheTransport->GetQuantized(gTime, &info);
-   int newStep = TheTransport->GetQuantized(gTime + gBufferSizeMs, &info, &remainderMs);
+   int newStep = TheTransport->GetQuantized(NextBufferTime(), &info, &remainderMs);
    if (oldStep != newStep && mSteps[newStep] > 0)
    {
-      double time = gTime + gBufferSizeMs - remainderMs;
+      double time = NextBufferTime() - remainderMs;
       mOwner->PlayNoteOutput(time, mPitch, mSteps[newStep] * 127, -1);
       mOwner->PlayNoteOutput(time + TheTransport->GetDuration(kInterval_16n), mPitch, 0, -1);
    }

--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -311,10 +311,10 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
 
    double remainderMs;
    int oldStep = TheTransport->GetQuantized(gTime, &info);
-   int newStep = TheTransport->GetQuantized(NextBufferTime(), &info, &remainderMs);
+   int newStep = TheTransport->GetQuantized(NextBufferTime(false), &info, &remainderMs);
    if (oldStep != newStep && mSteps[newStep] > 0)
    {
-      double time = NextBufferTime() - remainderMs;
+      double time = NextBufferTime(false) - remainderMs;
       mOwner->PlayNoteOutput(time, mPitch, mSteps[newStep] * 127, -1);
       mOwner->PlayNoteOutput(time + TheTransport->GetDuration(kInterval_16n), mPitch, 0, -1);
    }

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -91,9 +91,9 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    void SaveState(FileStreamOut& out) override;

--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -167,8 +167,13 @@ void ClickButton::OnClicked(float x, float y, bool right)
    if (right)
       return;
 
-   mClickTime = gTime;
-   mOwner->ButtonClicked(this);
+   DoClick(NextBufferTime());
+}
+
+void ClickButton::DoClick(double time)
+{
+   mClickTime = time;
+   mOwner->ButtonClicked(this, time);
 }
 
 void ClickButton::MouseReleased()
@@ -182,18 +187,18 @@ bool ClickButton::MouseMoved(float x, float y)
    return false;
 }
 
-void ClickButton::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void ClickButton::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
    if (slider > 0)
-      OnClicked(0, 0, false);
+      DoClick(time);
    else
       MouseReleased();
 }
 
-void ClickButton::SetValue(float value)
+void ClickButton::SetValue(float value, double time)
 {
    if (value > 0)
-      OnClicked(0, 0, false);
+      DoClick(time);
    else
       MouseReleased();
 }

--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -167,7 +167,7 @@ void ClickButton::OnClicked(float x, float y, bool right)
    if (right)
       return;
 
-   DoClick(NextBufferTime());
+   DoClick(NextBufferTime(false));
 }
 
 void ClickButton::DoClick(double time)

--- a/Source/ClickButton.h
+++ b/Source/ClickButton.h
@@ -34,7 +34,7 @@ class IButtonListener
 {
 public:
    virtual ~IButtonListener() {}
-   virtual void ButtonClicked(ClickButton* button) = 0;
+   virtual void ButtonClicked(ClickButton* button, double time) = 0;
 };
 
 enum class ButtonDisplayStyle
@@ -69,8 +69,8 @@ public:
    }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
-   void SetValue(float value) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override { return GetMidiValue(); }
    float GetMidiValue() const override;
    std::string GetDisplayValue(float val) const override;
@@ -89,6 +89,7 @@ protected:
    ~ClickButton(); //protected so that it can't be created on the stack
 
 private:
+   void DoClick(double time);
    bool ButtonLit() const;
 
    void OnClicked(float x, float y, bool right) override;

--- a/Source/ClipArranger.cpp
+++ b/Source/ClipArranger.cpp
@@ -227,15 +227,15 @@ ClipArranger::Clip* ClipArranger::GetEmptyClip()
    return nullptr;
 }
 
-void ClipArranger::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ClipArranger::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void ClipArranger::ButtonClicked(ClickButton* button)
+void ClipArranger::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void ClipArranger::CheckboxUpdated(Checkbox* checkbox)
+void ClipArranger::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/ClipArranger.h
+++ b/Source/ClipArranger.h
@@ -52,9 +52,9 @@ public:
 
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/ClipLauncher.cpp
+++ b/Source/ClipLauncher.cpp
@@ -114,7 +114,7 @@ void ClipLauncher::DropdownClicked(DropdownList* list)
 {
 }
 
-void ClipLauncher::DropdownUpdated(DropdownList* list, int oldVal)
+void ClipLauncher::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -142,11 +142,11 @@ int ClipLauncher::GetRowY(int idx)
    return 20 + idx * 40;
 }
 
-void ClipLauncher::ButtonClicked(ClickButton* button)
+void ClipLauncher::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void ClipLauncher::CheckboxUpdated(Checkbox* checkbox)
+void ClipLauncher::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (int i = 0; i < mSamples.size(); ++i)
    {
@@ -175,7 +175,7 @@ void ClipLauncher::CheckboxUpdated(Checkbox* checkbox)
             float data[JUMP_BLEND_SAMPLES];
             ChannelBuffer temp(data, JUMP_BLEND_SAMPLES);
             if (currentlyPlaying != -1)
-               mSamples[currentlyPlaying].mSample->ConsumeData(gTime, &temp, JUMP_BLEND_SAMPLES, true);
+               mSamples[currentlyPlaying].mSample->ConsumeData(time, &temp, JUMP_BLEND_SAMPLES, true);
             mJumpBlender.CaptureForJump(0, data, JUMP_BLEND_SAMPLES, gBufferSize);
             mSampleMutex.unlock();
          }
@@ -214,7 +214,7 @@ void ClipLauncher::GetModuleDimensions(float& width, float& height)
    height = 180;
 }
 
-void ClipLauncher::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ClipLauncher::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
@@ -231,7 +231,7 @@ void ClipLauncher::RecalcPos(double time, int idx)
    }
 }
 
-void ClipLauncher::IntSliderUpdated(IntSlider* slider, int oldVal)
+void ClipLauncher::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/ClipLauncher.h
+++ b/Source/ClipLauncher.h
@@ -58,12 +58,12 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void OnTimeEvent(double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/CodeEntry.h
+++ b/Source/CodeEntry.h
@@ -74,8 +74,8 @@ public:
    void SetDimensions(float width, float height);
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;
    bool IsSliderControl() override { return false; }

--- a/Source/Compressor.cpp
+++ b/Source/Compressor.cpp
@@ -169,13 +169,13 @@ void Compressor::DrawModule()
    ofPopStyle();
 }
 
-void Compressor::CheckboxUpdated(Checkbox* checkbox)
+void Compressor::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
       envdB_ = DC_OFFSET; //reset state
 }
 
-void Compressor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Compressor::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mAttackSlider)
       mEnv.setAttack(MAX(.1f, mAttack));

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -123,8 +123,8 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    std::string GetType() override { return "compressor"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/ControlSequencer.cpp
+++ b/Source/ControlSequencer.cpp
@@ -143,7 +143,7 @@ void ControlSequencer::Step(double time, int pulseFlags)
       for (auto* target : mTargets)
       {
          if (target != nullptr)
-            target->SetFromMidiCC(mGrid->GetVal(mStep, 0), true);
+            target->SetFromMidiCC(mGrid->GetVal(mStep, 0), time, true);
       }
    }
 }
@@ -281,7 +281,7 @@ void ControlSequencer::PostRepatch(PatchCableSource* cableSource, bool fromUserC
    }
 }
 
-void ControlSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void ControlSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLengthSlider)
    {
@@ -299,7 +299,7 @@ void ControlSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void ControlSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void ControlSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -309,7 +309,7 @@ void ControlSequencer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void ControlSequencer::ButtonClicked(ClickButton* button)
+void ControlSequencer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mRandomize)
    {

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -76,11 +76,11 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/ControlTactileFeedback.h
+++ b/Source/ControlTactileFeedback.h
@@ -47,10 +47,10 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/ControllingSong.cpp
+++ b/Source/ControllingSong.cpp
@@ -260,7 +260,7 @@ void ControllingSong::DrawModule()
    ofPopStyle();
 }
 
-void ControllingSong::DropdownUpdated(DropdownList* list, int oldVal)
+void ControllingSong::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mSongSelector)
    {
@@ -268,7 +268,7 @@ void ControllingSong::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void ControllingSong::ButtonClicked(ClickButton* button)
+void ControllingSong::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mNextSongButton)
       mNeedNewSong = true;
@@ -285,15 +285,15 @@ void ControllingSong::ButtonClicked(ClickButton* button)
    }
 }
 
-void ControllingSong::CheckboxUpdated(Checkbox* checkbox)
+void ControllingSong::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void ControllingSong::RadioButtonUpdated(RadioButton* list, int oldVal)
+void ControllingSong::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
 }
 
-void ControllingSong::IntSliderUpdated(IntSlider* slider, int oldVal)
+void ControllingSong::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mTestBeatOffsetSlider)
    {
@@ -301,7 +301,7 @@ void ControllingSong::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void ControllingSong::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ControllingSong::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/ControllingSong.h
+++ b/Source/ControllingSong.h
@@ -57,12 +57,12 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -107,7 +107,7 @@ void CurveLooper::OnTransportAdvanced(float amount)
       for (auto* control : mUIControls)
       {
          if (control != nullptr)
-            control->SetFromMidiCC(mAdsr.Value(GetPlaybackPosition() * kAdsrTime), true);
+            control->SetFromMidiCC(mAdsr.Value(GetPlaybackPosition() * kAdsrTime), gTime, true);
       }
    }
 }
@@ -174,11 +174,11 @@ void CurveLooper::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
    }
 }
 
-void CurveLooper::CheckboxUpdated(Checkbox* checkbox)
+void CurveLooper::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void CurveLooper::DropdownUpdated(DropdownList* list, int oldVal)
+void CurveLooper::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    /*int newSteps = int(mLength/4.0f * TheTransport->CountInStandardMeasure(mInterval));
    if (list == mIntervalSelector)
@@ -201,7 +201,7 @@ void CurveLooper::DropdownUpdated(DropdownList* list, int oldVal)
    }*/
 }
 
-void CurveLooper::ButtonClicked(ClickButton* button)
+void CurveLooper::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mRandomizeButton)
    {

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -54,9 +54,9 @@ public:
    void Resize(float w, float h) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/DCOffset.h
+++ b/Source/DCOffset.h
@@ -47,7 +47,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/DCRemoverEffect.cpp
+++ b/Source/DCRemoverEffect.cpp
@@ -72,7 +72,7 @@ void DCRemoverEffect::GetModuleDimensions(float& width, float& height)
    height = 0;
 }
 
-void DCRemoverEffect::CheckboxUpdated(Checkbox* checkbox)
+void DCRemoverEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/DCRemoverEffect.h
+++ b/Source/DCRemoverEffect.h
@@ -46,7 +46,7 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "dcremover"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/DebugAudioSource.h
+++ b/Source/DebugAudioSource.h
@@ -46,10 +46,10 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/DelayEffect.cpp
+++ b/Source/DelayEffect.cpp
@@ -198,7 +198,7 @@ void DelayEffect::SetEnabled(bool enabled)
       mDelayBuffer.ClearBuffer();
 }
 
-void DelayEffect::CheckboxUpdated(Checkbox* checkbox)
+void DelayEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mShortTimeCheckbox)
       SetShortMode(mShortTime);
@@ -209,16 +209,16 @@ void DelayEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void DelayEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void DelayEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mDelaySlider)
    {
       mInterval = kInterval_None;
-      mDelayRamp.Start(gTime, mDelay, gTime + 30);
+      mDelayRamp.Start(time, mDelay, time + 30);
    }
 }
 
-void DelayEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void DelayEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -61,9 +61,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "delay"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;

--- a/Source/DistortionEffect.cpp
+++ b/Source/DistortionEffect.cpp
@@ -201,7 +201,7 @@ float DistortionEffect::GetEffectAmount()
    return ofClamp((mPreamp - 1) / 10 + (1 - mClip), 0, 1);
 }
 
-void DistortionEffect::CheckboxUpdated(Checkbox* checkbox)
+void DistortionEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -210,7 +210,7 @@ void DistortionEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void DistortionEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void DistortionEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mClipSlider)
       SetClip(mClip);

--- a/Source/DistortionEffect.h
+++ b/Source/DistortionEffect.h
@@ -52,9 +52,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "distortion"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
 private:
    enum DistortionType

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -303,7 +303,7 @@ bool DropdownList::DropdownClickedAt(int x, int y)
    int index = GetItemIndexAt(x, y);
    if (index >= 0 && index < mElements.size())
    {
-      SetIndex(index, NextBufferTime(), K(forceUpdate));
+      SetIndex(index, NextBufferTime(false), K(forceUpdate));
       return true;
    }
    return false;

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -44,7 +44,7 @@ class IDropdownListener
 public:
    virtual ~IDropdownListener() {}
    virtual void DropdownClicked(DropdownList* list) {}
-   virtual void DropdownUpdated(DropdownList* list, int oldVal) = 0;
+   virtual void DropdownUpdated(DropdownList* list, int oldVal, double time) = 0;
 };
 
 class DropdownListModal : public IDrawableModule, public IButtonListener
@@ -77,7 +77,7 @@ public:
    void SetShowPagingControls(bool show);
    void SetIsScrolling(bool scrolling) { mIsScrolling = scrolling; }
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    void OnClicked(float x, float y, bool right) override;
@@ -105,7 +105,7 @@ public:
    void MouseReleased() override;
    void DrawDropdown(int w, int h, bool isScrolling);
    bool DropdownClickedAt(int x, int y);
-   void SetIndex(int i, bool forceUpdate = false);
+   void SetIndex(int i, double time, bool forceUpdate);
    void Clear();
    void SetVar(int* var) { mVar = var; }
    EnumMap GetEnumMap();
@@ -132,9 +132,9 @@ public:
    void ClearSeparators() { mSeparators.clear(); }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
@@ -157,7 +157,7 @@ private:
    void OnClicked(float x, float y, bool right) override;
    void CalcSliderVal();
    int FindItemIndex(float val) const;
-   void SetValue(int value, bool forceUpdate);
+   void SetValue(int value, double time, bool forceUpdate);
    void CalculateWidth();
    ofVec2f GetModalListPosition() const;
 

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -673,7 +673,7 @@ void DrumPlayer::OnGridButton(int x, int y, float velocity, IGridController* gri
    {
       if (velocity > 0 && mQuantizeInterval == kInterval_None)
       {
-         PlayNote(NextBufferTime(), sampleIdx, velocity * 127);
+         PlayNote(NextBufferTime(false), sampleIdx, velocity * 127);
       }
       else
       {

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -673,7 +673,7 @@ void DrumPlayer::OnGridButton(int x, int y, float velocity, IGridController* gri
    {
       if (velocity > 0 && mQuantizeInterval == kInterval_None)
       {
-         PlayNote(gTime + gBufferSizeMs, sampleIdx, velocity * 127);
+         PlayNote(NextBufferTime(), sampleIdx, velocity * 127);
       }
       else
       {
@@ -986,7 +986,7 @@ void DrumPlayer::GetModuleDimensions(float& width, float& height)
    }
 }
 
-void DrumPlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void DrumPlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mAuditionSlider)
    {
@@ -1005,7 +1005,7 @@ void DrumPlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
             LoadSampleLock();
             mDrumHits[mSelectedHitIdx].mSample.Read(file.c_str());
             LoadSampleUnlock();
-            mDrumHits[mSelectedHitIdx].StartPlayhead(gTime, 0, 1);
+            mDrumHits[mSelectedHitIdx].StartPlayhead(time, 0, 1);
             mDrumHits[mSelectedHitIdx].mVelocity = .5f;
             mDrumHits[mSelectedHitIdx].mEnvelopeLength = mDrumHits[mSelectedHitIdx].mSample.LengthInSamples() * gInvSampleRateMs;
          }
@@ -1013,11 +1013,11 @@ void DrumPlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void DrumPlayer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void DrumPlayer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void DrumPlayer::DropdownUpdated(DropdownList* list, int oldVal)
+void DrumPlayer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mKitSelector)
       LoadKit(mLoadedKit);
@@ -1035,7 +1035,7 @@ void DrumPlayer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void DrumPlayer::CheckboxUpdated(Checkbox* checkbox)
+void DrumPlayer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEditCheckbox)
       UpdateVisibleControls();
@@ -1063,7 +1063,7 @@ void DrumPlayer::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void DrumPlayer::ButtonClicked(ClickButton* button)
+void DrumPlayer::ButtonClicked(ClickButton* button, double time)
 {
    /*if (button == mSaveButton)
       SaveKits();
@@ -1075,7 +1075,7 @@ void DrumPlayer::ButtonClicked(ClickButton* button)
    for (int i = 0; i < NUM_DRUM_HITS; ++i)
    {
       if (button == mDrumHits[i].mTestButton)
-         PlayNote(gTime + gBufferSizeMs, i, 127);
+         PlayNote(time, i, 127);
       if (button == mDrumHits[i].mRandomButton)
          mDrumHits[i].LoadRandomSample();
       if (button == mDrumHits[i].mGrabSampleButton)

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -87,11 +87,11 @@ public:
    //ITimeListener
    void OnTimeEvent(double time) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/DrumSynth.cpp
+++ b/Source/DrumSynth.cpp
@@ -236,27 +236,27 @@ void DrumSynth::GetModuleDimensions(float& width, float& height)
    height = 2 + kPadYOffset + mHits.size() / DRUMSYNTH_PADS_HORIZONTAL * DRUMSYNTH_PAD_HEIGHT;
 }
 
-void DrumSynth::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void DrumSynth::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void DrumSynth::IntSliderUpdated(IntSlider* slider, int oldVal)
+void DrumSynth::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void DrumSynth::DropdownUpdated(DropdownList* list, int oldVal)
+void DrumSynth::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void DrumSynth::CheckboxUpdated(Checkbox* checkbox)
+void DrumSynth::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void DrumSynth::ButtonClicked(ClickButton* button)
+void DrumSynth::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void DrumSynth::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void DrumSynth::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -70,12 +70,12 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/EQEffect.cpp
+++ b/Source/EQEffect.cpp
@@ -110,15 +110,15 @@ void EQEffect::GetModuleDimensions(float& width, float& height)
    height = 80;
 }
 
-void EQEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void EQEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void EQEffect::RadioButtonUpdated(RadioButton* list, int oldVal)
+void EQEffect::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
 }
 
-void EQEffect::CheckboxUpdated(Checkbox* checkbox)
+void EQEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -130,11 +130,11 @@ void EQEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void EQEffect::IntSliderUpdated(IntSlider* slider, int oldVal)
+void EQEffect::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void EQEffect::ButtonClicked(ClickButton* button)
+void EQEffect::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mEvenButton)
    {

--- a/Source/EQEffect.h
+++ b/Source/EQEffect.h
@@ -57,11 +57,11 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "basiceq"; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
 
 private:

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -334,8 +334,8 @@ bool EQModule::MouseMoved(float x, float y)
    {
       if (mHoveredFilterHandleIndex != -1)
       {
-         mFilters[mHoveredFilterHandleIndex].mFSlider->SetValue(FreqForPos(x / w), NextBufferTime());
-         mFilters[mHoveredFilterHandleIndex].mGSlider->SetValue(GainForPos((y - kDrawYOffset) / h), NextBufferTime());
+         mFilters[mHoveredFilterHandleIndex].mFSlider->SetValue(FreqForPos(x / w), NextBufferTime(false));
+         mFilters[mHoveredFilterHandleIndex].mGSlider->SetValue(GainForPos((y - kDrawYOffset) / h), NextBufferTime(false));
       }
    }
    else

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -334,8 +334,8 @@ bool EQModule::MouseMoved(float x, float y)
    {
       if (mHoveredFilterHandleIndex != -1)
       {
-         mFilters[mHoveredFilterHandleIndex].mFSlider->SetValue(FreqForPos(x / w));
-         mFilters[mHoveredFilterHandleIndex].mGSlider->SetValue(GainForPos((y - kDrawYOffset) / h));
+         mFilters[mHoveredFilterHandleIndex].mFSlider->SetValue(FreqForPos(x / w), NextBufferTime());
+         mFilters[mHoveredFilterHandleIndex].mGSlider->SetValue(GainForPos((y - kDrawYOffset) / h), NextBufferTime());
       }
    }
    else
@@ -356,7 +356,7 @@ bool EQModule::MouseMoved(float x, float y)
    return false;
 }
 
-void EQModule::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void EQModule::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (auto& filter : mFilters)
    {
@@ -370,7 +370,7 @@ void EQModule::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void EQModule::DropdownUpdated(DropdownList* list, int oldVal)
+void EQModule::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    for (auto& filter : mFilters)
    {
@@ -382,7 +382,7 @@ void EQModule::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void EQModule::CheckboxUpdated(Checkbox* checkbox)
+void EQModule::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (auto& filter : mFilters)
    {

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -56,9 +56,9 @@ public:
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -461,7 +461,7 @@ void EffectChain::UpdateReshuffledDryWetSliders()
    }
 }
 
-void EffectChain::ButtonClicked(ClickButton* button)
+void EffectChain::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mSpawnEffectButton)
    {
@@ -492,15 +492,15 @@ void EffectChain::ButtonClicked(ClickButton* button)
    }
 }
 
-void EffectChain::CheckboxUpdated(Checkbox* checkbox)
+void EffectChain::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void EffectChain::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void EffectChain::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void EffectChain::DropdownUpdated(DropdownList* list, int oldVal)
+void EffectChain::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mEffectSpawnList)
    {

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -64,10 +64,10 @@ public:
    bool HasPush2OverrideControls() const override { return true; }
    void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const override;
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName) override;
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -538,7 +538,7 @@ bool EnvelopeEditor::MouseMoved(float x, float y)
    return false;
 }
 
-void EnvelopeEditor::CheckboxUpdated(Checkbox* checkbox)
+void EnvelopeEditor::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (int i = 0; i < (int)mStageControls.size(); ++i)
    {
@@ -557,7 +557,7 @@ void EnvelopeEditor::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void EnvelopeEditor::ButtonClicked(ClickButton* button)
+void EnvelopeEditor::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPinButton)
    {
@@ -585,7 +585,7 @@ void EnvelopeEditor::Pin()
    }
 }
 
-void EnvelopeEditor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void EnvelopeEditor::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mADSRViewLengthSlider)
    {

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -97,12 +97,12 @@ public:
    bool HasSpecialDelete() const override { return true; }
    void DoSpecialDelete() override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    void GetModuleDimensions(float& width, float& height) override
    {

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -136,15 +136,15 @@ void EnvelopeModulator::PostRepatch(PatchCableSource* cableSource, bool fromUser
    OnModulatorRepatch();
 }
 
-void EnvelopeModulator::CheckboxUpdated(Checkbox* checkbox)
+void EnvelopeModulator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void EnvelopeModulator::ButtonClicked(ClickButton* button)
+void EnvelopeModulator::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void EnvelopeModulator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void EnvelopeModulator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -68,12 +68,12 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    void GetModuleDimensions(float& width, float& height) override;
 

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -154,16 +154,16 @@ void EventCanvas::OnTransportAdvanced(float amount)
          if (curPos > elementEnd)
          {
             if (startPassed)
-               element->Trigger();
+               element->Trigger(NextBufferTime());
             if (endPassed)
-               element->TriggerEnd();
+               element->TriggerEnd(NextBufferTime());
          }
          else
          {
             if (endPassed)
-               element->TriggerEnd();
+               element->TriggerEnd(NextBufferTime());
             if (startPassed)
-               element->Trigger();
+               element->Trigger(NextBufferTime());
          }
 
          IUIControl* control = mRowConnections[element->mRow].mUIControl;
@@ -333,7 +333,7 @@ void EventCanvas::GetModuleDimensions(float& width, float& height)
    height = mCanvas->GetHeight() + extraH;
 }
 
-void EventCanvas::CheckboxUpdated(Checkbox* checkbox)
+void EventCanvas::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -341,7 +341,7 @@ void EventCanvas::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void EventCanvas::ButtonClicked(ClickButton* button)
+void EventCanvas::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mQuantizeButton)
    {
@@ -365,11 +365,11 @@ void EventCanvas::ButtonClicked(ClickButton* button)
    }
 }
 
-void EventCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void EventCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void EventCanvas::IntSliderUpdated(IntSlider* slider, int oldVal)
+void EventCanvas::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
@@ -381,7 +381,7 @@ void EventCanvas::TextEntryComplete(TextEntry* entry)
    }
 }
 
-void EventCanvas::DropdownUpdated(DropdownList* list, int oldVal)
+void EventCanvas::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {

--- a/Source/EventCanvas.cpp
+++ b/Source/EventCanvas.cpp
@@ -154,16 +154,16 @@ void EventCanvas::OnTransportAdvanced(float amount)
          if (curPos > elementEnd)
          {
             if (startPassed)
-               element->Trigger(NextBufferTime());
+               element->Trigger(NextBufferTime(false));
             if (endPassed)
-               element->TriggerEnd(NextBufferTime());
+               element->TriggerEnd(NextBufferTime(false));
          }
          else
          {
             if (endPassed)
-               element->TriggerEnd(NextBufferTime());
+               element->TriggerEnd(NextBufferTime(false));
             if (startPassed)
-               element->Trigger(NextBufferTime());
+               element->Trigger(NextBufferTime(false));
          }
 
          IUIControl* control = mRowConnections[element->mRow].mUIControl;

--- a/Source/EventCanvas.h
+++ b/Source/EventCanvas.h
@@ -64,11 +64,11 @@ public:
 
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/FFTtoAdditive.cpp
+++ b/Source/FFTtoAdditive.cpp
@@ -234,7 +234,7 @@ void FFTtoAdditive::DrawViz()
    ofPopStyle();
 }
 
-void FFTtoAdditive::CheckboxUpdated(Checkbox* checkbox)
+void FFTtoAdditive::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/FFTtoAdditive.h
+++ b/Source/FFTtoAdditive.h
@@ -56,9 +56,9 @@ public:
    void Process(double time) override;
 
    //IButtonListener
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/FMSynth.cpp
+++ b/Source/FMSynth.cpp
@@ -262,19 +262,19 @@ void FMSynth::UpdateHarmonicRatio()
    mVoiceParams.mHarmRatio2 *= mHarmRatioTweak2;
 }
 
-void FMSynth::DropdownUpdated(DropdownList* list, int oldVal)
+void FMSynth::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mHarmRatioBaseDropdown || list == mHarmRatioBaseDropdown2)
       UpdateHarmonicRatio();
 }
 
-void FMSynth::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FMSynth::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mHarmSlider || slider == mHarmSlider2)
       UpdateHarmonicRatio();
 }
 
-void FMSynth::CheckboxUpdated(Checkbox* checkbox)
+void FMSynth::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
       mPolyMgr.KillAll();

--- a/Source/FMSynth.h
+++ b/Source/FMSynth.h
@@ -55,9 +55,9 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/FeedbackModule.h
+++ b/Source/FeedbackModule.h
@@ -50,7 +50,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/FilterViz.cpp
+++ b/Source/FilterViz.cpp
@@ -142,14 +142,14 @@ void FilterViz::GraphFilter()
    }
 }
 
-void FilterViz::DropdownUpdated(DropdownList* list, int oldVal)
+void FilterViz::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void FilterViz::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FilterViz::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void FilterViz::ButtonClicked(ClickButton* button)
+void FilterViz::ButtonClicked(ClickButton* button, double time)
 {
 }

--- a/Source/FilterViz.h
+++ b/Source/FilterViz.h
@@ -48,9 +48,9 @@ public:
    //IDrawableModule
    void Poll() override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    void GraphFilter();

--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -339,11 +339,11 @@ void FloatSliderLFOControl::DoSpecialDelete()
    mPinned = false;
 }
 
-void FloatSliderLFOControl::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void FloatSliderLFOControl::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
-void FloatSliderLFOControl::DropdownUpdated(DropdownList* list, int oldVal)
+void FloatSliderLFOControl::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -379,7 +379,7 @@ void FloatSliderLFOControl::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void FloatSliderLFOControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FloatSliderLFOControl::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mOffsetSlider)
       mLFO.SetOffset(mLFOSettings.mLFOOffset);
@@ -395,7 +395,7 @@ void FloatSliderLFOControl::FloatSliderUpdated(FloatSlider* slider, float oldVal
       mLFO.SetLength(mLFOSettings.mLength);
 }
 
-void FloatSliderLFOControl::CheckboxUpdated(Checkbox* checkbox)
+void FloatSliderLFOControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -404,7 +404,7 @@ void FloatSliderLFOControl::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void FloatSliderLFOControl::ButtonClicked(ClickButton* button)
+void FloatSliderLFOControl::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPinButton)
    {

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -92,11 +92,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void GetModuleDimensions(float& width, float& height) override
    {

--- a/Source/FollowingSong.cpp
+++ b/Source/FollowingSong.cpp
@@ -135,27 +135,27 @@ void FollowingSong::DrawModule()
    ofPopStyle();
 }
 
-void FollowingSong::DropdownUpdated(DropdownList* list, int oldVal)
+void FollowingSong::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void FollowingSong::ButtonClicked(ClickButton* button)
+void FollowingSong::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void FollowingSong::CheckboxUpdated(Checkbox* checkbox)
+void FollowingSong::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void FollowingSong::RadioButtonUpdated(RadioButton* list, int oldVal)
+void FollowingSong::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
 }
 
-void FollowingSong::IntSliderUpdated(IntSlider* slider, int oldVal)
+void FollowingSong::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void FollowingSong::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FollowingSong::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/FollowingSong.h
+++ b/Source/FollowingSong.h
@@ -55,12 +55,12 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/FormantFilterEffect.cpp
+++ b/Source/FormantFilterEffect.cpp
@@ -158,15 +158,15 @@ void FormantFilterEffect::UpdateFilters()
       mBiquads[i].SetFilterParams(formant[i], formant[i] / (bandwidth / 2));
 }
 
-void FormantFilterEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void FormantFilterEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void FormantFilterEffect::RadioButtonUpdated(RadioButton* list, int oldVal)
+void FormantFilterEffect::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
 }
 
-void FormantFilterEffect::CheckboxUpdated(Checkbox* checkbox)
+void FormantFilterEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -174,7 +174,7 @@ void FormantFilterEffect::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void FormantFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FormantFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (!mRescaling)
    {
@@ -183,7 +183,7 @@ void FormantFilterEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
       {
          if (mSliders[i] != slider)
          {
-            mSliders[i]->SetValue(mSliders[i]->GetValue() * (1 - (slider->GetValue() - oldVal)));
+            mSliders[i]->SetValue(mSliders[i]->GetValue() * (1 - (slider->GetValue() - oldVal)), time);
          }
       }
       UpdateFilters();

--- a/Source/FormantFilterEffect.h
+++ b/Source/FormantFilterEffect.h
@@ -53,10 +53,10 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "formant"; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& info) override;
    void SetUpFromSaveData() override;

--- a/Source/FourOnTheFloor.cpp
+++ b/Source/FourOnTheFloor.cpp
@@ -70,7 +70,7 @@ void FourOnTheFloor::OnTimeEvent(double time)
    PlayNoteOutput(time, kick, 127, -1);
 }
 
-void FourOnTheFloor::CheckboxUpdated(Checkbox* checkbox)
+void FourOnTheFloor::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mTwoOnTheFloorCheckbox)
    {

--- a/Source/FourOnTheFloor.h
+++ b/Source/FourOnTheFloor.h
@@ -48,7 +48,7 @@ public:
    //ITimeListener
    void OnTimeEvent(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/FreeverbEffect.cpp
+++ b/Source/FreeverbEffect.cpp
@@ -123,11 +123,11 @@ float FreeverbEffect::GetEffectAmount()
    return mWet;
 }
 
-void FreeverbEffect::CheckboxUpdated(Checkbox* checkbox)
+void FreeverbEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void FreeverbEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FreeverbEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mRoomSizeSlider)
    {

--- a/Source/FreeverbEffect.h
+++ b/Source/FreeverbEffect.h
@@ -49,8 +49,8 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "freeverb"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/FreqDelay.cpp
+++ b/Source/FreqDelay.cpp
@@ -101,7 +101,7 @@ void FreqDelay::DrawModule()
    mDryWetSlider->Draw();
 }
 
-void FreqDelay::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void FreqDelay::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/FreqDelay.h
+++ b/Source/FreqDelay.h
@@ -50,7 +50,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/FreqDomainBoilerplate.cpp
+++ b/Source/FreqDomainBoilerplate.cpp
@@ -163,6 +163,6 @@ void FreqDomainBoilerplate::DrawModule()
    mPhaseOffsetSlider->Draw();
 }
 
-void FreqDomainBoilerplate::CheckboxUpdated(Checkbox* checkbox)
+void FreqDomainBoilerplate::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }

--- a/Source/FreqDomainBoilerplate.h
+++ b/Source/FreqDomainBoilerplate.h
@@ -55,9 +55,9 @@ public:
    void Process(double time) override;
 
    //IButtonListener
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
 private:
    //IDrawableModule

--- a/Source/FubbleModule.cpp
+++ b/Source/FubbleModule.cpp
@@ -438,11 +438,11 @@ void FubbleModule::PostRepatch(PatchCableSource* cableSource, bool fromUserClick
       mAxisV.UpdateControl();
 }
 
-void FubbleModule::CheckboxUpdated(Checkbox* checkbox)
+void FubbleModule::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void FubbleModule::DropdownUpdated(DropdownList* list, int oldVal)
+void FubbleModule::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    /*int newSteps = int(mLength/4.0f * TheTransport->CountInStandardMeasure(mInterval));
    if (list == mIntervalSelector)
@@ -465,7 +465,7 @@ void FubbleModule::DropdownUpdated(DropdownList* list, int oldVal)
    }*/
 }
 
-void FubbleModule::ButtonClicked(ClickButton* button)
+void FubbleModule::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mClearButton)
       Clear();

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -57,10 +57,10 @@ public:
    void Resize(float w, float h) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/GainStageEffect.cpp
+++ b/Source/GainStageEffect.cpp
@@ -61,10 +61,10 @@ void GainStageEffect::DrawModule()
    mGainSlider->Draw();
 }
 
-void GainStageEffect::CheckboxUpdated(Checkbox* checkbox)
+void GainStageEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void GainStageEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void GainStageEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }

--- a/Source/GainStageEffect.h
+++ b/Source/GainStageEffect.h
@@ -44,8 +44,8 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    std::string GetType() override { return "gainstage"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/GateEffect.cpp
+++ b/Source/GateEffect.cpp
@@ -108,14 +108,14 @@ void GateEffect::DrawModule()
    ofPopStyle();
 }
 
-void GateEffect::CheckboxUpdated(Checkbox* checkbox)
+void GateEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void GateEffect::IntSliderUpdated(IntSlider* slider, int oldVal)
+void GateEffect::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void GateEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void GateEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }

--- a/Source/GateEffect.h
+++ b/Source/GateEffect.h
@@ -49,9 +49,9 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    std::string GetType() override { return "gate"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/GlobalControls.cpp
+++ b/Source/GlobalControls.cpp
@@ -80,7 +80,7 @@ void GlobalControls::DrawModule()
    mBackgroundBSlider->Draw();
 }
 
-void GlobalControls::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void GlobalControls::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mZoomSlider && gHoveredUIControl != mZoomSlider) //avoid bad behavior when adjusting these via mouse
    {

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -42,7 +42,7 @@ public:
    void CreateUIControls() override;
    void Poll() override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/GridController.h
+++ b/Source/GridController.h
@@ -88,8 +88,8 @@ public:
    IGridController* GetGridController() { return mGridController; }
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    bool CanBeTargetedBy(PatchCableSource* source) const override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -331,7 +331,7 @@ void GridModule::SetUpFromSaveData()
    mDirectColorMode = mModuleSaveData.GetBool("direct_color_mode");
 }
 
-void GridModule::CheckboxUpdated(Checkbox* checkbox)
+void GridModule::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mMomentaryCheckbox)
       mGrid->SetMomentary(mMomentary);

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -91,7 +91,7 @@ public:
    bool HasInput() const override;
    bool IsConnected() const override { return true; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -130,7 +130,7 @@ void GridSliders::OnGridButton(int x, int y, float velocity, IGridController* gr
       {
          float value = squareIndex / float(length - 1);
          for (auto& cable : mControlCables[sliderIndex]->GetPatchCables())
-            dynamic_cast<IUIControl*>(cable->GetTarget())->SetFromMidiCC(value);
+            dynamic_cast<IUIControl*>(cable->GetTarget())->SetFromMidiCC(value, NextBufferTime(), false);
       }
    }
 }
@@ -181,7 +181,7 @@ void GridSliders::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
 {
 }
 
-void GridSliders::DropdownUpdated(DropdownList* list, int oldVal)
+void GridSliders::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mDirectionSelector)
    {

--- a/Source/GridSliders.cpp
+++ b/Source/GridSliders.cpp
@@ -130,7 +130,7 @@ void GridSliders::OnGridButton(int x, int y, float velocity, IGridController* gr
       {
          float value = squareIndex / float(length - 1);
          for (auto& cable : mControlCables[sliderIndex]->GetPatchCables())
-            dynamic_cast<IUIControl*>(cable->GetTarget())->SetFromMidiCC(value, NextBufferTime(), false);
+            dynamic_cast<IUIControl*>(cable->GetTarget())->SetFromMidiCC(value, NextBufferTime(false), false);
       }
    }
 }

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -54,7 +54,7 @@ public:
    void OnControllerPageSelected() override;
    void OnGridButton(int x, int y, float velocity, IGridController* grid) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/GroupControl.cpp
+++ b/Source/GroupControl.cpp
@@ -80,7 +80,7 @@ void GroupControl::PostRepatch(PatchCableSource* cableSource, bool fromUserClick
    }
 }
 
-void GroupControl::CheckboxUpdated(Checkbox* checkbox)
+void GroupControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (int i = 0; i < mControlCables.size(); ++i)
    {
@@ -88,7 +88,7 @@ void GroupControl::CheckboxUpdated(Checkbox* checkbox)
       if (mControlCables[i]->GetTarget())
          uicontrol = dynamic_cast<IUIControl*>(mControlCables[i]->GetTarget());
       if (uicontrol)
-         uicontrol->SetValue(mGroupEnabled ? 1 : 0);
+         uicontrol->SetValue(mGroupEnabled ? 1 : 0, time);
    }
 }
 

--- a/Source/GroupControl.h
+++ b/Source/GroupControl.h
@@ -41,7 +41,7 @@ public:
 
    void CreateUIControls() override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -148,7 +148,7 @@ void HelpDisplay::DrawModule()
          mScreenshotModule = TheSynth->SpawnModuleOnTheFly(mScreenshotsToProcess.front(), 100, 300);
 
          if (mScreenshotsToProcess.front().mLabel == "drumplayer")
-            mScreenshotModule->FindUIControl("edit")->SetValue(1);
+            mScreenshotModule->FindUIControl("edit")->SetValue(1, gTime);
 
          sScreenshotDelay = 10;
       }
@@ -179,7 +179,7 @@ void HelpDisplay::GetModuleDimensions(float& w, float& h)
    }
 }
 
-void HelpDisplay::CheckboxUpdated(Checkbox* checkbox)
+void HelpDisplay::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mShowTooltipsCheckbox)
    {
@@ -369,7 +369,7 @@ std::string HelpDisplay::GetModuleTooltipFromName(std::string moduleTypeName)
    return moduleTypeName + ": " + tooltip;
 }
 
-void HelpDisplay::ButtonClicked(ClickButton* button)
+void HelpDisplay::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mTutorialVideoLinkButton)
    {

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -48,9 +48,9 @@ public:
    std::string GetModuleTooltip(IDrawableModule* module);
    std::string GetModuleTooltipFromName(std::string moduleTypeName);
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void ScreenshotModule(IDrawableModule* module);
 

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -155,7 +155,7 @@ public:
    bool CanReceiveNotes() { return mCanReceiveNotes; }
    bool CanReceivePulses() { return mCanReceivePulses; }
 
-   virtual void CheckboxUpdated(Checkbox* checkbox) {}
+   virtual void CheckboxUpdated(Checkbox* checkbox, double time) {}
 
    virtual void LoadBasics(const ofxJSONElement& moduleInfo, std::string typeName);
    virtual void CreateUIControls();

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -96,7 +96,7 @@ void IModulator::Poll()
       float blend = exp2(kBlendRate / ofGetFrameRate()); //framerate-independent blend
       mSmoothedValue = mSmoothedValue * blend + mLastPollValue * (1 - blend);
       if (RequiresManualPolling())
-         mUIControlTarget->SetFromMidiCC(mLastPollValue, NextBufferTime(), true);
+         mUIControlTarget->SetValue(mLastPollValue, NextBufferTime());
    }
 }
 

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -96,7 +96,7 @@ void IModulator::Poll()
       float blend = exp2(kBlendRate / ofGetFrameRate()); //framerate-independent blend
       mSmoothedValue = mSmoothedValue * blend + mLastPollValue * (1 - blend);
       if (RequiresManualPolling())
-         mUIControlTarget->SetValue(mLastPollValue);
+         mUIControlTarget->SetFromMidiCC(mLastPollValue, NextBufferTime(), true);
    }
 }
 

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -96,7 +96,7 @@ void IModulator::Poll()
       float blend = exp2(kBlendRate / ofGetFrameRate()); //framerate-independent blend
       mSmoothedValue = mSmoothedValue * blend + mLastPollValue * (1 - blend);
       if (RequiresManualPolling())
-         mUIControlTarget->SetValue(mLastPollValue, NextBufferTime());
+         mUIControlTarget->SetValue(mLastPollValue, NextBufferTime(false));
    }
 }
 

--- a/Source/INoteReceiver.cpp
+++ b/Source/INoteReceiver.cpp
@@ -84,5 +84,5 @@ void NoteInputBuffer::QueueNote(double time, int pitch, float velocity, int voic
 //static
 bool NoteInputBuffer::IsTimeWithinFrame(double time)
 {
-   return time <= gTime + gBufferSizeMs;
+   return time <= NextBufferTime();
 }

--- a/Source/INoteReceiver.cpp
+++ b/Source/INoteReceiver.cpp
@@ -84,5 +84,5 @@ void NoteInputBuffer::QueueNote(double time, int pitch, float velocity, int voic
 //static
 bool NoteInputBuffer::IsTimeWithinFrame(double time)
 {
-   return time <= NextBufferTime();
+   return time <= NextBufferTime(false);
 }

--- a/Source/INoteSource.cpp
+++ b/Source/INoteSource.cpp
@@ -168,5 +168,5 @@ void INoteSource::SendCCOutput(int control, int value, int voiceIdx /*=-1*/)
 
 void INoteSource::PreRepatch(PatchCableSource* cableSource)
 {
-   mNoteOutput.Flush(NextBufferTime());
+   mNoteOutput.Flush(NextBufferTime(false));
 }

--- a/Source/INoteSource.cpp
+++ b/Source/INoteSource.cpp
@@ -128,21 +128,15 @@ void NoteOutput::Flush(double time)
       mNoteSource->GetPatchCableSource()->AddHistoryEvent(time, false);
 }
 
-void NoteOutput::FlushTarget(double time, INoteReceiver* target)
-{
-   if (target)
-   {
-      for (int i = 0; i < 128; ++i)
-      {
-         if (mNotes[i])
-            target->PlayNote(time, i, 0);
-      }
-   }
-}
-
 void INoteSource::PlayNoteOutput(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
 {
    PROFILER(INoteSourcePlayOutput);
+
+   if (std::this_thread::get_id() != ModularSynth::GetAudioThreadID())
+   {
+      ofLog() << "PlayNote() called from non-audio thread";
+   }
+
    if (time < gTime)
       ofLog() << "Calling PlayNoteOutput() with a time in the past!  " << ofToString(time / 1000) << " < " << ofToString(gTime / 1000);
 
@@ -160,5 +154,5 @@ void INoteSource::SendCCOutput(int control, int value, int voiceIdx /*=-1*/)
 
 void INoteSource::PreRepatch(PatchCableSource* cableSource)
 {
-   mNoteOutput.Flush(gTime);
+   mNoteOutput.Flush(NextBufferTime());
 }

--- a/Source/INoteSource.cpp
+++ b/Source/INoteSource.cpp
@@ -42,7 +42,7 @@ void NoteOutput::PlayNoteInternal(double time, int pitch, int velocity, int voic
 {
    if (std::this_thread::get_id() != ModularSynth::GetAudioThreadID())
    {
-      if (!isFromMainThreadAndScheduled)   //if we specifically scheduled this ahead of time, there's no need to make adjustments. otherwise, account for immediately requesting a note from the non-audio thread
+      if (!isFromMainThreadAndScheduled) //if we specifically scheduled this ahead of time, there's no need to make adjustments. otherwise, account for immediately requesting a note from the non-audio thread
       {
          time += TheTransport->GetEventLookaheadMs();
          if (velocity == 0)

--- a/Source/INoteSource.h
+++ b/Source/INoteSource.h
@@ -44,7 +44,6 @@ public:
    {}
 
    void Flush(double time);
-   void FlushTarget(double time, INoteReceiver* target);
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;

--- a/Source/INoteSource.h
+++ b/Source/INoteSource.h
@@ -51,7 +51,7 @@ public:
    void SendCC(int control, int value, int voiceIdx = -1) override;
    void SendMidi(const juce::MidiMessage& message) override;
 
-   void PlayNoteInternal(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
+   void PlayNoteInternal(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation, bool isFromMainThreadAndScheduled);
 
    void ResetStackDepth() { mStackDepth = 0; }
    bool* GetNotes() { return mNotes; }
@@ -73,7 +73,7 @@ public:
    , mInNoteOutput(false)
    {}
    virtual ~INoteSource() {}
-   void PlayNoteOutput(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
+   void PlayNoteOutput(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters(), bool isFromMainThreadAndScheduled = false);
    void SendCCOutput(int control, int value, int voiceIdx = -1);
 
    //IPatchable

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -53,10 +53,10 @@ public:
    virtual void Delete() { delete this; }
    void AddRemoteController() { ++mRemoteControlCount; }
    void RemoveRemoteController() { --mRemoteControlCount; }
-   virtual void SetFromMidiCC(float slider, bool setViaModulator = false) = 0;
+   virtual void SetFromMidiCC(float slider, double time, bool setViaModulator) = 0;
    virtual float GetValueForMidiCC(float slider) const { return 0; }
-   virtual void SetValue(float value) = 0;
-   virtual void SetValueDirect(float value) { SetValue(value); } //override if you need special control here
+   virtual void SetValue(float value, double time) = 0;
+   virtual void SetValueDirect(float value, double time) { SetValue(value, time); } //override if you need special control here
    virtual float GetValue() const { return 0; }
    virtual float GetMidiValue() const { return 0; }
    virtual int GetNumValues() { return 0; } //the number of distinct values that you can have for this control, zero indicates infinite (like a float slider)

--- a/Source/InputChannel.h
+++ b/Source/InputChannel.h
@@ -48,7 +48,7 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/KarplusStrong.cpp
+++ b/Source/KarplusStrong.cpp
@@ -185,15 +185,15 @@ void KarplusStrong::DrawModuleUnclipped()
    }
 }
 
-void KarplusStrong::DropdownUpdated(DropdownList* list, int oldVal)
+void KarplusStrong::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void KarplusStrong::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void KarplusStrong::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void KarplusStrong::CheckboxUpdated(Checkbox* checkbox)
+void KarplusStrong::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/KarplusStrong.h
+++ b/Source/KarplusStrong.h
@@ -57,9 +57,9 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    bool HasDebugDraw() const override { return true; }
 

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -90,7 +90,7 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
    if (IsHoveringOverResizeHandle())
       return;
 
-   double time = NextBufferTime();
+   double time = NextBufferTime(false);
    for (int i = 0; i < NumKeys(); ++i)
    {
       for (int pass = 0; pass < 2; ++pass)
@@ -129,7 +129,7 @@ void KeyboardDisplay::MouseReleased()
    IDrawableModule::MouseReleased();
    if (mPlayingMousePitch != -1 && !mLatch)
    {
-      double time = NextBufferTime();
+      double time = NextBufferTime(false);
       PlayNote(time, mPlayingMousePitch, 0);
       mPlayingMousePitch = -1;
    }
@@ -292,7 +292,7 @@ void KeyboardDisplay::KeyPressed(int key, bool isRepeat)
 
    if (mTypingInput && mEnabled && !isRepeat)
    {
-      double time = NextBufferTime();
+      double time = NextBufferTime(false);
       int pitch = GetPitchForTypingKey(key);
       if (pitch != -1)
          PlayNote(time, pitch, 127);
@@ -303,7 +303,7 @@ void KeyboardDisplay::KeyReleased(int key)
 {
    if (mTypingInput && mEnabled)
    {
-      double time = NextBufferTime();
+      double time = NextBufferTime(false);
       int pitch = GetPitchForTypingKey(key);
       if (pitch != -1)
          PlayNote(time, pitch, 0);

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -90,7 +90,7 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
    if (IsHoveringOverResizeHandle())
       return;
 
-   double time = gTime + gBufferSizeMs;
+   double time = NextBufferTime();
    for (int i = 0; i < NumKeys(); ++i)
    {
       for (int pass = 0; pass < 2; ++pass)
@@ -129,7 +129,7 @@ void KeyboardDisplay::MouseReleased()
    IDrawableModule::MouseReleased();
    if (mPlayingMousePitch != -1 && !mLatch)
    {
-      double time = gTime + gBufferSizeMs;
+      double time = NextBufferTime();
       PlayNote(time, mPlayingMousePitch, 0);
       mPlayingMousePitch = -1;
    }
@@ -292,7 +292,7 @@ void KeyboardDisplay::KeyPressed(int key, bool isRepeat)
 
    if (mTypingInput && mEnabled && !isRepeat)
    {
-      double time = gTime + gBufferSizeMs;
+      double time = NextBufferTime();
       int pitch = GetPitchForTypingKey(key);
       if (pitch != -1)
          PlayNote(time, pitch, 127);
@@ -303,7 +303,7 @@ void KeyboardDisplay::KeyReleased(int key)
 {
    if (mTypingInput && mEnabled)
    {
-      double time = gTime + gBufferSizeMs;
+      double time = NextBufferTime();
       int pitch = GetPitchForTypingKey(key);
       if (pitch != -1)
          PlayNote(time, pitch, 0);

--- a/Source/Kicker.cpp
+++ b/Source/Kicker.cpp
@@ -41,10 +41,10 @@ void Kicker::DrawModule()
       return;
 }
 
-void Kicker::CheckboxUpdated(Checkbox* checkbox)
+void Kicker::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void Kicker::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/Kicker.h
+++ b/Source/Kicker.h
@@ -47,7 +47,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/LFOController.cpp
+++ b/Source/LFOController.cpp
@@ -145,7 +145,7 @@ void LFOController::DrawModule()
    }
 }
 
-void LFOController::DropdownUpdated(DropdownList* list, int oldVal)
+void LFOController::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (mLFO == nullptr)
       return;
@@ -153,7 +153,7 @@ void LFOController::DropdownUpdated(DropdownList* list, int oldVal)
    mLFO->UpdateFromSettings();
 }
 
-void LFOController::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void LFOController::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (mLFO == nullptr)
       return;
@@ -167,7 +167,7 @@ void LFOController::FloatSliderUpdated(FloatSlider* slider, float oldVal)
       mLFO->GetMin() = MIN(mLFO->GetMax(), mLFO->GetMin());
 }
 
-void LFOController::ButtonClicked(ClickButton* button)
+void LFOController::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mBindButton)
       mWantBind = true;

--- a/Source/LFOController.h
+++ b/Source/LFOController.h
@@ -55,9 +55,9 @@ public:
    //IDrawableModule
    void Poll() override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -210,7 +210,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
       {
          mLatch = !mLatch;
          if (!mLatch)
-            mNoteOutput.Flush(gTime);
+            mNoteOutput.Flush(NextBufferTime());
          UpdateLights();
       }
       return;
@@ -238,7 +238,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
                currentPitch = i;
             mCurrentNotes[i] = 0;
          }
-         mNoteOutput.Flush(gTime);
+         mNoteOutput.Flush(NextBufferTime());
 
          if (currentPitch == pitch)
          {

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -182,7 +182,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
 {
    bool bOn = velocity > 0;
    int pitch = GridToPitch(x, y);
-   double time = NextBufferTime();
+   double time = NextBufferTime(false);
 
    if (pitch == INVALID_PITCH)
    {
@@ -210,7 +210,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
       {
          mLatch = !mLatch;
          if (!mLatch)
-            mNoteOutput.Flush(NextBufferTime());
+            mNoteOutput.Flush(NextBufferTime(false));
          UpdateLights();
       }
       return;
@@ -238,7 +238,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
                currentPitch = i;
             mCurrentNotes[i] = 0;
          }
-         mNoteOutput.Flush(NextBufferTime());
+         mNoteOutput.Flush(NextBufferTime(false));
 
          if (currentPitch == pitch)
          {
@@ -326,7 +326,7 @@ void LaunchpadKeyboard::ReleaseNoteFor(int x, int y)
    int pitch = GridToPitch(x, y);
    if (pitch >= 0 && pitch < 128)
    {
-      double time = NextBufferTime();
+      double time = NextBufferTime(false);
       PlayKeyboardNote(time, pitch, 0);
       mCurrentNotes[pitch] = 0;
    }

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -182,7 +182,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
 {
    bool bOn = velocity > 0;
    int pitch = GridToPitch(x, y);
-   double time = gTime + gBufferSizeMs;
+   double time = NextBufferTime();
 
    if (pitch == INVALID_PITCH)
    {
@@ -326,7 +326,7 @@ void LaunchpadKeyboard::ReleaseNoteFor(int x, int y)
    int pitch = GridToPitch(x, y);
    if (pitch >= 0 && pitch < 128)
    {
-      double time = gTime + gBufferSizeMs;
+      double time = NextBufferTime();
       PlayKeyboardNote(time, pitch, 0);
       mCurrentNotes[pitch] = 0;
    }
@@ -774,11 +774,10 @@ void LaunchpadKeyboard::Poll()
    }
 }
 
-void LaunchpadKeyboard::CheckboxUpdated(Checkbox* checkbox)
+void LaunchpadKeyboard::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      double time = gTime + gBufferSizeMs;
       mHeldChordTones.clear();
       mNoteOutput.Flush(time);
    }
@@ -796,25 +795,23 @@ void LaunchpadKeyboard::CheckboxUpdated(Checkbox* checkbox)
    {
       if (!mLatch)
       {
-         double time = gTime + gBufferSizeMs;
          mNoteOutput.Flush(time);
       }
    }
 }
 
-void LaunchpadKeyboard::IntSliderUpdated(IntSlider* slider, int oldVal)
+void LaunchpadKeyboard::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mOctaveSlider)
    {
       for (int i = 0; i < 128; ++i)
          mCurrentNotes[i] = 0;
-      double time = gTime + gBufferSizeMs;
       mNoteOutput.Flush(time);
       UpdateLights();
    }
 }
 
-void LaunchpadKeyboard::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void LaunchpadKeyboard::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
@@ -825,7 +822,7 @@ void LaunchpadKeyboard::Exit()
       mGridControlTarget->GetGridController()->ResetLights();
 }
 
-void LaunchpadKeyboard::DropdownUpdated(DropdownList* list, int oldVal)
+void LaunchpadKeyboard::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    UpdateLights();
 }

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -78,10 +78,10 @@ public:
    bool OnPush2Control(MidiMessageType type, int controlIndex, float midiValue) override;
    void UpdatePush2Leds(Push2Control* push2) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/LinnstrumentControl.cpp
+++ b/Source/LinnstrumentControl.cpp
@@ -346,7 +346,7 @@ void LinnstrumentControl::OnMidiControl(MidiControl& control)
    }
 }
 
-void LinnstrumentControl::DropdownUpdated(DropdownList* list, int oldVal)
+void LinnstrumentControl::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mControllerList)
    {
@@ -360,7 +360,7 @@ void LinnstrumentControl::DropdownClicked(DropdownList* list)
    BuildControllerList();
 }
 
-void LinnstrumentControl::CheckboxUpdated(Checkbox* checkbox)
+void LinnstrumentControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mBlackoutCheckbox)
    {

--- a/Source/LinnstrumentControl.h
+++ b/Source/LinnstrumentControl.h
@@ -79,10 +79,10 @@ public:
 
    void OnScaleChanged() override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Lissajous.h
+++ b/Source/Lissajous.h
@@ -50,7 +50,7 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/LiveGranulator.cpp
+++ b/Source/LiveGranulator.cpp
@@ -175,7 +175,7 @@ void LiveGranulator::OnTimeEvent(double time)
    Freeze();
 }
 
-void LiveGranulator::CheckboxUpdated(Checkbox* checkbox)
+void LiveGranulator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
       mBuffer.ClearBuffer();
@@ -190,7 +190,7 @@ void LiveGranulator::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void LiveGranulator::DropdownUpdated(DropdownList* list, int oldVal)
+void LiveGranulator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mAutoCaptureDropdown)
    {
@@ -205,7 +205,7 @@ void LiveGranulator::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void LiveGranulator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void LiveGranulator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mPosSlider)
    {

--- a/Source/LiveGranulator.h
+++ b/Source/LiveGranulator.h
@@ -58,9 +58,9 @@ public:
 
    void OnTimeEvent(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
 private:
    void Freeze();

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -176,7 +176,7 @@ void LoopStorer::DropdownClicked(DropdownList* list)
 {
 }
 
-void LoopStorer::DropdownUpdated(DropdownList* list, int oldVal)
+void LoopStorer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mQuantizationDropdown)
    {
@@ -186,7 +186,7 @@ void LoopStorer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void LoopStorer::ButtonClicked(ClickButton* button)
+void LoopStorer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mClearButton)
    {
@@ -203,7 +203,7 @@ void LoopStorer::ButtonClicked(ClickButton* button)
    }
 }
 
-void LoopStorer::CheckboxUpdated(Checkbox* checkbox)
+void LoopStorer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (int i = 0; i < mSamples.size(); ++i)
    {
@@ -223,11 +223,11 @@ void LoopStorer::GetModuleDimensions(float& width, float& height)
    height = GetRowY((int)mSamples.size());
 }
 
-void LoopStorer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void LoopStorer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void LoopStorer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void LoopStorer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/LoopStorer.h
+++ b/Source/LoopStorer.h
@@ -62,12 +62,12 @@ public:
 
    void OnTimeEvent(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -345,7 +345,7 @@ void Looper::Process(double time)
    if (mPitchShift != 1)
       latencyOffset = mPitchShifter[0]->GetLatency();
 
-   double processStartTime = gTime;
+   double processStartTime = time;
    for (int i = 0; i < bufferSize; ++i)
    {
       float smooth = .001f;
@@ -419,7 +419,7 @@ void Looper::Process(double time)
    GetBuffer()->Reset();
 
    if (mCommitBuffer && !mClearCommitBuffer && !mWantRewrite)
-      DoCommit();
+      DoCommit(time);
    if (mWantShiftMeasure)
       DoShiftMeasure();
    if (mWantHalfShift)
@@ -432,11 +432,11 @@ void Looper::Process(double time)
    {
       mWantRewrite = false;
       if (mRewriter)
-         mRewriter->Go();
+         mRewriter->Go(gTime);
    }
 }
 
-void Looper::DoCommit()
+void Looper::DoCommit(double time)
 {
    PROFILER(LooperDoCommit);
 
@@ -454,7 +454,7 @@ void Looper::DoCommit()
    {
       Clear();
       mMute = false;
-      mMuteRamp.Start(gTime, mMute ? 0 : 1, gTime + 1);
+      mMuteRamp.Start(time, mMute ? 0 : 1, time + 1);
    }
 
    {
@@ -1076,7 +1076,7 @@ void Looper::OnClicked(float x, float y, bool right)
    }
 }
 
-void Looper::ButtonClicked(ClickButton* button)
+void Looper::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mClearButton)
    {
@@ -1128,7 +1128,7 @@ void Looper::ButtonClicked(ClickButton* button)
       ResampleForSpeed(GetPlaybackSpeed());
 }
 
-void Looper::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Looper::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mScratchSpeedSlider)
    {
@@ -1149,17 +1149,17 @@ void Looper::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void Looper::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void Looper::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
-void Looper::DropdownUpdated(DropdownList* list, int oldVal)
+void Looper::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mNumBarsSelector)
       UpdateNumBars(oldVal);
 }
 
-void Looper::CheckboxUpdated(Checkbox* checkbox)
+void Looper::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mAllowScratchCheckbox)
    {
@@ -1171,7 +1171,7 @@ void Looper::CheckboxUpdated(Checkbox* checkbox)
    }
    if (checkbox == mMuteCheckbox)
    {
-      mMuteRamp.Start(gTime, mMute ? 0 : 1, gTime + 1);
+      mMuteRamp.Start(time, mMute ? 0 : 1, time + 1);
    }
    if (checkbox == mWriteInputCheckbox)
    {
@@ -1179,11 +1179,11 @@ void Looper::CheckboxUpdated(Checkbox* checkbox)
       {
          if (mBufferTempo != TheTransport->GetTempo())
             ResampleForSpeed(GetPlaybackSpeed());
-         mWriteInputRamp.Start(gTime, 1, gTime + 10);
+         mWriteInputRamp.Start(time, 1, time + 10);
       }
       else
       {
-         mWriteInputRamp.Start(gTime, 0, gTime + 10);
+         mWriteInputRamp.Start(time, 0, time + 10);
       }
    }
 }

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -107,15 +107,15 @@ public:
    bool CheckNeedsDraw() override { return true; }
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IRadioButtonListener
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
@@ -128,7 +128,7 @@ private:
    void DoHalfShift();
    void DoShiftDownbeat();
    void DoShiftOffset();
-   void DoCommit();
+   void DoCommit(double time);
    void UpdateNumBars(int oldNumBars);
    void BakeVolume();
    void DoUndo();

--- a/Source/LooperGranulator.cpp
+++ b/Source/LooperGranulator.cpp
@@ -126,11 +126,11 @@ void LooperGranulator::PostRepatch(PatchCableSource* cableSource, bool fromUserC
    }
 }
 
-void LooperGranulator::ButtonClicked(ClickButton* button)
+void LooperGranulator::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void LooperGranulator::DropdownUpdated(DropdownList* list, int oldVal)
+void LooperGranulator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 

--- a/Source/LooperGranulator.h
+++ b/Source/LooperGranulator.h
@@ -55,10 +55,10 @@ public:
    bool ShouldFreeze() { return mOn && mFreeze; }
    void OnCommit();
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -148,8 +148,8 @@ void LooperRecorder::Process(double time)
       mCommitToLooper->Commit();
 
       mRecorderMode = kRecorderMode_Record;
-      mQuietInputRamp.Start(gTime, 0, gTime + 10);
-      mUnquietInputTime = gTime + 1000; //no input for 1 second
+      mQuietInputRamp.Start(time, 0, time + 10);
+      mUnquietInputTime = time + 1000; //no input for 1 second
       mCommitToLooper = nullptr;
    }
 
@@ -546,21 +546,21 @@ void LooperRecorder::ResetSpeed()
    mBaseTempo = TheTransport->GetTempo();
 }
 
-void LooperRecorder::StartFreeRecord()
+void LooperRecorder::StartFreeRecord(double time)
 {
    if (mFreeRecording)
       return;
 
    mFreeRecording = true;
-   mStartFreeRecordTime = gTime;
+   mStartFreeRecordTime = time;
 }
 
-void LooperRecorder::EndFreeRecord()
+void LooperRecorder::EndFreeRecord(double time)
 {
    if (!mFreeRecording)
       return;
 
-   float recordedTime = gTime - mStartFreeRecordTime;
+   float recordedTime = time - mStartFreeRecordTime;
    int beats = mNumBars * TheTransport->GetTimeSigTop();
    float minutes = recordedTime / 1000.0f / 60.0f;
    TheTransport->SetTempo(beats / minutes);
@@ -575,7 +575,7 @@ void LooperRecorder::CancelFreeRecord()
    mStartFreeRecordTime = 0;
 }
 
-void LooperRecorder::ButtonClicked(ClickButton* button)
+void LooperRecorder::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResampleButton)
       SyncLoopLengths();
@@ -596,8 +596,8 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
       }
       TheTransport->SetTempo(TheTransport->GetTempo() * 2);
       mBaseTempo = TheTransport->GetTempo();
-      float pos = TheTransport->GetMeasurePos(gTime) + (TheTransport->GetMeasure(gTime) % 8);
-      int count = TheTransport->GetMeasure(gTime) - int(pos);
+      float pos = TheTransport->GetMeasurePos(time) + (TheTransport->GetMeasure(time) % 8);
+      int count = TheTransport->GetMeasure(time) - int(pos);
       pos *= 2;
       count += int(pos);
       pos -= int(pos);
@@ -618,8 +618,8 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
       }
       TheTransport->SetTempo(TheTransport->GetTempo() / 2);
       mBaseTempo = TheTransport->GetTempo();
-      float pos = TheTransport->GetMeasurePos(gTime) + (TheTransport->GetMeasure(gTime) % 8);
-      int count = TheTransport->GetMeasure(gTime) - int(pos);
+      float pos = TheTransport->GetMeasurePos(time) + (TheTransport->GetMeasure(time) % 8);
+      int count = TheTransport->GetMeasure(time) - int(pos);
       pos /= 2;
       count += int(pos);
       pos -= int(pos);
@@ -638,7 +638,7 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
          if (mLoopers[i])
             mLoopers[i]->ShiftMeasure();
       }
-      int newMeasure = TheTransport->GetMeasure(gTime) - 1;
+      int newMeasure = TheTransport->GetMeasure(time) - 1;
       if (newMeasure < 0)
          newMeasure = 7;
       TheTransport->SetMeasure(newMeasure);
@@ -651,17 +651,17 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
          if (mLoopers[i])
             mLoopers[i]->HalfShift();
       }
-      int newMeasure = int(TheTransport->GetMeasure(gTime) + TheTransport->GetMeasurePos(gTime) - .5f);
+      int newMeasure = int(TheTransport->GetMeasure(time) + TheTransport->GetMeasurePos(time) - .5f);
       if (newMeasure < 0)
          newMeasure = 7;
-      float newMeasurePos = TheTransport->GetMeasurePos(gTime) - .5f;
+      float newMeasurePos = TheTransport->GetMeasurePos(time) - .5f;
       FloatWrap(newMeasurePos, 1);
       TheTransport->SetMeasureTime(newMeasure + newMeasurePos);
    }
 
    if (button == mShiftDownbeatButton)
    {
-      TheTransport->SetMeasure(TheTransport->GetMeasure(gTime) / 8 * 8); //align to 8 bars
+      TheTransport->SetMeasure(TheTransport->GetMeasure(time) / 8 * 8); //align to 8 bars
       TheTransport->SetDownbeat();
       for (int i = 0; i < mLoopers.size(); ++i)
       {
@@ -713,28 +713,28 @@ void LooperRecorder::ButtonClicked(ClickButton* button)
    }
 }
 
-void LooperRecorder::CheckboxUpdated(Checkbox* checkbox)
+void LooperRecorder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mFreeRecordingCheckbox)
    {
       bool freeRec = mFreeRecording;
       mFreeRecording = !mFreeRecording; //flip back so these methods won't be ignored
       if (freeRec)
-         StartFreeRecord();
+         StartFreeRecord(time);
       else
-         EndFreeRecord();
+         EndFreeRecord(time);
    }
 }
 
-void LooperRecorder::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void LooperRecorder::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void LooperRecorder::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void LooperRecorder::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
-void LooperRecorder::DropdownUpdated(DropdownList* list, int oldVal)
+void LooperRecorder::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mNumBarsSelector)
    {
@@ -742,7 +742,7 @@ void LooperRecorder::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void LooperRecorder::IntSliderUpdated(IntSlider* slider, int oldVal)
+void LooperRecorder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -70,8 +70,8 @@ public:
    RollingBuffer* GetRecordBuffer() { return &mRecordBuffer; }
    Looper* GetNextCommitTarget() { return (mNextCommitTargetIndex < (int)mLoopers.size()) ? mLoopers[mNextCommitTargetIndex] : nullptr; }
 
-   void StartFreeRecord();
-   void EndFreeRecord();
+   void StartFreeRecord(double time);
+   void EndFreeRecord(double time);
    void CancelFreeRecord();
    bool InFreeRecord() { return mFreeRecording; }
 
@@ -85,12 +85,12 @@ public:
    void PreRepatch(PatchCableSource* cableSource) override;
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    bool HasDebugDraw() const override { return true; }
 

--- a/Source/M185Sequencer.cpp
+++ b/Source/M185Sequencer.cpp
@@ -194,13 +194,13 @@ void M185Sequencer::GetModuleDimensions(float& width, float& height)
    height = mHeight;
 }
 
-void M185Sequencer::ButtonClicked(ClickButton* button)
+void M185Sequencer::ButtonClicked(ClickButton* button, double time)
 {
    if (mResetStepButton == button)
       ResetStep();
 }
 
-void M185Sequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void M185Sequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -210,7 +210,7 @@ void M185Sequencer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void M185Sequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void M185Sequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -32,7 +32,7 @@ public:
    void Init() override;
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    //IDrawableModule
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
@@ -48,10 +48,10 @@ public:
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/MPESmoother.cpp
+++ b/Source/MPESmoother.cpp
@@ -108,11 +108,11 @@ void MPESmoother::OnTransportAdvanced(float amount)
    }
 }
 
-void MPESmoother::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MPESmoother::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void MPESmoother::CheckboxUpdated(Checkbox* checkbox)
+void MPESmoother::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/MPESmoother.h
+++ b/Source/MPESmoother.h
@@ -51,8 +51,8 @@ public:
 
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/MPETweaker.cpp
+++ b/Source/MPETweaker.cpp
@@ -102,7 +102,7 @@ void MPETweaker::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void MPETweaker::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MPETweaker::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mPitchBendMultiplierSlider)
    {
@@ -138,7 +138,7 @@ void MPETweaker::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void MPETweaker::CheckboxUpdated(Checkbox* checkbox)
+void MPETweaker::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/MPETweaker.h
+++ b/Source/MPETweaker.h
@@ -47,8 +47,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -68,7 +68,7 @@ void MacroSlider::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
    }
 }
 
-void MacroSlider::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MacroSlider::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/MacroSlider.h
+++ b/Source/MacroSlider.h
@@ -45,7 +45,7 @@ public:
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;

--- a/Source/Metronome.h
+++ b/Source/Metronome.h
@@ -52,10 +52,10 @@ public:
    //ITimeListener
    void OnTimeEvent(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MidiClockIn.cpp
+++ b/Source/MidiClockIn.cpp
@@ -174,7 +174,7 @@ void MidiClockIn::OnMidi(const juce::MidiMessage& message)
    }
 }
 
-void MidiClockIn::DropdownUpdated(DropdownList* list, int oldVal)
+void MidiClockIn::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mDeviceList)
    {

--- a/Source/MidiClockIn.h
+++ b/Source/MidiClockIn.h
@@ -48,10 +48,10 @@ public:
    void OnMidiControl(MidiControl& control) override {}
    void OnMidi(const juce::MidiMessage& message) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MidiClockOut.cpp
+++ b/Source/MidiClockOut.cpp
@@ -110,7 +110,7 @@ void MidiClockOut::OnTransportAdvanced(float amount)
       int pulsesPerMeasure = TheTransport->GetTimeSigTop() * pulsesPerBeat;
 
       double oldPulse = TheTransport->GetMeasureTime(gTime) * pulsesPerMeasure;
-      double newPulse = TheTransport->GetMeasureTime(gTime + gBufferSizeMs) * pulsesPerMeasure;
+      double newPulse = TheTransport->GetMeasureTime(NextBufferTime()) * pulsesPerMeasure;
       int pulses = int(floor(newPulse) - floor(oldPulse));
       double distToFirstPulse = 1 - fmod(oldPulse, 1);
       double pulseMs = TheTransport->GetDuration(kInterval_4n) / pulsesPerBeat;
@@ -129,7 +129,7 @@ void MidiClockOut::OnTransportAdvanced(float amount)
    }
 }
 
-void MidiClockOut::DropdownUpdated(DropdownList* list, int oldVal)
+void MidiClockOut::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mDeviceList)
    {
@@ -137,7 +137,7 @@ void MidiClockOut::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void MidiClockOut::ButtonClicked(ClickButton* button)
+void MidiClockOut::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mStartButton)
       mClockStartQueued = true;

--- a/Source/MidiClockOut.cpp
+++ b/Source/MidiClockOut.cpp
@@ -110,7 +110,7 @@ void MidiClockOut::OnTransportAdvanced(float amount)
       int pulsesPerMeasure = TheTransport->GetTimeSigTop() * pulsesPerBeat;
 
       double oldPulse = TheTransport->GetMeasureTime(gTime) * pulsesPerMeasure;
-      double newPulse = TheTransport->GetMeasureTime(NextBufferTime()) * pulsesPerMeasure;
+      double newPulse = TheTransport->GetMeasureTime(NextBufferTime(false)) * pulsesPerMeasure;
       int pulses = int(floor(newPulse) - floor(oldPulse));
       double distToFirstPulse = 1 - fmod(oldPulse, 1);
       double pulseMs = TheTransport->GetDuration(kInterval_4n) / pulsesPerBeat;

--- a/Source/MidiClockOut.h
+++ b/Source/MidiClockOut.h
@@ -49,10 +49,10 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MidiControlChange.cpp
+++ b/Source/MidiControlChange.cpp
@@ -57,7 +57,7 @@ void MidiControlChange::PlayNote(double time, int pitch, int velocity, int voice
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void MidiControlChange::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MidiControlChange::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mValueSlider && mEnabled)
    {

--- a/Source/MidiControlChange.h
+++ b/Source/MidiControlChange.h
@@ -49,7 +49,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -606,7 +606,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                   float sign = change > 0 ? 1 : -1;
                   change = sign * sqrtf(fabsf(change)); //make response fall off for bigger changes
                   curValue += increment * change;
-                  uicontrol->SetFromMidiCC(curValue);
+                  uicontrol->SetFromMidiCC(curValue, NextBufferTime(), false);
                }
             }
             else
@@ -615,7 +615,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                   value = value > 0 ? 1 : 0;
                if (connection->mScaleOutput && (connection->mMidiOffValue != 0 || connection->mMidiOnValue != 127))
                   value = ofLerp(connection->mMidiOffValue / 127.0f, connection->mMidiOnValue / 127.0f, value);
-               uicontrol->SetFromMidiCC(value);
+               uicontrol->SetFromMidiCC(value, NextBufferTime(), false);
             }
             uicontrol->StartBeacon();
          }
@@ -624,7 +624,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
             if (value > 0)
             {
                float val = uicontrol->GetMidiValue();
-               uicontrol->SetValue(val == 0);
+               uicontrol->SetValue(val == 0, NextBufferTime());
                uicontrol->StartBeacon();
             }
          }
@@ -635,7 +635,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue);
+                  uicontrol->SetValue(connection->mValue, NextBufferTime());
                uicontrol->StartBeacon();
             }
          }
@@ -646,13 +646,13 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue);
+                  uicontrol->SetValue(connection->mValue, NextBufferTime());
                uicontrol->StartBeacon();
             }
          }
          else if (connection->mType == kControlType_Direct)
          {
-            uicontrol->SetValue(value * 127);
+            uicontrol->SetValue(value * 127, NextBufferTime());
             uicontrol->StartBeacon();
          }
 
@@ -1838,7 +1838,7 @@ void MidiController::OnDeviceChanged()
    mModulation.GetPressure(-1)->SetValue(mPressureOffset);
 }
 
-void MidiController::CheckboxUpdated(Checkbox* checkbox)
+void MidiController::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (auto iter = mConnections.begin(); iter != mConnections.end(); ++iter)
    {
@@ -1851,7 +1851,7 @@ void MidiController::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void MidiController::ButtonClicked(ClickButton* button)
+void MidiController::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mAddConnectionButton)
    {
@@ -1892,7 +1892,7 @@ void MidiController::ButtonClicked(ClickButton* button)
    }
 }
 
-void MidiController::DropdownUpdated(DropdownList* list, int oldVal)
+void MidiController::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mPageSelector)
    {
@@ -1957,7 +1957,7 @@ void MidiController::DropdownClicked(DropdownList* list)
    }
 }
 
-void MidiController::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void MidiController::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mMappingDisplayModeSelector)
    {

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -606,7 +606,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                   float sign = change > 0 ? 1 : -1;
                   change = sign * sqrtf(fabsf(change)); //make response fall off for bigger changes
                   curValue += increment * change;
-                  uicontrol->SetFromMidiCC(curValue, NextBufferTime(), false);
+                  uicontrol->SetFromMidiCC(curValue, NextBufferTime(false), false);
                }
             }
             else
@@ -615,7 +615,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                   value = value > 0 ? 1 : 0;
                if (connection->mScaleOutput && (connection->mMidiOffValue != 0 || connection->mMidiOnValue != 127))
                   value = ofLerp(connection->mMidiOffValue / 127.0f, connection->mMidiOnValue / 127.0f, value);
-               uicontrol->SetFromMidiCC(value, NextBufferTime(), false);
+               uicontrol->SetFromMidiCC(value, NextBufferTime(false), false);
             }
             uicontrol->StartBeacon();
          }
@@ -624,7 +624,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
             if (value > 0)
             {
                float val = uicontrol->GetMidiValue();
-               uicontrol->SetValue(val == 0, NextBufferTime());
+               uicontrol->SetValue(val == 0, NextBufferTime(false));
                uicontrol->StartBeacon();
             }
          }
@@ -635,7 +635,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue, NextBufferTime());
+                  uicontrol->SetValue(connection->mValue, NextBufferTime(false));
                uicontrol->StartBeacon();
             }
          }
@@ -646,13 +646,13 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue, NextBufferTime());
+                  uicontrol->SetValue(connection->mValue, NextBufferTime(false));
                uicontrol->StartBeacon();
             }
          }
          else if (connection->mType == kControlType_Direct)
          {
-            uicontrol->SetValue(value * 127, NextBufferTime());
+            uicontrol->SetValue(value * 127, NextBufferTime(false));
             uicontrol->StartBeacon();
          }
 

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -339,11 +339,11 @@ public:
 
    void OnTransportAdvanced(float amount) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
    void TextEntryActivated(TextEntry* entry) override;
    void TextEntryComplete(TextEntry* entry) override;
    void PreRepatch(PatchCableSource* cableSource) override;

--- a/Source/MidiOutput.cpp
+++ b/Source/MidiOutput.cpp
@@ -147,7 +147,7 @@ void MidiOutputModule::OnTransportAdvanced(float amount)
    }
 }
 
-void MidiOutputModule::DropdownUpdated(DropdownList* list, int oldVal)
+void MidiOutputModule::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    mDevice.ConnectOutput(mControllerIndex);
 }

--- a/Source/MidiOutput.h
+++ b/Source/MidiOutput.h
@@ -53,7 +53,7 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModWheel.cpp
+++ b/Source/ModWheel.cpp
@@ -75,13 +75,13 @@ void ModWheel::OnTransportAdvanced(float amount)
    ComputeSliders(0);
 }
 
-void ModWheel::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ModWheel::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mModWheelSlider)
       mModulation.GetModWheel(-1)->SetValue(mModWheel);
 }
 
-void ModWheel::CheckboxUpdated(Checkbox* checkbox)
+void ModWheel::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/ModWheel.h
+++ b/Source/ModWheel.h
@@ -51,8 +51,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/ModWheelToCV.h
+++ b/Source/ModWheelToCV.h
@@ -57,7 +57,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1651,7 +1651,7 @@ void ModularSynth::MouseScrolled(float xScroll, float yScroll, bool isSmoothScro
       else
          val += change;
       val = ofClamp(val, 0, 1);
-      gHoveredUIControl->SetFromMidiCC(val);
+      gHoveredUIControl->SetFromMidiCC(val, NextBufferTime(), false);
 
       gHoveredUIControl->NotifyMouseScrolled(GetMouseX(&mModuleContainer), GetMouseY(&mModuleContainer), xScroll, yScroll, isSmoothScroll, isInvertedScroll);
    }

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -61,6 +61,7 @@ float ModularSynth::sBackgroundR = 0.09f;
 float ModularSynth::sBackgroundG = 0.09f;
 float ModularSynth::sBackgroundB = 0.09f;
 int ModularSynth::sLoadingFileSaveStateRev = ModularSynth::kSaveStateRev;
+std::thread::id ModularSynth::sAudioThreadId;
 
 #if BESPOKE_WINDOWS
 LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo);
@@ -1888,6 +1889,8 @@ void ModularSynth::MouseReleased(int intX, int intY, int button, const juce::Mou
 void ModularSynth::AudioOut(float** output, int bufferSize, int nChannels)
 {
    PROFILER(audioOut_total);
+
+   sAudioThreadId = std::this_thread::get_id();
 
    static bool sFirst = true;
    if (sFirst)

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -37,6 +37,7 @@
 #include "EffectChain.h"
 #include "ClickButton.h"
 #include "UserPrefs.h"
+#include "NoteOutputQueue.h"
 
 #include "juce_audio_processors/juce_audio_processors.h"
 
@@ -1108,7 +1109,7 @@ void ModularSynth::SetMousePosition(ModuleContainer* context, float x, float y)
 {
    x = (x + context->GetDrawOffset().x) * context->GetDrawScale() - UserPrefs.mouse_offset_x.Get() + mMainComponent->getScreenX();
    y = (y + context->GetDrawOffset().y) * context->GetDrawScale() - UserPrefs.mouse_offset_y.Get() + mMainComponent->getScreenY();
-   Desktop::setMousePosition(Point<int>(x, y));
+   Desktop::setMousePosition(juce::Point<int>(x, y));
 }
 
 bool ModularSynth::IsMouseButtonHeld(int button) const
@@ -1912,6 +1913,8 @@ void ModularSynth::AudioOut(float** output, int bufferSize, int nChannels)
    ScopedMutex mutex(&mAudioThreadMutex, "audioOut()");
 
    /////////// AUDIO PROCESSING STARTS HERE /////////////
+   mNoteOutputQueue->Process();
+
    assert(bufferSize == mIOBufferSize);
    assert(nChannels == (int)mOutputBuffers.size());
    assert(mIOBufferSize == gBufferSize); //need to be the same for now
@@ -2156,6 +2159,7 @@ void ModularSynth::ResetLayout()
    delete TheSaveDataPanel;
    delete mQuickSpawn;
    delete mUserPrefsEditor;
+   delete mNoteOutputQueue;
 
    TitleBar* titleBar = new TitleBar();
    titleBar->SetPosition(0, 0);
@@ -2210,6 +2214,8 @@ void ModularSynth::ResetLayout()
    GetDrawOffset().set(0, 0);
 
    SetUIScale(UserPrefs.ui_scale.Get());
+
+   mNoteOutputQueue = new NoteOutputQueue();
 }
 
 bool ModularSynth::LoadLayoutFromFile(std::string jsonFile, bool makeDefaultLayout /*= true*/)

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1653,7 +1653,7 @@ void ModularSynth::MouseScrolled(float xScroll, float yScroll, bool isSmoothScro
       else
          val += change;
       val = ofClamp(val, 0, 1);
-      gHoveredUIControl->SetFromMidiCC(val, NextBufferTime(), false);
+      gHoveredUIControl->SetFromMidiCC(val, NextBufferTime(false), false);
 
       gHoveredUIControl->NotifyMouseScrolled(GetMouseX(&mModuleContainer), GetMouseY(&mModuleContainer), xScroll, yScroll, isSmoothScroll, isInvertedScroll);
    }

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -45,6 +45,7 @@ class ADSRDisplay;
 class UserPrefsEditor;
 class Minimap;
 class ScriptWarningPopup;
+class NoteOutputQueue;
 
 enum LogEventType
 {
@@ -232,6 +233,7 @@ public:
    std::recursive_mutex& GetRenderLock() { return mRenderLock; }
    NamedMutex* GetAudioMutex() { return &mAudioThreadMutex; }
    static std::thread::id GetAudioThreadID() { return sAudioThreadId; }
+   NoteOutputQueue* GetNoteOutputQueue() { return mNoteOutputQueue; }
 
    IDrawableModule* CreateModule(const ofxJSONElement& moduleInfo);
    void SetUpModule(IDrawableModule* module, const ofxJSONElement& moduleInfo);
@@ -363,6 +365,7 @@ private:
 
    NamedMutex mAudioThreadMutex;
    static std::thread::id sAudioThreadId;
+   NoteOutputQueue* mNoteOutputQueue{ nullptr };
 
    bool mAudioPaused;
    bool mIsLoadingState;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -14,6 +14,7 @@
 #include "EffectFactory.h"
 #include "ModuleContainer.h"
 #include "Minimap.h"
+#include <thread>
 
 #ifdef BESPOKE_LINUX
 #include <climits>
@@ -230,6 +231,7 @@ public:
    float GetFrameRate() const { return mFrameRate; }
    std::recursive_mutex& GetRenderLock() { return mRenderLock; }
    NamedMutex* GetAudioMutex() { return &mAudioThreadMutex; }
+   static std::thread::id GetAudioThreadID() { return sAudioThreadId; }
 
    IDrawableModule* CreateModule(const ofxJSONElement& moduleInfo);
    void SetUpModule(IDrawableModule* module, const ofxJSONElement& moduleInfo);
@@ -360,6 +362,7 @@ private:
    std::list<std::string> mErrors;
 
    NamedMutex mAudioThreadMutex;
+   static std::thread::id sAudioThreadId;
 
    bool mAudioPaused;
    bool mIsLoadingState;

--- a/Source/ModulatorAccum.h
+++ b/Source/ModulatorAccum.h
@@ -61,7 +61,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorAdd.h
+++ b/Source/ModulatorAdd.h
@@ -54,7 +54,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorAddCentered.h
+++ b/Source/ModulatorAddCentered.h
@@ -54,7 +54,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -57,7 +57,7 @@ public:
    bool MouseMoved(float x, float y) override;
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorExpression.h
+++ b/Source/ModulatorExpression.h
@@ -52,7 +52,7 @@ public:
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    //ITextEntryListener
    void TextEntryComplete(TextEntry* entry) override;

--- a/Source/ModulatorGravity.cpp
+++ b/Source/ModulatorGravity.cpp
@@ -102,7 +102,7 @@ void ModulatorGravity::OnPulse(double time, float velocity, int flags)
    Kick(velocity);
 }
 
-void ModulatorGravity::ButtonClicked(ClickButton* button)
+void ModulatorGravity::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mKickButton)
       Kick(1);

--- a/Source/ModulatorGravity.h
+++ b/Source/ModulatorGravity.h
@@ -63,10 +63,10 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorMult.h
+++ b/Source/ModulatorMult.h
@@ -54,7 +54,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorSmoother.h
+++ b/Source/ModulatorSmoother.h
@@ -60,7 +60,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModulatorSubtract.h
+++ b/Source/ModulatorSubtract.h
@@ -54,7 +54,7 @@ public:
    FloatSlider* GetTarget() { return mSliderTarget; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -272,7 +272,7 @@ void ModuleSaveDataPanel::FillDropdownList(DropdownList* list, ModuleSaveData::S
       list->SetUnknownItemString(save->mString);
 }
 
-void ModuleSaveDataPanel::ButtonClicked(ClickButton* button)
+void ModuleSaveDataPanel::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mApplyButton)
       ApplyChanges();
@@ -289,15 +289,15 @@ void ModuleSaveDataPanel::ButtonClicked(ClickButton* button)
    }
 }
 
-void ModuleSaveDataPanel::CheckboxUpdated(Checkbox* checkbox)
+void ModuleSaveDataPanel::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void ModuleSaveDataPanel::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ModuleSaveDataPanel::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void ModuleSaveDataPanel::IntSliderUpdated(IntSlider* slider, int oldVal)
+void ModuleSaveDataPanel::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
@@ -326,7 +326,7 @@ void ModuleSaveDataPanel::DropdownClicked(DropdownList* list)
    }
 }
 
-void ModuleSaveDataPanel::DropdownUpdated(DropdownList* list, int oldVal)
+void ModuleSaveDataPanel::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    for (auto iter = mStringDropdowns.begin(); iter != mStringDropdowns.end(); ++iter)
    {

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -57,13 +57,13 @@ public:
    void UpdatePosition();
    void ReloadSaveData();
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    bool IsSaveable() override { return false; }
 

--- a/Source/ModwheelToVibrato.cpp
+++ b/Source/ModwheelToVibrato.cpp
@@ -79,15 +79,15 @@ void ModwheelToVibrato::PlayNote(double time, int pitch, int velocity, int voice
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void ModwheelToVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void ModwheelToVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void ModwheelToVibrato::DropdownUpdated(DropdownList* list, int oldVal)
+void ModwheelToVibrato::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void ModwheelToVibrato::CheckboxUpdated(Checkbox* checkbox)
+void ModwheelToVibrato::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/ModwheelToVibrato.h
+++ b/Source/ModwheelToVibrato.h
@@ -47,9 +47,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -104,7 +104,7 @@ void Monome::SetLightInternal(int x, int y, float value)
    Vec2i pos = Rotate(x, y, mGridRotation);
    int index = pos.x + pos.y * mMaxColumns;
    mLights[index].mValue = value;
-   mLights[index].mLastUpdatedTime = NextBufferTime();
+   mLights[index].mLastUpdatedTime = NextBufferTime(false);
 }
 
 void Monome::SetLight(int x, int y, float value)
@@ -195,7 +195,7 @@ void Monome::ConnectToDevice(std::string deviceDesc)
       for (int i = 0; i < mListForMidiController->GetNumValues(); ++i)
       {
          if (mListForMidiController->GetLabel(i) == device->GetDescription())
-            mListForMidiController->SetValueDirect(i, NextBufferTime());
+            mListForMidiController->SetValueDirect(i, NextBufferTime(false));
       }
    }
 

--- a/Source/Monome.cpp
+++ b/Source/Monome.cpp
@@ -104,7 +104,7 @@ void Monome::SetLightInternal(int x, int y, float value)
    Vec2i pos = Rotate(x, y, mGridRotation);
    int index = pos.x + pos.y * mMaxColumns;
    mLights[index].mValue = value;
-   mLights[index].mLastUpdatedTime = gTime + gBufferSizeMs;
+   mLights[index].mLastUpdatedTime = NextBufferTime();
 }
 
 void Monome::SetLight(int x, int y, float value)
@@ -195,7 +195,7 @@ void Monome::ConnectToDevice(std::string deviceDesc)
       for (int i = 0; i < mListForMidiController->GetNumValues(); ++i)
       {
          if (mListForMidiController->GetLabel(i) == device->GetDescription())
-            mListForMidiController->SetValueDirect(i);
+            mListForMidiController->SetValueDirect(i, NextBufferTime());
       }
    }
 

--- a/Source/Monophonify.cpp
+++ b/Source/Monophonify.cpp
@@ -170,17 +170,17 @@ int Monophonify::GetMostRecentCurrentlyHeldPitch() const
    return mostRecentPitch;
 }
 
-void Monophonify::CheckboxUpdated(Checkbox* checkbox)
+void Monophonify::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
       for (int i = 0; i < 128; ++i)
          mHeldNotes[i] = -1;
    }
 }
 
-void Monophonify::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Monophonify::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -47,9 +47,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MultibandCompressor.cpp
+++ b/Source/MultibandCompressor.cpp
@@ -166,7 +166,7 @@ void MultibandCompressor::CalcFilters()
    }
 }
 
-void MultibandCompressor::IntSliderUpdated(IntSlider* slider, int oldVal)
+void MultibandCompressor::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumBandsSlider)
    {
@@ -174,7 +174,7 @@ void MultibandCompressor::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void MultibandCompressor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MultibandCompressor::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mFMinSlider || slider == mFMaxSlider)
    {

--- a/Source/MultibandCompressor.h
+++ b/Source/MultibandCompressor.h
@@ -54,8 +54,8 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -158,11 +158,11 @@ void MultitapDelay::DropdownClicked(DropdownList* list)
 {
 }
 
-void MultitapDelay::DropdownUpdated(DropdownList* list, int oldVal)
+void MultitapDelay::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void MultitapDelay::ButtonClicked(ClickButton* button)
+void MultitapDelay::ButtonClicked(ClickButton* button, double time)
 {
 }
 
@@ -181,7 +181,7 @@ bool MultitapDelay::MouseMoved(float x, float y)
    return IDrawableModule::MouseMoved(x, y);
 }
 
-void MultitapDelay::CheckboxUpdated(Checkbox* checkbox)
+void MultitapDelay::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -191,11 +191,11 @@ void MultitapDelay::GetModuleDimensions(float& width, float& height)
    height = mBufferY + mBufferH + 10 + 100 * mNumTaps;
 }
 
-void MultitapDelay::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MultitapDelay::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void MultitapDelay::IntSliderUpdated(IntSlider* slider, int oldVal)
+void MultitapDelay::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -62,16 +62,16 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IFloatSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IDropdownListener
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -121,7 +121,7 @@ int MultitrackRecorder::GetRecordingLength()
    return recordingLength;
 }
 
-void MultitrackRecorder::ButtonClicked(ClickButton* button)
+void MultitrackRecorder::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mAddTrackButton)
    {
@@ -159,7 +159,7 @@ void MultitrackRecorder::ButtonClicked(ClickButton* button)
    }
 }
 
-void MultitrackRecorder::CheckboxUpdated(Checkbox* checkbox)
+void MultitrackRecorder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mRecordCheckbox)
    {
@@ -436,15 +436,15 @@ void MultitrackRecorderTrack::Clear()
    mRecordingLength = 0;
 }
 
-void MultitrackRecorderTrack::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void MultitrackRecorderTrack::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void MultitrackRecorderTrack::CheckboxUpdated(Checkbox* checkbox)
+void MultitrackRecorderTrack::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void MultitrackRecorderTrack::ButtonClicked(ClickButton* button)
+void MultitrackRecorderTrack::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mDeleteButton)
       mRecorder->RemoveTrack(this);

--- a/Source/MultitrackRecorder.h
+++ b/Source/MultitrackRecorder.h
@@ -51,8 +51,8 @@ public:
 
    void RemoveTrack(MultitrackRecorderTrack* track);
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
@@ -109,9 +109,9 @@ public:
    void Clear();
    int GetRecordingLength() const { return mRecordingLength; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/Muter.cpp
+++ b/Source/Muter.cpp
@@ -64,8 +64,7 @@ void Muter::DrawModule()
    mRampTimeSlider->Draw();
 }
 
-void Muter::CheckboxUpdated(Checkbox* checkbox)
+void Muter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
-   double time = gTime + gBufferSizeMs;
    mRamp.Start(time, mPass ? 1 : 0, time + mRampTimeMs);
 }

--- a/Source/Muter.h
+++ b/Source/Muter.h
@@ -49,8 +49,8 @@ public:
    void SetEnabled(bool enabled) override {}
    std::string GetType() override { return "muter"; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
 private:
    //IDrawableModule

--- a/Source/Neighborhooder.cpp
+++ b/Source/Neighborhooder.cpp
@@ -50,16 +50,16 @@ void Neighborhooder::DrawModule()
    DrawTextNormal(NoteName(mMinPitch) + ofToString(mMinPitch / 12 - 2), 91, 15);
 }
 
-void Neighborhooder::CheckboxUpdated(Checkbox* checkbox)
+void Neighborhooder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void Neighborhooder::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Neighborhooder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mMinSlider || slider == mRangeSlider)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void Neighborhooder::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/Neighborhooder.h
+++ b/Source/Neighborhooder.h
@@ -46,8 +46,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoiseEffect.cpp
+++ b/Source/NoiseEffect.cpp
@@ -86,14 +86,14 @@ float NoiseEffect::GetEffectAmount()
    return mAmount;
 }
 
-void NoiseEffect::CheckboxUpdated(Checkbox* checkbox)
+void NoiseEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void NoiseEffect::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoiseEffect::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void NoiseEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoiseEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }

--- a/Source/NoiseEffect.h
+++ b/Source/NoiseEffect.h
@@ -48,11 +48,11 @@ public:
    std::string GetType() override { return "noisify"; }
 
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -219,7 +219,7 @@ void NoteCanvas::OnTransportAdvanced(float amount)
 
    if (mStopQueued)
    {
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(NextBufferTime());
       for (int i = 0; i < mCurrentNotes.size(); ++i)
          mCurrentNotes[i] = nullptr;
       mStopQueued = false;

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -325,7 +325,7 @@ void NoteCanvas::UpdateNumColumns()
       mCanvas->SetMajorColumnInterval(TheTransport->CountInStandardMeasure(mInterval) / 4);
 }
 
-void NoteCanvas::Clear()
+void NoteCanvas::Clear(double time)
 {
    bool wasPlaying = mPlay;
    mPlay = false;
@@ -334,7 +334,7 @@ void NoteCanvas::Clear()
       mInputNotes[pitch] = nullptr;
       mCurrentNotes[pitch] = nullptr;
    }
-   mNoteOutput.Flush(gTime);
+   mNoteOutput.Flush(time);
    mCanvas->Clear();
    mPlay = wasPlaying;
 }
@@ -623,7 +623,7 @@ void NoteCanvas::LoadMidi()
       bool wasPlaying = mPlay;
       mPlay = false;
 
-      mCanvas->Clear();
+      Clear(NextBufferTime());
       SetNumMeasures(1);
       File file = chooser.getResult();
       FileInputStream inputStream(file);
@@ -699,13 +699,13 @@ void NoteCanvas::SaveMidi()
    }
 }
 
-void NoteCanvas::CheckboxUpdated(Checkbox* checkbox)
+void NoteCanvas::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
       for (int pitch = 0; pitch < 128; ++pitch)
          mInputNotes[pitch] = nullptr;
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
    }
    if (checkbox == mPlayCheckbox)
    {
@@ -729,7 +729,7 @@ void NoteCanvas::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void NoteCanvas::ButtonClicked(ClickButton* button)
+void NoteCanvas::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mQuantizeButton)
       QuantizeNotes();
@@ -744,11 +744,11 @@ void NoteCanvas::ButtonClicked(ClickButton* button)
       SaveMidi();
 }
 
-void NoteCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void NoteCanvas::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteCanvas::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumMeasuresSlider)
    {
@@ -756,7 +756,7 @@ void NoteCanvas::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void NoteCanvas::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteCanvas::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -219,7 +219,7 @@ void NoteCanvas::OnTransportAdvanced(float amount)
 
    if (mStopQueued)
    {
-      mNoteOutput.Flush(NextBufferTime());
+      mNoteOutput.Flush(NextBufferTime(false));
       for (int i = 0; i < mCurrentNotes.size(); ++i)
          mCurrentNotes[i] = nullptr;
       mStopQueued = false;
@@ -623,7 +623,7 @@ void NoteCanvas::LoadMidi()
       bool wasPlaying = mPlay;
       mPlay = false;
 
-      Clear(NextBufferTime());
+      Clear(NextBufferTime(false));
       SetNumMeasures(1);
       File file = chooser.getResult();
       FileInputStream inputStream(file);

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -60,7 +60,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void Clear();
+   void Clear(double time);
    NoteCanvasElement* AddNote(double measurePos, int pitch, int velocity, double length, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
 
    /**
@@ -72,11 +72,11 @@ public:
 
    void CanvasUpdated(Canvas* canvas) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/NoteChainNode.cpp
+++ b/Source/NoteChainNode.cpp
@@ -96,13 +96,13 @@ void NoteChainNode::OnTimeEvent(double time)
 
 void NoteChainNode::OnTransportAdvanced(float amount)
 {
-   if (mNoteOn && gTime + gBufferSizeMs > mStartTime + mDurationMs)
+   if (mNoteOn && NextBufferTime() > mStartTime + mDurationMs)
    {
       mNoteOn = false;
       mNoteOutput.Flush(mStartTime + mDurationMs);
    }
 
-   if (mWaitingToTrigger && gTime + gBufferSizeMs > mStartTime + mNext)
+   if (mWaitingToTrigger && NextBufferTime() > mStartTime + mNext)
    {
       mWaitingToTrigger = false;
       DispatchPulse(mNextNodeCable, mStartTime + mNext, 1, 0);
@@ -131,13 +131,13 @@ void NoteChainNode::TriggerNote(double time)
    }
 }
 
-void NoteChainNode::CheckboxUpdated(Checkbox* checkbox)
+void NoteChainNode::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void NoteChainNode::ButtonClicked(ClickButton* button)
+void NoteChainNode::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mTriggerButton)
       mQueueTrigger = true;
@@ -148,7 +148,7 @@ void NoteChainNode::TextEntryComplete(TextEntry* entry)
    if (entry == mPitchEntry)
    {
       mNoteOn = false;
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(NextBufferTime());
    }
 }
 

--- a/Source/NoteChainNode.cpp
+++ b/Source/NoteChainNode.cpp
@@ -96,13 +96,13 @@ void NoteChainNode::OnTimeEvent(double time)
 
 void NoteChainNode::OnTransportAdvanced(float amount)
 {
-   if (mNoteOn && NextBufferTime() > mStartTime + mDurationMs)
+   if (mNoteOn && NextBufferTime(true) > mStartTime + mDurationMs)
    {
       mNoteOn = false;
       mNoteOutput.Flush(mStartTime + mDurationMs);
    }
 
-   if (mWaitingToTrigger && NextBufferTime() > mStartTime + mNext)
+   if (mWaitingToTrigger && NextBufferTime(true) > mStartTime + mNext)
    {
       mWaitingToTrigger = false;
       DispatchPulse(mNextNodeCable, mStartTime + mNext, 1, 0);
@@ -148,7 +148,7 @@ void NoteChainNode::TextEntryComplete(TextEntry* entry)
    if (entry == mPitchEntry)
    {
       mNoteOn = false;
-      mNoteOutput.Flush(NextBufferTime());
+      mNoteOutput.Flush(NextBufferTime(false));
    }
 }
 

--- a/Source/NoteChainNode.h
+++ b/Source/NoteChainNode.h
@@ -56,11 +56,11 @@ public:
 
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/NoteChance.cpp
+++ b/Source/NoteChance.cpp
@@ -154,7 +154,7 @@ void NoteChance::Reseed()
    mSeed = gRandom() % 10000;
 }
 
-void NoteChance::ButtonClicked(ClickButton* button)
+void NoteChance::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;

--- a/Source/NoteChance.h
+++ b/Source/NoteChance.h
@@ -45,10 +45,10 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/NoteCounter.cpp
+++ b/Source/NoteCounter.cpp
@@ -219,7 +219,7 @@ void NoteCounter::Reseed()
    mSeed = gRandom() % 10000;
 }
 
-void NoteCounter::ButtonClicked(ClickButton* button)
+void NoteCounter::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;
@@ -229,22 +229,22 @@ void NoteCounter::ButtonClicked(ClickButton* button)
       mSeed = (mSeed + 1) % 10000;
 }
 
-void NoteCounter::CheckboxUpdated(Checkbox* checkbox)
+void NoteCounter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
       mStep = 0;
    }
 }
 
-void NoteCounter::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteCounter::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mCustomDivisorSlider)
       mTransportListenerInfo->mCustomDivisor = mCustomDivisor;
 }
 
-void NoteCounter::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteCounter::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {

--- a/Source/NoteCounter.h
+++ b/Source/NoteCounter.h
@@ -59,11 +59,11 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteCreator.cpp
+++ b/Source/NoteCreator.cpp
@@ -84,10 +84,8 @@ void NoteCreator::TriggerNote(double time, float velocity)
    PlayNoteOutput(mStartTime + mDuration, mPitch, 0, mVoiceIndex);
 }
 
-void NoteCreator::CheckboxUpdated(Checkbox* checkbox)
+void NoteCreator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
-   double time = gTime + gBufferSizeMs;
-
    if (checkbox == mEnabledCheckbox)
       mNoteOutput.Flush(time);
    if (checkbox == mNoteOnCheckbox)
@@ -104,11 +102,10 @@ void NoteCreator::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void NoteCreator::ButtonClicked(ClickButton* button)
+void NoteCreator::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mTriggerButton)
    {
-      double time = gTime + gBufferSizeMs;
       TriggerNote(time, mVelocity);
    }
 }
@@ -119,7 +116,7 @@ void NoteCreator::TextEntryComplete(TextEntry* entry)
    {
       if (mNoteOn)
       {
-         double time = gTime + gBufferSizeMs;
+         double time = NextBufferTime();
          mNoteOutput.Flush(time);
          PlayNoteOutput(time + .1f, mPitch, mVelocity * 127, mVoiceIndex);
       }

--- a/Source/NoteCreator.cpp
+++ b/Source/NoteCreator.cpp
@@ -116,7 +116,7 @@ void NoteCreator::TextEntryComplete(TextEntry* entry)
    {
       if (mNoteOn)
       {
-         double time = NextBufferTime();
+         double time = NextBufferTime(false);
          mNoteOutput.Flush(time);
          PlayNoteOutput(time + .1f, mPitch, mVelocity * 127, mVoiceIndex);
       }

--- a/Source/NoteCreator.h
+++ b/Source/NoteCreator.h
@@ -48,10 +48,10 @@ public:
 
    void OnPulse(double time, float velocity, int flags) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/NoteDelayer.cpp
+++ b/Source/NoteDelayer.cpp
@@ -94,7 +94,7 @@ void NoteDelayer::OnTransportAdvanced(float amount)
    for (int i = mConsumeIndex; i < end; ++i)
    {
       const NoteInfo& info = mInputNotes[i % kQueueSize];
-      if (NextBufferTime() >= info.mTriggerTime)
+      if (NextBufferTime(true) >= info.mTriggerTime)
       {
          PlayNoteOutput(info.mTriggerTime, info.mPitch, info.mVelocity, -1, info.mModulation);
          mConsumeIndex = (mConsumeIndex + 1) % kQueueSize;

--- a/Source/NoteDelayer.cpp
+++ b/Source/NoteDelayer.cpp
@@ -72,11 +72,11 @@ void NoteDelayer::DrawModule()
    }
 }
 
-void NoteDelayer::CheckboxUpdated(Checkbox* checkbox)
+void NoteDelayer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
       mAppendIndex = 0;
       mConsumeIndex = 0;
    }
@@ -94,7 +94,7 @@ void NoteDelayer::OnTransportAdvanced(float amount)
    for (int i = mConsumeIndex; i < end; ++i)
    {
       const NoteInfo& info = mInputNotes[i % kQueueSize];
-      if (gTime + gBufferSizeMs >= info.mTriggerTime)
+      if (NextBufferTime() >= info.mTriggerTime)
       {
          PlayNoteOutput(info.mTriggerTime, info.mPitch, info.mVelocity, -1, info.mModulation);
          mConsumeIndex = (mConsumeIndex + 1) % kQueueSize;
@@ -122,7 +122,7 @@ void NoteDelayer::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    }
 }
 
-void NoteDelayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteDelayer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/NoteDelayer.h
+++ b/Source/NoteDelayer.h
@@ -51,8 +51,8 @@ public:
 
    void OnTransportAdvanced(float amount) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteEcho.h
+++ b/Source/NoteEcho.h
@@ -45,7 +45,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteFlusher.cpp
+++ b/Source/NoteFlusher.cpp
@@ -45,11 +45,10 @@ void NoteFlusher::DrawModule()
    mFlushButton->Draw();
 }
 
-void NoteFlusher::ButtonClicked(ClickButton* button)
+void NoteFlusher::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mFlushButton)
    {
-      double time = gTime + gBufferSizeMs;
       mNoteOutput.Flush(time);
       for (int i = 0; i < 127; ++i)
          mNoteOutput.PlayNote(time, i, 0);

--- a/Source/NoteFlusher.h
+++ b/Source/NoteFlusher.h
@@ -40,7 +40,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteGate.cpp
+++ b/Source/NoteGate.cpp
@@ -59,45 +59,19 @@ void NoteGate::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modu
       mActiveNotes[pitch].voiceIdx = voiceIdx;
       mActiveNotes[pitch].modulation = modulation;
    }
-
-   if (!mGate)
-   {
-      mPendingNotes[pitch].velocity = velocity;
-      mPendingNotes[pitch].voiceIdx = voiceIdx;
-      mPendingNotes[pitch].modulation = modulation;
-   }
 }
 
-void NoteGate::CheckboxUpdated(Checkbox* checkbox)
+void NoteGate::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mGateCheckbox)
    {
-      double time = gTime + gBufferSizeMs;
-
-      if (mGate)
-      {
-         for (int pitch = 0; pitch < 128; ++pitch)
-         {
-            if (mPendingNotes[pitch].velocity > 0)
-            {
-               PlayNoteOutput(time, pitch, mPendingNotes[pitch].velocity, mPendingNotes[pitch].voiceIdx, mPendingNotes[pitch].modulation);
-               mActiveNotes[pitch].velocity = mPendingNotes[pitch].velocity;
-               mActiveNotes[pitch].voiceIdx = mPendingNotes[pitch].voiceIdx;
-               mActiveNotes[pitch].modulation = mPendingNotes[pitch].modulation;
-               mPendingNotes[pitch].velocity = 0;
-            }
-         }
-      }
-      else
+      if (!mGate)
       {
          for (int pitch = 0; pitch < 128; ++pitch)
          {
             if (mActiveNotes[pitch].velocity > 0)
             {
                PlayNoteOutput(time, pitch, 0, mActiveNotes[pitch].voiceIdx, mActiveNotes[pitch].modulation);
-               mPendingNotes[pitch].velocity = mActiveNotes[pitch].velocity;
-               mPendingNotes[pitch].voiceIdx = mActiveNotes[pitch].voiceIdx;
-               mPendingNotes[pitch].modulation = mActiveNotes[pitch].modulation;
                mActiveNotes[pitch].velocity = 0;
             }
          }

--- a/Source/NoteGate.h
+++ b/Source/NoteGate.h
@@ -42,7 +42,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
@@ -56,7 +56,6 @@ private:
    bool mGate{ true };
    Checkbox* mGateCheckbox{ nullptr };
    std::array<NoteInputElement, 128> mActiveNotes{ false };
-   std::array<NoteInputElement, 128> mPendingNotes{ false };
 };
 
 

--- a/Source/NoteHocket.cpp
+++ b/Source/NoteHocket.cpp
@@ -184,7 +184,7 @@ void NoteHocket::SendCC(int control, int value, int voiceIdx)
    SendCCOutput(control, value, voiceIdx);
 }
 
-void NoteHocket::ButtonClicked(ClickButton* button)
+void NoteHocket::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;

--- a/Source/NoteHocket.h
+++ b/Source/NoteHocket.h
@@ -48,10 +48,10 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteHumanizer.cpp
+++ b/Source/NoteHumanizer.cpp
@@ -57,10 +57,10 @@ void NoteHumanizer::DrawModule()
    mVelocitySlider->Draw();
 }
 
-void NoteHumanizer::CheckboxUpdated(Checkbox* checkbox)
+void NoteHumanizer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime + gBufferSizeMs);
+      mNoteOutput.Flush(time);
 }
 
 void NoteHumanizer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -87,7 +87,7 @@ void NoteHumanizer::PlayNote(double time, int pitch, int velocity, int voiceIdx,
    PlayNoteOutput(time + delayMs, pitch, outputVelocity, voiceIdx, modulation);
 }
 
-void NoteHumanizer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteHumanizer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/NoteHumanizer.h
+++ b/Source/NoteHumanizer.h
@@ -51,8 +51,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteLatch.cpp
+++ b/Source/NoteLatch.cpp
@@ -41,11 +41,10 @@ void NoteLatch::DrawModule()
       return;
 }
 
-void NoteLatch::CheckboxUpdated(Checkbox* checkbox)
+void NoteLatch::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      double time = gTime + gBufferSizeMs;
       for (int i = 0; i < 128; ++i)
       {
          if (mNoteState[i])

--- a/Source/NoteLatch.h
+++ b/Source/NoteLatch.h
@@ -43,7 +43,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -288,11 +288,10 @@ int NoteLooper::GetNewVoice(int voiceIdx)
    return ret;
 }
 
-void NoteLooper::CheckboxUpdated(Checkbox* checkbox)
+void NoteLooper::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      double time = gTime + gBufferSizeMs;
       for (int i = 0; i < (int)mCurrentNotes.size(); ++i)
       {
          if (mCurrentNotes[i] != nullptr)
@@ -304,21 +303,20 @@ void NoteLooper::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void NoteLooper::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteLooper::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void NoteLooper::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteLooper::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumMeasuresSlider)
       SetNumMeasures(mNumMeasures);
 }
 
-void NoteLooper::ButtonClicked(ClickButton* button)
+void NoteLooper::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mClearButton)
    {
-      double time = gTime + gBufferSizeMs;
       for (int i = 0; i < (int)mCurrentNotes.size(); ++i)
       {
          if (mCurrentNotes[i] != nullptr)
@@ -375,7 +373,7 @@ void NoteLooper::SetNumMeasures(int numMeasures)
    mCanvas->mLoopEnd = mNumMeasures;
 }
 
-void NoteLooper::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteLooper::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -58,15 +58,15 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/NoteOctaver.cpp
+++ b/Source/NoteOctaver.cpp
@@ -54,10 +54,10 @@ void NoteOctaver::DrawModule()
    mRetriggerCheckbox->Draw();
 }
 
-void NoteOctaver::CheckboxUpdated(Checkbox* checkbox)
+void NoteOctaver::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void NoteOctaver::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -86,11 +86,10 @@ void NoteOctaver::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    PlayNoteOutput(time, mInputNotes[pitch].mOutputPitch, velocity, mInputNotes[pitch].mVoiceIdx, modulation);
 }
 
-void NoteOctaver::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteOctaver::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mOctaveSlider && mEnabled && mRetrigger)
    {
-      double time = gTime + gBufferSizeMs;
       for (int pitch = 0; pitch < 128; ++pitch)
       {
          if (mInputNotes[pitch].mOn)

--- a/Source/NoteOctaver.h
+++ b/Source/NoteOctaver.h
@@ -47,9 +47,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteOutputQueue.cpp
+++ b/Source/NoteOutputQueue.cpp
@@ -66,7 +66,7 @@ void NoteOutputQueue::Process()
       else
       {
          //ofLog() << "playing queued note " << output.time << " " << output.pitch << " " << output.velocity << " " << gTime;
-         output.target->PlayNoteInternal(output.time, output.pitch, output.velocity, output.voiceIdx, output.modulation);
+         output.target->PlayNoteInternal(output.time, output.pitch, output.velocity, output.voiceIdx, output.modulation, false);
       }
    }
 }

--- a/Source/NoteOutputQueue.cpp
+++ b/Source/NoteOutputQueue.cpp
@@ -1,0 +1,72 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  INoteSource.cpp
+//  modularSynth
+//
+//  Created by Ryan Challinor on 12/14/12.
+//
+//
+
+#include "NoteOutputQueue.h"
+#include "INoteSource.h"
+#include "ModularSynth.h"
+
+void NoteOutputQueue::QueuePlayNote(NoteOutput* target, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
+{
+   PendingNoteOutput output;
+   output.target = target;
+   output.time = time;
+   output.pitch = pitch;
+   output.velocity = velocity;
+   output.voiceIdx = voiceIdx;
+   output.modulation = modulation;
+   mQueue.enqueue(output);
+}
+
+void NoteOutputQueue::QueueFlush(NoteOutput* target, double time)
+{
+   PendingNoteOutput output;
+   output.target = target;
+   output.isFlush = true;
+   output.time = time;
+   mQueue.enqueue(output);
+}
+
+void NoteOutputQueue::Process()
+{
+   assert(std::this_thread::get_id() == ModularSynth::GetAudioThreadID());
+
+   PendingNoteOutput output;
+   while (true)
+   {
+      bool hasData = mQueue.try_dequeue(output);
+      if (!hasData)
+         break;
+
+      if (output.isFlush)
+      {
+         output.target->Flush(output.time);
+      }
+      else
+      {
+         //ofLog() << "playing queued note " << output.time << " " << output.pitch << " " << output.velocity << " " << gTime;
+         output.target->PlayNoteInternal(output.time, output.pitch, output.velocity, output.voiceIdx, output.modulation);
+      }
+   }
+}

--- a/Source/NoteOutputQueue.h
+++ b/Source/NoteOutputQueue.h
@@ -1,0 +1,53 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  INoteSource.h
+//  modularSynth
+//
+//  Created by Ryan Challinor on 12/12/12.
+//
+//
+
+#pragma once
+
+#include "readerwriterqueue.h"
+#include "ModulationChain.h"
+
+class NoteOutput;
+
+class NoteOutputQueue
+{
+public:
+   void QueuePlayNote(NoteOutput* target, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation);
+   void QueueFlush(NoteOutput* target, double time);
+   void Process();
+
+private:
+   struct PendingNoteOutput
+   {
+      NoteOutput* target;
+      bool isFlush{ false };
+      double time{ 0 };
+      int pitch{ 0 };
+      int velocity{ 0 };
+      int voiceIdx{ -1 };
+      ModulationParameters modulation{};
+   };
+
+   moodycamel::ReaderWriterQueue<PendingNoteOutput> mQueue;
+};

--- a/Source/NotePanAlternator.h
+++ b/Source/NotePanAlternator.h
@@ -47,7 +47,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NotePanRandom.h
+++ b/Source/NotePanRandom.h
@@ -46,7 +46,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NotePanner.h
+++ b/Source/NotePanner.h
@@ -47,7 +47,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteQuantizer.cpp
+++ b/Source/NoteQuantizer.cpp
@@ -159,7 +159,7 @@ void NoteQuantizer::OnPulse(double time, float velocity, int flags)
    OnEvent(time, velocity);
 }
 
-void NoteQuantizer::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteQuantizer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mQuantizeIntervalSelector)
    {

--- a/Source/NoteQuantizer.h
+++ b/Source/NoteQuantizer.h
@@ -46,7 +46,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void OnTimeEvent(double time) override;
    void OnPulse(double time, float velocity, int flags) override;
 

--- a/Source/NoteRangeFilter.cpp
+++ b/Source/NoteRangeFilter.cpp
@@ -63,16 +63,16 @@ void NoteRangeFilter::DrawModule()
    mWrapCheckbox->Draw();
 }
 
-void NoteRangeFilter::CheckboxUpdated(Checkbox* checkbox)
+void NoteRangeFilter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void NoteRangeFilter::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteRangeFilter::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mMinPitchSlider || slider == mMaxPitchSlider)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void NoteRangeFilter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/NoteRangeFilter.h
+++ b/Source/NoteRangeFilter.h
@@ -45,8 +45,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteRatchet.cpp
+++ b/Source/NoteRatchet.cpp
@@ -82,7 +82,7 @@ void NoteRatchet::DrawModule()
    mRatchetSubdivisionSelector->Draw();
 }
 
-void NoteRatchet::CheckboxUpdated(Checkbox* checkbox)
+void NoteRatchet::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -106,7 +106,7 @@ void NoteRatchet::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    }
 }
 
-void NoteRatchet::DropdownUpdated(DropdownList* slider, int oldVal)
+void NoteRatchet::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 

--- a/Source/NoteRatchet.h
+++ b/Source/NoteRatchet.h
@@ -46,8 +46,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteRouter.cpp
+++ b/Source/NoteRouter.cpp
@@ -61,7 +61,7 @@ void NoteRouter::SetSelectedMask(int mask)
 {
    int oldMask = mRouteMask;
    mRouteMask = mask;
-   RadioButtonUpdated(mRouteSelector, oldMask, NextBufferTime());
+   RadioButtonUpdated(mRouteSelector, oldMask, NextBufferTime(false));
 }
 
 void NoteRouter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/NoteRouter.cpp
+++ b/Source/NoteRouter.cpp
@@ -61,7 +61,7 @@ void NoteRouter::SetSelectedMask(int mask)
 {
    int oldMask = mRouteMask;
    mRouteMask = mask;
-   RadioButtonUpdated(mRouteSelector, oldMask);
+   RadioButtonUpdated(mRouteSelector, oldMask, NextBufferTime());
 }
 
 void NoteRouter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -76,14 +76,14 @@ void NoteRouter::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
    }
 }
 
-void NoteRouter::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void NoteRouter::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mRouteSelector)
    {
       if (mRadioButtonMode)
       {
          if (oldVal < (int)mDestinationCables.size())
-            mDestinationCables[oldVal]->Flush(gTime + gBufferSizeMs);
+            mDestinationCables[oldVal]->Flush(time);
       }
       else //bitmask mode
       {
@@ -95,7 +95,7 @@ void NoteRouter::RadioButtonUpdated(RadioButton* radio, int oldVal)
             if (1 & (removed >> i))
             {
                if (i < (int)mDestinationCables.size())
-                  mDestinationCables[i]->Flush(gTime + gBufferSizeMs);
+                  mDestinationCables[i]->Flush(time);
             }
          }
       }

--- a/Source/NoteRouter.h
+++ b/Source/NoteRouter.h
@@ -50,7 +50,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
    //IRadioButtonListener
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteSinger.cpp
+++ b/Source/NoteSinger.cpp
@@ -145,15 +145,15 @@ int NoteSinger::GetPitchForBucket(int bucket)
    return TheScale->GetPitchFromTone(bucket + TheScale->NumTonesInScale() * 2);
 }
 
-void NoteSinger::ButtonClicked(ClickButton* button)
+void NoteSinger::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void NoteSinger::CheckboxUpdated(Checkbox* checkbox)
+void NoteSinger::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
-      PlayNoteOutput(gTime, mPitch, 0, -1);
+      PlayNoteOutput(time, mPitch, 0, -1);
       mPitch = -1;
    }
 }

--- a/Source/NoteSinger.h
+++ b/Source/NoteSinger.h
@@ -64,15 +64,15 @@ public:
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
    //IRadioButtonListener
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override {}
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteSorter.cpp
+++ b/Source/NoteSorter.cpp
@@ -95,9 +95,9 @@ void NoteSorter::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void NoteSorter::TextEntryComplete(TextEntry* entry)
 {
-   mNoteOutput.Flush(NextBufferTime());
+   mNoteOutput.Flush(NextBufferTime(false));
    for (int i = 0; i < kMaxDestinations; ++i)
-      mDestinationCables[i]->Flush(NextBufferTime());
+      mDestinationCables[i]->Flush(NextBufferTime(false));
 }
 
 void NoteSorter::SetUpFromSaveData()

--- a/Source/NoteSorter.cpp
+++ b/Source/NoteSorter.cpp
@@ -95,9 +95,9 @@ void NoteSorter::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void NoteSorter::TextEntryComplete(TextEntry* entry)
 {
-   mNoteOutput.Flush(gTime + gBufferSizeMs);
+   mNoteOutput.Flush(NextBufferTime());
    for (int i = 0; i < kMaxDestinations; ++i)
-      mDestinationCables[i]->Flush(gTime + gBufferSizeMs);
+      mDestinationCables[i]->Flush(NextBufferTime());
 }
 
 void NoteSorter::SetUpFromSaveData()

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -692,7 +692,7 @@ void NoteStepSequencer::UpdateLights()
          int color = 0;
          if (i < mLength)
          {
-            if (i == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()))
+            if (i == mGrid->GetHighlightCol(NextBufferTime(true)))
             {
                color = LaunchpadInterpreter::LaunchpadColor(0, 3);
             }
@@ -849,7 +849,7 @@ void NoteStepSequencer::UpdateGridControllerLights(bool force)
             int row = y - mGridControlOffsetY;
 
             GridColor color = GridColor::kGridColorOff;
-            bool isHighlightCol = (column == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()));
+            bool isHighlightCol = (column == mGrid->GetHighlightCol(NextBufferTime(true)));
             if (isHighlightCol)
                color = GridColor::kGridColor2Dim;
             if (column < mLength)

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -434,10 +434,10 @@ bool NoteStepSequencer::MouseScrolled(float x, float y, float scrollX, float scr
    return false;
 }
 
-void NoteStepSequencer::CheckboxUpdated(Checkbox* checkbox)
+void NoteStepSequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void NoteStepSequencer::GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue)
@@ -692,7 +692,7 @@ void NoteStepSequencer::UpdateLights()
          int color = 0;
          if (i < mLength)
          {
-            if (i == mGrid->GetHighlightCol(gTime + gBufferSizeMs + TheTransport->GetEventLookaheadMs()))
+            if (i == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()))
             {
                color = LaunchpadInterpreter::LaunchpadColor(0, 3);
             }
@@ -849,7 +849,7 @@ void NoteStepSequencer::UpdateGridControllerLights(bool force)
             int row = y - mGridControlOffsetY;
 
             GridColor color = GridColor::kGridColorOff;
-            bool isHighlightCol = (column == mGrid->GetHighlightCol(gTime + gBufferSizeMs + TheTransport->GetEventLookaheadMs()));
+            bool isHighlightCol = (column == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()));
             if (isHighlightCol)
                color = GridColor::kGridColor2Dim;
             if (column < mLength)
@@ -894,7 +894,7 @@ void NoteStepSequencer::OnGridButton(int x, int y, float velocity, IGridControll
    }
 }
 
-void NoteStepSequencer::ButtonClicked(ClickButton* button)
+void NoteStepSequencer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mShiftBackButton)
       ShiftSteps(-1);
@@ -1000,7 +1000,7 @@ void NoteStepSequencer::RandomizePitches(bool fifths)
    }
 }
 
-void NoteStepSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteStepSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -1021,7 +1021,7 @@ void NoteStepSequencer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void NoteStepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteStepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (int i = 0; i < NSS_MAX_STEPS; ++i)
    {
@@ -1030,7 +1030,7 @@ void NoteStepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void NoteStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLoopResetPointSlider || slider == mLengthSlider)
       mLoopResetPoint = MIN(mLoopResetPoint, mLength - 1);
@@ -1150,6 +1150,10 @@ void NoteStepSequencer::SaveState(FileStreamOut& out)
    mGrid->SaveState(out);
    mVelocityGrid->SaveState(out);
    out << mHasExternalPulseSource;
+   float width, height;
+   GetModuleDimensions(width, height);
+   out << width;
+   out << height;
 }
 
 void NoteStepSequencer::LoadState(FileStreamIn& in, int rev)
@@ -1166,4 +1170,11 @@ void NoteStepSequencer::LoadState(FileStreamIn& in, int rev)
    GridUpdated(mVelocityGrid, 0, 0, 0, 0);
    if (rev >= 2)
       in >> mHasExternalPulseSource;
+   if (rev >= 3)
+   {
+      float width, height;
+      in >> width;
+      in >> height;
+      Resize(width, height);
+   }
 }

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -110,18 +110,18 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;
-   int GetModuleSaveStateRev() const override { return 2; }
+   int GetModuleSaveStateRev() const override { return 3; }
 
 private:
    //IDrawableModule

--- a/Source/NoteStepper.cpp
+++ b/Source/NoteStepper.cpp
@@ -117,7 +117,7 @@ void NoteStepper::SendCC(int control, int value, int voiceIdx)
    SendCCOutput(control, value, voiceIdx);
 }
 
-void NoteStepper::ButtonClicked(ClickButton* button)
+void NoteStepper::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetButton)
       mCurrentDestinationIndex = -1;

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -47,8 +47,8 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx = -1) override;
 
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteStreamDisplay.cpp
+++ b/Source/NoteStreamDisplay.cpp
@@ -187,7 +187,7 @@ bool NoteStreamDisplay::IsElementActive(int index) const
    return mNoteStream[index].timeOn != -1 && (mNoteStream[index].timeOff == -1 || gTime - mNoteStream[index].timeOff < mDurationMs);
 }
 
-void NoteStreamDisplay::ButtonClicked(ClickButton* button)
+void NoteStreamDisplay::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetButton)
    {

--- a/Source/NoteStreamDisplay.h
+++ b/Source/NoteStreamDisplay.h
@@ -45,7 +45,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    bool HasDebugDraw() const override { return true; }
 

--- a/Source/NoteStrummer.cpp
+++ b/Source/NoteStrummer.cpp
@@ -110,7 +110,7 @@ void NoteStrummer::OnTransportAdvanced(float amount)
    }
 }
 
-void NoteStrummer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteStrummer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/NoteStrummer.h
+++ b/Source/NoteStrummer.h
@@ -46,7 +46,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;

--- a/Source/NoteSustain.cpp
+++ b/Source/NoteSustain.cpp
@@ -109,7 +109,7 @@ void NoteSustain::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    }
 }
 
-void NoteSustain::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteSustain::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -45,7 +45,7 @@ public:
    void SetEnabled(bool enabled) override
    {
       mEnabled = enabled;
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(NextBufferTime());
    }
 
    void OnTransportAdvanced(float amount) override;

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -53,7 +53,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -45,7 +45,7 @@ public:
    void SetEnabled(bool enabled) override
    {
       mEnabled = enabled;
-      mNoteOutput.Flush(NextBufferTime());
+      mNoteOutput.Flush(NextBufferTime(false));
    }
 
    void OnTransportAdvanced(float amount) override;

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -290,10 +290,10 @@ bool NoteTable::MouseMoved(float x, float y)
    return false;
 }
 
-void NoteTable::CheckboxUpdated(Checkbox* checkbox)
+void NoteTable::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void NoteTable::GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue)
@@ -456,7 +456,7 @@ void NoteTable::OnGridButton(int x, int y, float velocity, IGridController* grid
    }
 }
 
-void NoteTable::ButtonClicked(ClickButton* button)
+void NoteTable::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mRandomizePitchButton)
    {
@@ -509,7 +509,7 @@ void NoteTable::RandomizePitches(bool fifths)
    }
 }
 
-void NoteTable::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteTable::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mNoteModeSelector)
    {
@@ -524,7 +524,7 @@ void NoteTable::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void NoteTable::IntSliderUpdated(IntSlider* slider, int oldVal)
+void NoteTable::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLengthSlider)
    {

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -81,11 +81,11 @@ public:
    void OnControllerPageSelected() override;
    void OnGridButton(int x, int y, float velocity, IGridController* grid) override;
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/NoteToggle.cpp
+++ b/Source/NoteToggle.cpp
@@ -75,7 +75,7 @@ void NoteToggle::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
    for (size_t i = 0; i < mTargets.size(); ++i)
    {
       if (mTargets[i] != nullptr)
-         mTargets[i]->SetValue(hasHeldNotes ? 1 : 0);
+         mTargets[i]->SetValue(hasHeldNotes ? 1 : 0, time);
    }
 }
 

--- a/Source/NoteTransformer.cpp
+++ b/Source/NoteTransformer.cpp
@@ -65,10 +65,10 @@ void NoteTransformer::DrawModule()
    }
 }
 
-void NoteTransformer::CheckboxUpdated(Checkbox* checkbox)
+void NoteTransformer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void NoteTransformer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/NoteTransformer.h
+++ b/Source/NoteTransformer.h
@@ -45,8 +45,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/NoteVibrato.cpp
+++ b/Source/NoteVibrato.cpp
@@ -89,19 +89,19 @@ void NoteVibrato::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void NoteVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void NoteVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mVibratoSlider)
       mModulation.GetPitchBend(-1)->SetLFO(mVibratoInterval, mVibratoAmount);
 }
 
-void NoteVibrato::DropdownUpdated(DropdownList* list, int oldVal)
+void NoteVibrato::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
       mModulation.GetPitchBend(-1)->SetLFO(mVibratoInterval, mVibratoAmount);
 }
 
-void NoteVibrato::CheckboxUpdated(Checkbox* checkbox)
+void NoteVibrato::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/NoteVibrato.h
+++ b/Source/NoteVibrato.h
@@ -51,9 +51,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/OSCOutput.cpp
+++ b/Source/OSCOutput.cpp
@@ -142,7 +142,7 @@ void OSCOutput::GetModuleDimensions(float& w, float& h)
    h = mHeight;
 }
 
-void OSCOutput::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void OSCOutput::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    char address[120];
    address[0] = 0;

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -58,7 +58,7 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/OutputChannel.h
+++ b/Source/OutputChannel.h
@@ -47,7 +47,7 @@ public:
    //IAudioSource
    void Process(double time) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PSMoveController.cpp
+++ b/Source/PSMoveController.cpp
@@ -79,21 +79,21 @@ void PSMoveController::Poll()
    {
       mPitch = ofClamp(mPitch + gyros.x / 50000, 0, 1);
       if (mPitchUIControl)
-         mPitchUIControl->SetFromMidiCC(mPitch, NextBufferTime(), false);
+         mPitchUIControl->SetFromMidiCC(mPitch, NextBufferTime(false), false);
       isButtonDown = true;
    }
    if (mMoveMgr.IsButtonDown(0, Btn_SQUARE))
    {
       mYaw = ofClamp(mYaw - gyros.z / 50000, 0, 1);
       if (mYawUIControl)
-         mYawUIControl->SetFromMidiCC(mYaw, NextBufferTime(), false);
+         mYawUIControl->SetFromMidiCC(mYaw, NextBufferTime(false), false);
       isButtonDown = true;
    }
    if (mMoveMgr.IsButtonDown(0, Btn_T))
    {
       mRoll = ofClamp(mRoll + gyros.y / 80000, 0, 1);
       if (mRollUIControl)
-         mRollUIControl->SetFromMidiCC(mRoll, NextBufferTime(), false);
+         mRollUIControl->SetFromMidiCC(mRoll, NextBufferTime(false), false);
       isButtonDown = true;
    }
    if (isButtonDown)
@@ -118,7 +118,7 @@ void PSMoveController::Poll()
    mMoveMgr.GetAccel(0, accel);
    mEnergy = ofClamp(accel.length() / 5000 - .8f, 0, 1);
    if (mEnergyUIControl)
-      mEnergyUIControl->SetFromMidiCC(mEnergy, NextBufferTime(), false);
+      mEnergyUIControl->SetFromMidiCC(mEnergy, NextBufferTime(false), false);
 }
 
 void PSMoveController::Exit()

--- a/Source/PSMoveController.cpp
+++ b/Source/PSMoveController.cpp
@@ -79,21 +79,21 @@ void PSMoveController::Poll()
    {
       mPitch = ofClamp(mPitch + gyros.x / 50000, 0, 1);
       if (mPitchUIControl)
-         mPitchUIControl->SetFromMidiCC(mPitch);
+         mPitchUIControl->SetFromMidiCC(mPitch, NextBufferTime(), false);
       isButtonDown = true;
    }
    if (mMoveMgr.IsButtonDown(0, Btn_SQUARE))
    {
       mYaw = ofClamp(mYaw - gyros.z / 50000, 0, 1);
       if (mYawUIControl)
-         mYawUIControl->SetFromMidiCC(mYaw);
+         mYawUIControl->SetFromMidiCC(mYaw, NextBufferTime(), false);
       isButtonDown = true;
    }
    if (mMoveMgr.IsButtonDown(0, Btn_T))
    {
       mRoll = ofClamp(mRoll + gyros.y / 80000, 0, 1);
       if (mRollUIControl)
-         mRollUIControl->SetFromMidiCC(mRoll);
+         mRollUIControl->SetFromMidiCC(mRoll, NextBufferTime(), false);
       isButtonDown = true;
    }
    if (isButtonDown)
@@ -118,7 +118,7 @@ void PSMoveController::Poll()
    mMoveMgr.GetAccel(0, accel);
    mEnergy = ofClamp(accel.length() / 5000 - .8f, 0, 1);
    if (mEnergyUIControl)
-      mEnergyUIControl->SetFromMidiCC(mEnergy);
+      mEnergyUIControl->SetFromMidiCC(mEnergy, NextBufferTime(), false);
 }
 
 void PSMoveController::Exit()
@@ -147,11 +147,11 @@ void PSMoveController::DrawModule()
    DrawTextNormal("b: " + ofToString(mMoveMgr.GetBattery(0), 1), 80, 14);
 }
 
-void PSMoveController::CheckboxUpdated(Checkbox* checkbox)
+void PSMoveController::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void PSMoveController::ButtonClicked(ClickButton* button)
+void PSMoveController::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mConnectButton)
       mMoveMgr.AddMoves();
@@ -189,7 +189,7 @@ void PSMoveController::OnTimeEvent(double time)
    }
 }
 
-void PSMoveController::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PSMoveController::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mOffsetSlider)
    {

--- a/Source/PSMoveController.h
+++ b/Source/PSMoveController.h
@@ -58,13 +58,13 @@ public:
    void SetRollControl(IUIControl* control) { mRollUIControl = control; }
    void SetEnergyControl(IUIControl* control) { mEnergyUIControl = control; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    //ITimeListener
    void OnTimeEvent(double time) override;
    //IFloatSliderLIstener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Panner.cpp
+++ b/Source/Panner.cpp
@@ -122,19 +122,19 @@ void Panner::DrawModule()
    GetRightPanGain(mPan);
 }
 
-void Panner::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Panner::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void Panner::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Panner::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void Panner::ButtonClicked(ClickButton* button)
+void Panner::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void Panner::CheckboxUpdated(Checkbox* checkbox)
+void Panner::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/Panner.h
+++ b/Source/Panner.h
@@ -52,10 +52,10 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PitchBender.cpp
+++ b/Source/PitchBender.cpp
@@ -78,13 +78,13 @@ void PitchBender::OnTransportAdvanced(float amount)
    ComputeSliders(0);
 }
 
-void PitchBender::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PitchBender::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mBendSlider)
       mModulation.GetPitchBend(-1)->SetValue(mBend);
 }
 
-void PitchBender::CheckboxUpdated(Checkbox* checkbox)
+void PitchBender::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    /*if (checkbox == &mBendingCheckbox)
    {

--- a/Source/PitchBender.h
+++ b/Source/PitchBender.h
@@ -51,8 +51,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PitchChorus.h
+++ b/Source/PitchChorus.h
@@ -51,8 +51,8 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
 
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}

--- a/Source/PitchDive.cpp
+++ b/Source/PitchDive.cpp
@@ -71,11 +71,11 @@ void PitchDive::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void PitchDive::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PitchDive::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void PitchDive::CheckboxUpdated(Checkbox* checkbox)
+void PitchDive::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/PitchDive.h
+++ b/Source/PitchDive.h
@@ -47,8 +47,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PitchPanner.h
+++ b/Source/PitchPanner.h
@@ -47,7 +47,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PitchRemap.cpp
+++ b/Source/PitchRemap.cpp
@@ -71,10 +71,10 @@ void PitchRemap::DrawModule()
    }
 }
 
-void PitchRemap::CheckboxUpdated(Checkbox* checkbox)
+void PitchRemap::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void PitchRemap::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -117,7 +117,7 @@ void PitchRemap::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
 void PitchRemap::TextEntryComplete(TextEntry* entry)
 {
    //TODO(Ryan) make this handle mappings changing while notes are input
-   mNoteOutput.Flush(gTime + gBufferSizeMs);
+   mNoteOutput.Flush(NextBufferTime());
 }
 
 void PitchRemap::LoadLayout(const ofxJSONElement& moduleInfo)

--- a/Source/PitchRemap.cpp
+++ b/Source/PitchRemap.cpp
@@ -117,7 +117,7 @@ void PitchRemap::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
 void PitchRemap::TextEntryComplete(TextEntry* entry)
 {
    //TODO(Ryan) make this handle mappings changing while notes are input
-   mNoteOutput.Flush(NextBufferTime());
+   mNoteOutput.Flush(NextBufferTime(false));
 }
 
 void PitchRemap::LoadLayout(const ofxJSONElement& moduleInfo)

--- a/Source/PitchRemap.h
+++ b/Source/PitchRemap.h
@@ -46,7 +46,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/PitchSetter.cpp
+++ b/Source/PitchSetter.cpp
@@ -50,16 +50,16 @@ void PitchSetter::DrawModule()
    mPitchSlider->Draw();
 }
 
-void PitchSetter::CheckboxUpdated(Checkbox* checkbox)
+void PitchSetter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void PitchSetter::IntSliderUpdated(IntSlider* slider, int oldVal)
+void PitchSetter::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mPitchSlider)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void PitchSetter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/PitchSetter.h
+++ b/Source/PitchSetter.h
@@ -46,8 +46,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PitchShiftEffect.cpp
+++ b/Source/PitchShiftEffect.cpp
@@ -104,17 +104,17 @@ float PitchShiftEffect::GetEffectAmount()
    return ofClamp(fabsf((mRatio - 1) * 10), 0, 1);
 }
 
-void PitchShiftEffect::IntSliderUpdated(IntSlider* slider, int oldVal)
+void PitchShiftEffect::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void PitchShiftEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PitchShiftEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mRatioSlider)
       mRatioSelection = -1;
 }
 
-void PitchShiftEffect::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void PitchShiftEffect::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mRatioSelector)
       mRatio = mRatioSelection / 10.0f;

--- a/Source/PitchShiftEffect.h
+++ b/Source/PitchShiftEffect.h
@@ -49,9 +49,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "pitchshift"; }
 
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/PitchToCV.h
+++ b/Source/PitchToCV.h
@@ -56,7 +56,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/PitchToSpeed.h
+++ b/Source/PitchToSpeed.h
@@ -57,7 +57,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -440,9 +440,9 @@ void PlaySequencer::OnGridButton(int x, int y, float velocity, IGridController* 
             mGrid->Clear();
 
          if (x >= 4 && y == 0)
-            ButtonClicked(mSavedPatterns[x - 4].mStoreButton, NextBufferTime());
+            ButtonClicked(mSavedPatterns[x - 4].mStoreButton, NextBufferTime(false));
          if (x >= 4 && y == 1)
-            ButtonClicked(mSavedPatterns[x - 4].mLoadButton, NextBufferTime());
+            ButtonClicked(mSavedPatterns[x - 4].mLoadButton, NextBufferTime(false));
 
          if (y >= 4)
          {

--- a/Source/PlaySequencer.cpp
+++ b/Source/PlaySequencer.cpp
@@ -177,7 +177,7 @@ bool PlaySequencer::MouseMoved(float x, float y)
    return false;
 }
 
-void PlaySequencer::CheckboxUpdated(Checkbox* checkbox)
+void PlaySequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    for (size_t i = 0; i < mLanes.size(); ++i)
    {
@@ -440,9 +440,9 @@ void PlaySequencer::OnGridButton(int x, int y, float velocity, IGridController* 
             mGrid->Clear();
 
          if (x >= 4 && y == 0)
-            ButtonClicked(mSavedPatterns[x - 4].mStoreButton);
+            ButtonClicked(mSavedPatterns[x - 4].mStoreButton, NextBufferTime());
          if (x >= 4 && y == 1)
-            ButtonClicked(mSavedPatterns[x - 4].mLoadButton);
+            ButtonClicked(mSavedPatterns[x - 4].mLoadButton, NextBufferTime());
 
          if (y >= 4)
          {
@@ -495,7 +495,7 @@ void PlaySequencer::OnGridButton(int x, int y, float velocity, IGridController* 
    }
 }
 
-void PlaySequencer::ButtonClicked(ClickButton* button)
+void PlaySequencer::ButtonClicked(ClickButton* button, double time)
 {
    for (size_t i = 0; i < mSavedPatterns.size(); ++i)
    {
@@ -523,7 +523,7 @@ void PlaySequencer::ButtonClicked(ClickButton* button)
    }
 }
 
-void PlaySequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void PlaySequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
       UpdateInterval();
@@ -531,7 +531,7 @@ void PlaySequencer::DropdownUpdated(DropdownList* list, int oldVal)
       UpdateNumMeasures(oldVal);
 }
 
-void PlaySequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void PlaySequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -69,15 +69,15 @@ public:
    void OnTimeEvent(double time) override;
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IIntSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PolyphonyMgr.h
+++ b/Source/PolyphonyMgr.h
@@ -54,6 +54,7 @@ struct VoiceInfo
    IMidiVoice* mVoice{ nullptr };
    double mTime{ 0 };
    bool mNoteOn{ false };
+   float mActivity{ 0 };
 };
 
 class PolyphonyMgr

--- a/Source/Polyrhythms.cpp
+++ b/Source/Polyrhythms.cpp
@@ -125,7 +125,7 @@ bool Polyrhythms::MouseMoved(float x, float y)
    return false;
 }
 
-void Polyrhythms::DropdownUpdated(DropdownList* list, int oldVal)
+void Polyrhythms::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    for (int i = 0; i < mRhythmLines.size(); ++i)
    {

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -82,7 +82,7 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -207,7 +207,7 @@ void Prefab::GetModuleDimensions(float& width, float& height)
    }
 }
 
-void Prefab::ButtonClicked(ClickButton* button)
+void Prefab::ButtonClicked(ClickButton* button, double time)
 {
    using namespace juce;
    if (button == mSaveButton)

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -49,7 +49,7 @@ public:
    void Poll() override;
    bool ShouldClipContents() override { return false; }
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -78,7 +78,7 @@ void Presets::Init()
 
    int defaultPreset = mModuleSaveData.GetInt("defaultpreset");
    if (defaultPreset != -1)
-      SetPreset(defaultPreset, false);
+      SetPreset(defaultPreset, gTime, false);
 
    TheTransport->AddAudioPoller(this);
 }
@@ -87,7 +87,7 @@ void Presets::Poll()
 {
    if (mQueuedPresetIndex != -1)
    {
-      SetPreset(mQueuedPresetIndex, false);
+      SetPreset(mQueuedPresetIndex, NextBufferTime(), false);
       mQueuedPresetIndex = -1;
    }
 
@@ -183,7 +183,7 @@ void Presets::OnClicked(float x, float y, bool right)
       if (GetKeyModifiers() == kModifier_Shift)
          Store(mCurrentPreset);
       else
-         SetPreset(mCurrentPreset, false);
+         SetPreset(mCurrentPreset, NextBufferTime(), false);
 
       UpdateGridValues();
    }
@@ -201,12 +201,12 @@ void Presets::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modul
    if (pitch < (int)mPresetCollection.size())
    {
       mCurrentPreset = pitch;
-      SetPreset(pitch, true);
+      SetPreset(pitch, time, true);
       UpdateGridValues();
    }
 }
 
-void Presets::SetPreset(int idx, bool queueForMainThread)
+void Presets::SetPreset(int idx, double time, bool queueForMainThread)
 {
    if (queueForMainThread && !mForceImmediateSet)
    {
@@ -241,7 +241,7 @@ void Presets::SetPreset(int idx, bool queueForMainThread)
              !i->mGridContents.empty() ||
              !i->mString.empty())
          {
-            control->SetValueDirect(i->mValue);
+            control->SetValueDirect(i->mValue, time);
 
             FloatSlider* slider = dynamic_cast<FloatSlider*>(control);
             if (slider)
@@ -305,7 +305,7 @@ void Presets::RandomizeControl(IUIControl* control)
       return;
    if (dynamic_cast<ClickButton*>(control) != nullptr)
       return;
-   control->SetFromMidiCC(ofRandom(1), true);
+   control->SetFromMidiCC(ofRandom(1), NextBufferTime(), true);
 }
 
 void Presets::OnTransportAdvanced(float amount)
@@ -318,7 +318,7 @@ void Presets::OnTransportAdvanced(float amount)
 
       for (auto& ramp : mBlendRamps)
       {
-         ramp.mUIControl->SetValueDirect(ramp.mRamp.Value(mBlendProgress));
+         ramp.mUIControl->SetValueDirect(ramp.mRamp.Value(mBlendProgress), gTime);
       }
 
       if (mBlendProgress >= mBlendTime)
@@ -409,7 +409,7 @@ namespace
    const int maxGridSide = 20;
 }
 
-void Presets::ButtonClicked(ClickButton* button)
+void Presets::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mRandomizeButton)
       RandomizeTargets();
@@ -429,11 +429,11 @@ void Presets::ButtonClicked(ClickButton* button)
    }
 }
 
-void Presets::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Presets::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mCurrentPresetSlider)
    {
-      SetPreset(mCurrentPreset, true);
+      SetPreset(mCurrentPreset, time, true);
       UpdateGridValues();
    }
 }

--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -87,7 +87,7 @@ void Presets::Poll()
 {
    if (mQueuedPresetIndex != -1)
    {
-      SetPreset(mQueuedPresetIndex, NextBufferTime(), false);
+      SetPreset(mQueuedPresetIndex, NextBufferTime(false), false);
       mQueuedPresetIndex = -1;
    }
 
@@ -183,7 +183,7 @@ void Presets::OnClicked(float x, float y, bool right)
       if (GetKeyModifiers() == kModifier_Shift)
          Store(mCurrentPreset);
       else
-         SetPreset(mCurrentPreset, NextBufferTime(), false);
+         SetPreset(mCurrentPreset, NextBufferTime(false), false);
 
       UpdateGridValues();
    }
@@ -305,7 +305,7 @@ void Presets::RandomizeControl(IUIControl* control)
       return;
    if (dynamic_cast<ClickButton*>(control) != nullptr)
       return;
-   control->SetFromMidiCC(ofRandom(1), NextBufferTime(), true);
+   control->SetFromMidiCC(ofRandom(1), NextBufferTime(false), true);
 }
 
 void Presets::OnTransportAdvanced(float amount)

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -58,10 +58,10 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
@@ -78,7 +78,7 @@ public:
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
 private:
-   void SetPreset(int idx, bool queueForMainThread);
+   void SetPreset(int idx, double time, bool queueForMainThread);
    void Store(int idx);
    void UpdateGridValues();
    void SetGridSize(float w, float h);

--- a/Source/Pressure.cpp
+++ b/Source/Pressure.cpp
@@ -75,13 +75,13 @@ void Pressure::OnTransportAdvanced(float amount)
    ComputeSliders(0);
 }
 
-void Pressure::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Pressure::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mPressureSlider)
       mModulation.GetPressure(-1)->SetValue(mPressure);
 }
 
-void Pressure::CheckboxUpdated(Checkbox* checkbox)
+void Pressure::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/Pressure.h
+++ b/Source/Pressure.h
@@ -51,8 +51,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PressureToCV.h
+++ b/Source/PressureToCV.h
@@ -56,7 +56,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/PressureToVibrato.cpp
+++ b/Source/PressureToVibrato.cpp
@@ -79,15 +79,15 @@ void PressureToVibrato::PlayNote(double time, int pitch, int velocity, int voice
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void PressureToVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PressureToVibrato::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void PressureToVibrato::DropdownUpdated(DropdownList* list, int oldVal)
+void PressureToVibrato::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void PressureToVibrato::CheckboxUpdated(Checkbox* checkbox)
+void PressureToVibrato::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/PressureToVibrato.h
+++ b/Source/PressureToVibrato.h
@@ -47,9 +47,9 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/Producer.cpp
+++ b/Source/Producer.cpp
@@ -178,7 +178,7 @@ void Producer::DropdownClicked(DropdownList* list)
 {
 }
 
-void Producer::DropdownUpdated(DropdownList* list, int oldVal)
+void Producer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -186,7 +186,7 @@ void Producer::UpdateSample()
 {
 }
 
-void Producer::ButtonClicked(ClickButton* button)
+void Producer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mWriteButton)
    {
@@ -395,7 +395,7 @@ void Producer::OnClicked(float x, float y, bool right)
    }
 }
 
-void Producer::CheckboxUpdated(Checkbox* checkbox)
+void Producer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mPlayCheckbox)
    {
@@ -410,7 +410,7 @@ void Producer::GetModuleDimensions(float& width, float& height)
    height = 430;
 }
 
-void Producer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Producer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mClipStartSlider)
    {
@@ -436,7 +436,7 @@ void Producer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void Producer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Producer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -65,16 +65,16 @@ public:
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
 
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IFloatSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IDropdownListener
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PulseButton.cpp
+++ b/Source/PulseButton.cpp
@@ -55,14 +55,14 @@ void PulseButton::DrawModule()
    mButton->Draw();
 }
 
-void PulseButton::ButtonClicked(ClickButton* button)
+void PulseButton::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mButton)
    {
-      double time = gTime + TheTransport->GetEventLookaheadMs();
+      double scheduledTime = gTime + TheTransport->GetEventLookaheadMs();
       if (mForceImmediate)
-         time = gTime;
-      DispatchPulse(GetPatchCableSource(), time, 1, 0);
+         scheduledTime = time;
+      DispatchPulse(GetPatchCableSource(), scheduledTime, 1, 0);
    }
 }
 

--- a/Source/PulseButton.h
+++ b/Source/PulseButton.h
@@ -41,7 +41,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PulseChance.cpp
+++ b/Source/PulseChance.cpp
@@ -129,7 +129,7 @@ void PulseChance::Reseed()
    mSeed = gRandom() % 10000;
 }
 
-void PulseChance::ButtonClicked(ClickButton* button)
+void PulseChance::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;

--- a/Source/PulseChance.h
+++ b/Source/PulseChance.h
@@ -46,9 +46,9 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PulseDelayer.cpp
+++ b/Source/PulseDelayer.cpp
@@ -74,7 +74,7 @@ void PulseDelayer::DrawModule()
    }
 }
 
-void PulseDelayer::CheckboxUpdated(Checkbox* checkbox)
+void PulseDelayer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (!mEnabled)
       mConsumeIndex = mAppendIndex; //effectively clears the queue
@@ -119,7 +119,7 @@ void PulseDelayer::OnPulse(double time, float velocity, int flags)
    }
 }
 
-void PulseDelayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PulseDelayer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 

--- a/Source/PulseDelayer.h
+++ b/Source/PulseDelayer.h
@@ -51,8 +51,8 @@ public:
 
    void OnTransportAdvanced(float amount) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/PulseHocket.cpp
+++ b/Source/PulseHocket.cpp
@@ -143,7 +143,7 @@ void PulseHocket::Reseed()
    mSeed = gRandom() % 10000;
 }
 
-void PulseHocket::ButtonClicked(ClickButton* button)
+void PulseHocket::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;

--- a/Source/PulseHocket.h
+++ b/Source/PulseHocket.h
@@ -47,9 +47,9 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -121,7 +121,7 @@ void PulseSequence::DrawModule()
    }
 }
 
-void PulseSequence::CheckboxUpdated(Checkbox* checkbox)
+void PulseSequence::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -218,15 +218,15 @@ bool PulseSequence::MouseScrolled(float x, float y, float scrollX, float scrollY
    return false;
 }
 
-void PulseSequence::ButtonClicked(ClickButton* button)
+void PulseSequence::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mAdvanceBackwardButton)
-      Step(1, 0, kPulseFlag_Backward);
+      Step(time, 0, kPulseFlag_Backward);
    if (button == mAdvanceForwardButton)
-      Step(1, 0, 0);
+      Step(time, 0, 0);
 }
 
-void PulseSequence::DropdownUpdated(DropdownList* list, int oldVal)
+void PulseSequence::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -236,11 +236,11 @@ void PulseSequence::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void PulseSequence::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PulseSequence::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void PulseSequence::IntSliderUpdated(IntSlider* slider, int oldVal)
+void PulseSequence::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLengthSlider)
    {

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -75,11 +75,11 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;

--- a/Source/PulseTrain.cpp
+++ b/Source/PulseTrain.cpp
@@ -114,7 +114,7 @@ void PulseTrain::DrawModule()
    }
 }
 
-void PulseTrain::CheckboxUpdated(Checkbox* checkbox)
+void PulseTrain::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -202,7 +202,7 @@ bool PulseTrain::MouseScrolled(float x, float y, float scrollX, float scrollY, b
    return false;
 }
 
-void PulseTrain::DropdownUpdated(DropdownList* list, int oldVal)
+void PulseTrain::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -212,11 +212,11 @@ void PulseTrain::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void PulseTrain::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void PulseTrain::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void PulseTrain::IntSliderUpdated(IntSlider* slider, int oldVal)
+void PulseTrain::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLengthSlider)
    {

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -68,10 +68,10 @@ public:
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;

--- a/Source/Pulser.cpp
+++ b/Source/Pulser.cpp
@@ -110,7 +110,7 @@ void Pulser::DrawModule()
    mCustomDivisorSlider->Draw();
 }
 
-void Pulser::CheckboxUpdated(Checkbox* checkbox)
+void Pulser::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {
@@ -198,7 +198,7 @@ void Pulser::GetModuleDimensions(float& width, float& height)
       height += 18;
 }
 
-void Pulser::ButtonClicked(ClickButton* button)
+void Pulser::ButtonClicked(ClickButton* button, double time)
 {
 }
 
@@ -221,7 +221,7 @@ float Pulser::GetOffset()
    return (-mOffset / TheTransport->CountInStandardMeasure(mInterval));
 }
 
-void Pulser::DropdownUpdated(DropdownList* list, int oldVal)
+void Pulser::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -258,7 +258,7 @@ void Pulser::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void Pulser::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Pulser::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mOffsetSlider)
    {
@@ -274,7 +274,7 @@ void Pulser::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void Pulser::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Pulser::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mCustomDivisorSlider)
       mTransportListenerInfo->mCustomDivisor = mCustomDivisor;

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -57,11 +57,11 @@ public:
    //ITimeListener
    void OnTimeEvent(double time) override;
 
-   void ButtonClicked(ClickButton* button) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/Pumper.cpp
+++ b/Source/Pumper.cpp
@@ -158,11 +158,11 @@ float Pumper::GetEffectAmount()
    return mAmount;
 }
 
-void Pumper::DropdownUpdated(DropdownList* list, int oldVal)
+void Pumper::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void Pumper::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Pumper::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mAmountSlider)
    {

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -50,9 +50,9 @@ public:
    float GetEffectAmount() override;
    std::string GetType() override { return "pumper"; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -819,7 +819,7 @@ void Push2Control::Poll()
             IDrawableModule* module = mSpawnLists.GetDropdowns()[i]->Spawn(mSpawnLists.GetDropdowns()[i]->GetList()->GetValue());
             ofRectangle rect = module->GetRect();
             module->SetPosition(newModulePos.x, newModulePos.y);
-            mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1);
+            mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
             mScreenDisplayMode = ScreenDisplayMode::kNormal;
             SetDisplayModule(module, true);
             break;
@@ -1037,7 +1037,7 @@ void Push2Control::OnMidiNote(MidiNote& note)
             for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
             {
                if (i != note.mPitch)
-                  mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1);
+                  mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
             }
          }
       }
@@ -1055,7 +1055,7 @@ void Push2Control::OnMidiNote(MidiNote& note)
             gridIndex = gridX + (7 - gridY) * 8;
             if (gridIndex < list->GetNumValues())
             {
-               list->SetValueDirect(gridIndex);
+               list->SetValueDirect(gridIndex, gTime);
                mSelectedGridSpawnListIndex = -1;
             }
          }
@@ -1123,7 +1123,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
          float currentNormalized = mSliderControls[controlIndex]->GetMidiValue();
          float increment = control.mValue < 64 ? control.mValue : control.mValue - 128;
          increment *= .005f;
-         mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment);
+         mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment, NextBufferTime(), false);
       }
    }
    else if (control.mControl >= kAboveScreenButtonRow && control.mControl < kAboveScreenButtonRow + 8) //buttons below encoders
@@ -1153,7 +1153,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
                {
                   float current = mButtonControls[controlIndex]->GetMidiValue();
                   float newValue = current > 0 ? 0 : 1;
-                  mButtonControls[controlIndex]->SetFromMidiCC(newValue);
+                  mButtonControls[controlIndex]->SetFromMidiCC(newValue, NextBufferTime(), false);
                }
             }
             else
@@ -1174,7 +1174,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
                mSelectedGridSpawnListIndex = -1;
 
             for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
-               mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1);
+               mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
          }
       }
    }
@@ -1244,7 +1244,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
             mScreenDisplayMode = ScreenDisplayMode::kAddModule;
             mGridControlModule = nullptr;
             for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
-               mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1);
+               mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
             mSelectedGridSpawnListIndex = -1;
          }
 

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -1123,7 +1123,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
          float currentNormalized = mSliderControls[controlIndex]->GetMidiValue();
          float increment = control.mValue < 64 ? control.mValue : control.mValue - 128;
          increment *= .005f;
-         mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment, NextBufferTime(), false);
+         mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment, NextBufferTime(false), false);
       }
    }
    else if (control.mControl >= kAboveScreenButtonRow && control.mControl < kAboveScreenButtonRow + 8) //buttons below encoders
@@ -1153,7 +1153,7 @@ void Push2Control::OnMidiControl(MidiControl& control)
                {
                   float current = mButtonControls[controlIndex]->GetMidiValue();
                   float newValue = current > 0 ? 0 : 1;
-                  mButtonControls[controlIndex]->SetFromMidiCC(newValue, NextBufferTime(), false);
+                  mButtonControls[controlIndex]->SetFromMidiCC(newValue, NextBufferTime(false), false);
                }
             }
             else

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -55,7 +55,7 @@ public:
    void OnMidiControl(MidiControl& control) override;
    void OnMidiPitchBend(MidiPitchBend& pitchBend) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -220,9 +220,9 @@ void RadioButton::OnClicked(float x, float y, bool right)
       return;
 
    if (mDirection == kRadioVertical)
-      SetIndex(y / radioSpacing);
+      SetIndex(y / radioSpacing, NextBufferTime());
    else //kRadioHorizontal
-      SetIndex(int(x / mElementWidth));
+      SetIndex(int(x / mElementWidth), NextBufferTime());
 }
 
 ofVec2f RadioButton::GetOptionPosition(int optionIndex)
@@ -235,7 +235,7 @@ ofVec2f RadioButton::GetOptionPosition(int optionIndex)
       return ofVec2f(x + float(mWidth) / GetNumValues() * (optionIndex + .5f), y + mHeight);
 }
 
-void RadioButton::SetIndex(int i)
+void RadioButton::SetIndex(int i, double time)
 {
    if (mElements.empty())
       return;
@@ -249,15 +249,15 @@ void RadioButton::SetIndex(int i)
    if (oldVal != *mVar)
    {
       CalcSliderVal();
-      mOwner->RadioButtonUpdated(this, oldVal);
+      mOwner->RadioButtonUpdated(this, oldVal, time);
       gControlTactileFeedback = 1;
    }
 }
 
-void RadioButton::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void RadioButton::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
    slider = ofClamp(slider, 0, 1);
-   SetIndex(int(slider * mElements.size()));
+   SetIndex(int(slider * mElements.size()), time);
    mSliderVal = slider;
    mLastSetValue = *mVar;
 }
@@ -272,14 +272,14 @@ float RadioButton::GetValueForMidiCC(float slider) const
    return mElements[index].mValue;
 }
 
-void RadioButton::SetValue(float value)
+void RadioButton::SetValue(float value, double time)
 {
    if (mMultiSelect)
       value = *mVar ^ (1 << (int)value);
-   SetValueDirect(value);
+   SetValueDirect(value, time);
 }
 
-void RadioButton::SetValueDirect(float value)
+void RadioButton::SetValueDirect(float value, double time)
 {
    int oldVal = *mVar;
 
@@ -287,7 +287,7 @@ void RadioButton::SetValueDirect(float value)
    if (oldVal != *mVar)
    {
       CalcSliderVal();
-      mOwner->RadioButtonUpdated(this, oldVal);
+      mOwner->RadioButtonUpdated(this, oldVal, time);
       gControlTactileFeedback = 1;
    }
 }
@@ -339,7 +339,7 @@ void RadioButton::Increment(float amount)
       }
    }
 
-   SetIndex(current + (int)amount);
+   SetIndex(current + (int)amount, NextBufferTime());
 }
 
 EnumMap RadioButton::GetEnumMap()
@@ -389,5 +389,5 @@ void RadioButton::LoadState(FileStreamIn& in, bool shouldSetValue)
    float var;
    in >> var;
    if (shouldSetValue)
-      SetValueDirect(var);
+      SetValueDirect(var, gTime);
 }

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -220,9 +220,9 @@ void RadioButton::OnClicked(float x, float y, bool right)
       return;
 
    if (mDirection == kRadioVertical)
-      SetIndex(y / radioSpacing, NextBufferTime());
+      SetIndex(y / radioSpacing, NextBufferTime(false));
    else //kRadioHorizontal
-      SetIndex(int(x / mElementWidth), NextBufferTime());
+      SetIndex(int(x / mElementWidth), NextBufferTime(false));
 }
 
 ofVec2f RadioButton::GetOptionPosition(int optionIndex)
@@ -339,7 +339,7 @@ void RadioButton::Increment(float amount)
       }
    }
 
-   SetIndex(current + (int)amount, NextBufferTime());
+   SetIndex(current + (int)amount, NextBufferTime(false));
 }
 
 EnumMap RadioButton::GetEnumMap()

--- a/Source/RadioButton.h
+++ b/Source/RadioButton.h
@@ -46,7 +46,7 @@ class IRadioButtonListener
 {
 public:
    virtual ~IRadioButtonListener() {}
-   virtual void RadioButtonUpdated(RadioButton* radio, int oldVal) = 0;
+   virtual void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) = 0;
 };
 
 class RadioButton : public IUIControl
@@ -68,10 +68,10 @@ public:
    static int GetSpacing();
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value) override;
-   void SetValueDirect(float value) override;
+   void SetValue(float value, double time) override;
+   void SetValueDirect(float value, double time) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
@@ -95,7 +95,7 @@ protected:
    ~RadioButton(); //protected so that it can't be created on the stack
 
 private:
-   void SetIndex(int i);
+   void SetIndex(int i, double time);
    void CalcSliderVal();
    void UpdateDimensions();
 

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -117,7 +117,7 @@ void RadioSequencer::UpdateGridLights()
          {
             if (mGrid->GetVal(col, row) == 1)
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Bright);
-            else if (col == mGrid->GetHighlightCol(gTime + gBufferSizeMs + TheTransport->GetEventLookaheadMs()))
+            else if (col == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()))
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Dim);
             else
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColorOff);
@@ -175,13 +175,13 @@ void RadioSequencer::Step(double time, int pulseFlags)
             if (mGrid->GetVal(mStep, i) > 0)
                controlsToEnable.push_back(uicontrol);
             else
-               uicontrol->SetValue(0);
+               uicontrol->SetValue(0, time);
          }
       }
    }
 
    for (auto* control : controlsToEnable)
-      control->SetValue(1);
+      control->SetValue(1, time);
 
    UpdateGridLights();
 }
@@ -281,7 +281,7 @@ void RadioSequencer::SyncControlCablesToGrid()
    }
 }
 
-void RadioSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void RadioSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -291,7 +291,7 @@ void RadioSequencer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void RadioSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void RadioSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLengthSlider)
    {

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -117,7 +117,7 @@ void RadioSequencer::UpdateGridLights()
          {
             if (mGrid->GetVal(col, row) == 1)
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Bright);
-            else if (col == mGrid->GetHighlightCol(NextBufferTime() + TheTransport->GetEventLookaheadMs()))
+            else if (col == mGrid->GetHighlightCol(NextBufferTime(true)))
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Dim);
             else
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColorOff);

--- a/Source/RadioSequencer.cpp
+++ b/Source/RadioSequencer.cpp
@@ -90,6 +90,7 @@ void RadioSequencer::CreateUIControls()
 
 void RadioSequencer::Poll()
 {
+   UpdateGridLights();
 }
 
 void RadioSequencer::OnControllerPageSelected()
@@ -109,6 +110,11 @@ void RadioSequencer::OnGridButton(int x, int y, float velocity, IGridController*
 
 void RadioSequencer::UpdateGridLights()
 {
+   bool blinkOn = true;
+   TransportListenerInfo transportInfo(this, kInterval_16n, OffsetInfo(0, false), false);
+   if (TheTransport->GetQuantized(gTime, &transportInfo) % 2 == 1)
+      blinkOn = false;
+
    if (mGridControlTarget->GetGridController())
    {
       for (int row = 0; row < mGrid->GetRows(); ++row)
@@ -118,7 +124,7 @@ void RadioSequencer::UpdateGridLights()
             if (mGrid->GetVal(col, row) == 1)
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Bright);
             else if (col == mGrid->GetHighlightCol(NextBufferTime(true)))
-               mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColor1Dim);
+               mGridControlTarget->GetGridController()->SetLight(col, row, blinkOn ? GridColor::kGridColor1Dim : GridColor::kGridColorOff);
             else
                mGridControlTarget->GetGridController()->SetLight(col, row, GridColor::kGridColorOff);
          }

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -80,9 +80,9 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override {}
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/Ramper.cpp
+++ b/Source/Ramper.cpp
@@ -94,7 +94,7 @@ void Ramper::OnTransportAdvanced(float amount)
          for (auto* control : mUIControls)
          {
             if (control != nullptr)
-               control->SetValue(ofLerp(mStartValue, mTargetValue, progress));
+               control->SetValue(ofLerp(mStartValue, mTargetValue, progress), gTime);
          }
       }
       else if (progress >= 1)
@@ -166,10 +166,10 @@ void Ramper::OnPulse(double time, float velocity, int flags)
       Go(time);
 }
 
-void Ramper::ButtonClicked(ClickButton* button)
+void Ramper::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mTriggerButton)
-      Go(gTime);
+      Go(time);
 }
 
 void Ramper::GetModuleDimensions(float& width, float& height)

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -56,9 +56,9 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override {}
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/RandomNoteGenerator.cpp
+++ b/Source/RandomNoteGenerator.cpp
@@ -107,13 +107,13 @@ void RandomNoteGenerator::OnTimeEvent(double time)
    }
 }
 
-void RandomNoteGenerator::CheckboxUpdated(Checkbox* checkbox)
+void RandomNoteGenerator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void RandomNoteGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void RandomNoteGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mOffsetSlider)
    {
@@ -126,13 +126,13 @@ void RandomNoteGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void RandomNoteGenerator::IntSliderUpdated(IntSlider* slider, int oldVal)
+void RandomNoteGenerator::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mPitchSlider)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void RandomNoteGenerator::DropdownUpdated(DropdownList* list, int oldVal)
+void RandomNoteGenerator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {

--- a/Source/RandomNoteGenerator.h
+++ b/Source/RandomNoteGenerator.h
@@ -49,10 +49,10 @@ public:
    //ITimeListener
    void OnTimeEvent(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Razor.cpp
+++ b/Source/Razor.cpp
@@ -391,7 +391,7 @@ void Razor::SetEnabled(bool enabled)
    mEnabled = enabled;
 }
 
-void Razor::CheckboxUpdated(Checkbox* checkbox)
+void Razor::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
       SetEnabled(mEnabled);
@@ -402,11 +402,11 @@ void Razor::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void Razor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Razor::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void Razor::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Razor::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumPartialsSlider)
    {
@@ -414,7 +414,7 @@ void Razor::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void Razor::ButtonClicked(ClickButton* button)
+void Razor::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetDetuneButton)
    {

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -66,10 +66,10 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Rewriter.cpp
+++ b/Source/Rewriter.cpp
@@ -155,30 +155,30 @@ void Rewriter::DrawModule()
    }
 }
 
-void Rewriter::ButtonClicked(ClickButton* button)
+void Rewriter::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mStartRecordTimeButton)
    {
       if (mStartRecordTime == -1)
-         mStartRecordTime = gTime + gBufferSizeMs;
+         mStartRecordTime = time;
       else
          mStartRecordTime = -1;
    }
    if (button == mRewriteButton)
-      Go();
+      Go(time);
 }
 
-void Rewriter::CheckboxUpdated(Checkbox* checkbox)
+void Rewriter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void Rewriter::Go()
+void Rewriter::Go(double time)
 {
    if (mConnectedLooper)
    {
       if (mStartRecordTime != -1)
       {
-         float recordedMs = gTime + gBufferSizeMs - mStartRecordTime;
+         float recordedMs = time - mStartRecordTime;
          float numBarsCurrentTempo = recordedMs / TheTransport->MsPerBar();
          int numBars = int(numBarsCurrentTempo + .5f);
          numBars = MAX(1, int(Pow2(floor(log2(numBars))))); //find closest power of 2

--- a/Source/Rewriter.h
+++ b/Source/Rewriter.h
@@ -46,7 +46,7 @@ public:
 
    void CreateUIControls() override;
 
-   void Go();
+   void Go(double time);
 
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
@@ -54,9 +54,9 @@ public:
    void Process(double time) override;
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/RingModulator.cpp
+++ b/Source/RingModulator.cpp
@@ -137,15 +137,15 @@ void RingModulator::PlayNote(double time, int pitch, int velocity, int voiceIdx,
    }
 }
 
-void RingModulator::ButtonClicked(ClickButton* button)
+void RingModulator::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void RingModulator::CheckboxUpdated(Checkbox* checkbox)
+void RingModulator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void RingModulator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void RingModulator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mFreqSlider)
    {

--- a/Source/RingModulator.h
+++ b/Source/RingModulator.h
@@ -56,11 +56,11 @@ public:
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -84,7 +84,7 @@ void SampleBrowser::DrawModule()
       DrawTextNormal(ofToString(mCurrentPage + 1) + "/" + ofToString(numPages), 40, mBackButton->GetPosition(true).y + 12);
 }
 
-void SampleBrowser::ButtonClicked(ClickButton* button)
+void SampleBrowser::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mBackButton)
       ShowPage(mCurrentPage - 1);

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -42,7 +42,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SampleCanvas.cpp
+++ b/Source/SampleCanvas.cpp
@@ -245,15 +245,15 @@ void SampleCanvas::UpdateNumColumns()
       mCanvas->SetMajorColumnInterval(TheTransport->CountInStandardMeasure(mInterval) / 4);
 }
 
-void SampleCanvas::CheckboxUpdated(Checkbox* checkbox)
+void SampleCanvas::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void SampleCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SampleCanvas::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SampleCanvas::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SampleCanvas::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumMeasuresSlider)
    {
@@ -261,7 +261,7 @@ void SampleCanvas::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void SampleCanvas::DropdownUpdated(DropdownList* list, int oldVal)
+void SampleCanvas::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -63,10 +63,10 @@ public:
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -192,7 +192,7 @@ void SampleCapturer::DrawModule()
    mDeleteButton->Draw();
 }
 
-void SampleCapturer::ButtonClicked(ClickButton* button)
+void SampleCapturer::ButtonClicked(ClickButton* button, double time)
 {
    using namespace juce;
    if (button == mPlayButton)

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -46,8 +46,8 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SampleFinder.cpp
+++ b/Source/SampleFinder.cpp
@@ -240,7 +240,7 @@ void SampleFinder::DropdownClicked(DropdownList* list)
 {
 }
 
-void SampleFinder::DropdownUpdated(DropdownList* list, int oldVal)
+void SampleFinder::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -248,7 +248,7 @@ void SampleFinder::UpdateSample()
 {
 }
 
-void SampleFinder::ButtonClicked(ClickButton* button)
+void SampleFinder::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mWriteButton)
    {
@@ -300,7 +300,7 @@ void SampleFinder::UpdateZoomExtents()
    mClipEndSlider->SetExtents(mZoomStart, mZoomEnd);
 }
 
-void SampleFinder::CheckboxUpdated(Checkbox* checkbox)
+void SampleFinder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mPlayCheckbox)
    {
@@ -323,11 +323,11 @@ void SampleFinder::GetModuleDimensions(float& width, float& height)
    }
 }
 
-void SampleFinder::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SampleFinder::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SampleFinder::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SampleFinder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mClipStartSlider)
    {

--- a/Source/SampleFinder.h
+++ b/Source/SampleFinder.h
@@ -63,12 +63,12 @@ public:
 
    bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -420,7 +420,7 @@ void SamplePlayer::PlayCuePoint(double time, int index, int velocity, float spee
    {
       float startSeconds, lengthSeconds, speed;
       GetPlayInfoForPitch(index, startSeconds, lengthSeconds, speed, mStopOnNoteOff);
-      mSample->SetPlayPosition(((gTime - time) / 1000 + startSeconds + startOffsetSeconds) * gSampleRate * mSample->GetSampleRateRatio());
+      mSample->SetPlayPosition((startSeconds + startOffsetSeconds) * gSampleRate * mSample->GetSampleRateRatio());
       mCuePointSpeed = speed * speedMult;
       mPlay = true;
       mAdsr.Clear();
@@ -435,13 +435,13 @@ void SamplePlayer::DropdownClicked(DropdownList* list)
 {
 }
 
-void SamplePlayer::DropdownUpdated(DropdownList* list, int oldVal)
+void SamplePlayer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mCuePointSelector)
       UpdateActiveCuePoint();
 }
 
-void SamplePlayer::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void SamplePlayer::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
@@ -519,7 +519,7 @@ void SamplePlayer::UpdateSample(Sample* sample, bool ownsSample)
    mIsLoadingSample = true;
 }
 
-void SamplePlayer::ButtonClicked(ClickButton* button)
+void SamplePlayer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPlayButton && mSample != nullptr)
    {
@@ -529,7 +529,7 @@ void SamplePlayer::ButtonClicked(ClickButton* button)
          mStopOnNoteOff = false;
          mPlay = true;
          mAdsr.Clear();
-         mAdsr.Start(gTime + gBufferSize * gInvSampleRateMs, 1);
+         mAdsr.Start(time * gInvSampleRateMs, 1);
       }
    }
    if (button == mPauseButton && mSample != nullptr)
@@ -589,7 +589,7 @@ void SamplePlayer::ButtonClicked(ClickButton* button)
    }
 
    if (button == mPlayCurrentCuePointButton)
-      PlayCuePoint(gTime, mActiveCuePointIndex, 127, 1, 0);
+      PlayCuePoint(time, mActiveCuePointIndex, 127, 1, 0);
 
    if (button == mAutoSlice4)
       AutoSlice(4);
@@ -601,7 +601,7 @@ void SamplePlayer::ButtonClicked(ClickButton* button)
       AutoSlice(32);
 
    if (button == mPlayHoveredClipButton)
-      PlayCuePoint(gTime, mHoveredCuePointIndex, 127, 1, 0);
+      PlayCuePoint(time, mHoveredCuePointIndex, 127, 1, 0);
    if (button == mGrabHoveredClipButton)
    {
       ChannelBuffer* data = GetCueSampleData(mHoveredCuePointIndex);
@@ -791,7 +791,7 @@ void SamplePlayer::OnClicked(float x, float y, bool right)
       mStopOnNoteOff = false;
       mPlay = true;
       mAdsr.Clear();
-      mAdsr.Start(gTime + gBufferSizeMs, 1);
+      mAdsr.Start(NextBufferTime(), 1);
       mSample->SetPlayPosition(int(GetPlayPositionForMouse(x)));
       mScrubbingSample = true;
 
@@ -841,7 +841,7 @@ bool SamplePlayer::MouseMoved(float x, float y)
       mSwitchAndRamp.StartSwitch();
       mSample->SetPlayPosition(int(GetPlayPositionForMouse(x)));
       mAdsr.Clear();
-      mAdsr.Start(gTime + gBufferSizeMs, 1);
+      mAdsr.Start(NextBufferTime(), 1);
 
       if (mSetCuePoint)
          SetCuePointForX(x);
@@ -1292,7 +1292,7 @@ bool SamplePlayer::MouseScrolled(float x, float y, float scrollX, float scrollY,
    return false;
 }
 
-void SamplePlayer::CheckboxUpdated(Checkbox* checkbox)
+void SamplePlayer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mLoopCheckbox)
    {
@@ -1370,11 +1370,11 @@ void SamplePlayer::GetModuleDimensions(float& width, float& height)
    height = mHeight;
 }
 
-void SamplePlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SamplePlayer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SamplePlayer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SamplePlayer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -791,7 +791,7 @@ void SamplePlayer::OnClicked(float x, float y, bool right)
       mStopOnNoteOff = false;
       mPlay = true;
       mAdsr.Clear();
-      mAdsr.Start(NextBufferTime(), 1);
+      mAdsr.Start(NextBufferTime(false), 1);
       mSample->SetPlayPosition(int(GetPlayPositionForMouse(x)));
       mScrubbingSample = true;
 
@@ -841,7 +841,7 @@ bool SamplePlayer::MouseMoved(float x, float y)
       mSwitchAndRamp.StartSwitch();
       mSample->SetPlayPosition(int(GetPlayPositionForMouse(x)));
       mAdsr.Clear();
-      mAdsr.Start(NextBufferTime(), 1);
+      mAdsr.Start(NextBufferTime(false), 1);
 
       if (mSetCuePoint)
          SetCuePointForX(x);

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -84,14 +84,14 @@ public:
    void oscMessageReceived(const juce::OSCMessage& msg) override;
    void oscBundleReceived(const juce::OSCBundle& bundle) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -276,21 +276,21 @@ void Sampler::SetUpFromSaveData()
 }
 
 
-void Sampler::DropdownUpdated(DropdownList* list, int oldVal)
+void Sampler::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void Sampler::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Sampler::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mVolSlider)
       mADSRDisplay->SetVol(mVoiceParams.mVol);
 }
 
-void Sampler::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Sampler::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void Sampler::CheckboxUpdated(Checkbox* checkbox)
+void Sampler::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mRecordCheckbox)
    {

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -70,10 +70,10 @@ public:
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -425,19 +425,19 @@ void SamplerGrid::SetUpFromSaveData()
    mLastColumnIsGroup = mModuleSaveData.GetBool("last_column_is_group");
 }
 
-void SamplerGrid::DropdownUpdated(DropdownList* list, int oldVal)
+void SamplerGrid::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void SamplerGrid::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SamplerGrid::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SamplerGrid::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SamplerGrid::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void SamplerGrid::CheckboxUpdated(Checkbox* checkbox)
+void SamplerGrid::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -78,10 +78,10 @@ public:
    void SampleDropped(int x, int y, Sample* sample) override;
    bool CanDropSample() const override { return true; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -681,7 +681,7 @@ float Scale::GetTuningTableRatio(int semitonesFromCenter)
    return mTuningTable[CLAMP(128 + semitonesFromCenter, 0, 255)];
 }
 
-void Scale::DropdownUpdated(DropdownList* list, int oldVal)
+void Scale::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mRootSelector)
       SetRoot(mScale.mScaleRoot, true);
@@ -691,15 +691,15 @@ void Scale::DropdownUpdated(DropdownList* list, int oldVal)
       UpdateTuningTable();
 }
 
-void Scale::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Scale::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void Scale::IntSliderUpdated(IntSlider* slider, int oldVal)
+void Scale::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void Scale::CheckboxUpdated(Checkbox* checkbox)
+void Scale::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -715,7 +715,7 @@ void Scale::TextEntryComplete(TextEntry* entry)
       UpdateTuningTable();
 }
 
-void Scale::ButtonClicked(ClickButton* button)
+void Scale::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mLoadSCLButton || button == mLoadKBMButton)
    {

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -128,13 +128,13 @@ public:
 
    const ChordDatabase& GetChordDatabase() const { return mChordDatabase; }
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/ScaleDegree.cpp
+++ b/Source/ScaleDegree.cpp
@@ -124,7 +124,7 @@ void ScaleDegree::DropdownUpdated(DropdownList* list, int oldVal, double time)
       {
          if (mInputNotes[pitch].mOn)
          {
-            PlayNoteOutput(time + .01, mInputNotes[pitch].mOutputPitch, 0, mInputNotes[pitch].mVoiceIdx, ModulationParameters());
+            PlayNoteOutput(time, mInputNotes[pitch].mOutputPitch, 0, mInputNotes[pitch].mVoiceIdx, ModulationParameters());
             mInputNotes[pitch].mOutputPitch = TransformPitch(pitch);
             PlayNoteOutput(time, mInputNotes[pitch].mOutputPitch, mInputNotes[pitch].mVelocity, mInputNotes[pitch].mVoiceIdx, ModulationParameters());
          }

--- a/Source/ScaleDegree.cpp
+++ b/Source/ScaleDegree.cpp
@@ -69,10 +69,10 @@ void ScaleDegree::DrawModule()
    mDiatonicCheckbox->Draw();
 }
 
-void ScaleDegree::CheckboxUpdated(Checkbox* checkbox)
+void ScaleDegree::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void ScaleDegree::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -116,11 +116,10 @@ int ScaleDegree::TransformPitch(int pitch)
    }
 }
 
-void ScaleDegree::DropdownUpdated(DropdownList* slider, int oldVal)
+void ScaleDegree::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
-   if (slider == mScaleDegreeSelector && mEnabled && mRetrigger)
+   if (list == mScaleDegreeSelector && mEnabled && mRetrigger)
    {
-      double time = gTime + gBufferSizeMs;
       for (int pitch = 0; pitch < 128; ++pitch)
       {
          if (mInputNotes[pitch].mOn)

--- a/Source/ScaleDegree.h
+++ b/Source/ScaleDegree.h
@@ -45,8 +45,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/ScaleDetect.cpp
+++ b/Source/ScaleDetect.cpp
@@ -118,7 +118,7 @@ bool ScaleDetect::ScaleSatisfied(int root, std::string type)
    return true;
 }
 
-void ScaleDetect::ButtonClicked(ClickButton* button)
+void ScaleDetect::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetButton)
    {
@@ -129,7 +129,7 @@ void ScaleDetect::ButtonClicked(ClickButton* button)
    }
 }
 
-void ScaleDetect::DropdownUpdated(DropdownList* list, int oldVal)
+void ScaleDetect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mMatchesDropdown)
    {

--- a/Source/ScaleDetect.h
+++ b/Source/ScaleDetect.h
@@ -55,8 +55,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -575,7 +575,7 @@ void ScriptModule::Poll()
       if (mScheduledUIControlValue[i].time != -1 &&
           time + TheTransport->GetEventLookaheadMs() > mScheduledUIControlValue[i].time)
       {
-         AdjustUIControl(mScheduledUIControlValue[i].control, mScheduledUIControlValue[i].value, mScheduledUIControlValue[i].lineNum);
+         AdjustUIControl(mScheduledUIControlValue[i].control, mScheduledUIControlValue[i].value, mScheduledUIControlValue[i].time, mScheduledUIControlValue[i].lineNum);
          mScheduledUIControlValue[i].time = -1;
       }
    }
@@ -784,9 +784,9 @@ IUIControl* ScriptModule::GetUIControl(std::string path)
    return control;
 }
 
-void ScriptModule::AdjustUIControl(IUIControl* control, float value, int lineNum)
+void ScriptModule::AdjustUIControl(IUIControl* control, float value, double time, int lineNum)
 {
-   control->SetValue(value);
+   control->SetValue(value, time);
 
    mUIControlTracker.AddEvent(lineNum);
 
@@ -898,7 +898,7 @@ void ScriptModule::MidiReceived(MidiMessageType messageType, int control, float 
    mMidiMessageQueueMutex.unlock();
 }
 
-void ScriptModule::ButtonClicked(ClickButton* button)
+void ScriptModule::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPythonInstalledConfirmButton)
       InitializePythonIfNecessary();
@@ -906,7 +906,7 @@ void ScriptModule::ButtonClicked(ClickButton* button)
    if (button == mRunButton)
    {
       mCodeEntry->Publish();
-      RunScript(gTime);
+      RunScript(time);
    }
 
    if (button == mStopButton)
@@ -1017,7 +1017,7 @@ void ScriptModule::DropdownClicked(DropdownList* list)
       RefreshScriptFiles();
 }
 
-void ScriptModule::DropdownUpdated(DropdownList* list, int oldValue)
+void ScriptModule::DropdownUpdated(DropdownList* list, int oldValue, double time)
 {
 }
 
@@ -1053,7 +1053,7 @@ void ScriptModule::RefreshScriptFiles()
 
 void ScriptModule::ExecuteCode()
 {
-   RunScript(gTime + gBufferSizeMs);
+   RunScript(NextBufferTime());
 }
 
 std::pair<int, int> ScriptModule::ExecuteBlock(int lineStart, int lineEnd)
@@ -1416,7 +1416,7 @@ void ScriptModule::OnModuleReferenceBound(IDrawableModule* target)
 
 void ScriptModule::Stop()
 {
-   double time = gTime + gBufferSizeMs;
+   double time = NextBufferTime();
 
    //run through any scheduled note offs for this pitch
    for (size_t i = 0; i < mScheduledNoteOutput.size(); ++i)
@@ -1694,7 +1694,7 @@ void ScriptReferenceDisplay::GetModuleDimensions(float& w, float& h)
    h = mHeight;
 }
 
-void ScriptReferenceDisplay::ButtonClicked(ClickButton* button)
+void ScriptReferenceDisplay::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mCloseButton)
       GetOwningContainer()->DeleteModule(this);

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -840,13 +840,13 @@ void ScriptModule::SendNoteToIndex(int index, double time, int pitch, int veloci
 {
    if (index == 0)
    {
-      PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
+      PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation, true);
       return;
    }
 
    if (index - 1 < (int)mExtraNoteOutputs.size())
    {
-      mExtraNoteOutputs[index - 1]->PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
+      mExtraNoteOutputs[index - 1]->PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation, true);
    }
 }
 

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1053,7 +1053,7 @@ void ScriptModule::RefreshScriptFiles()
 
 void ScriptModule::ExecuteCode()
 {
-   RunScript(NextBufferTime());
+   RunScript(NextBufferTime(false));
 }
 
 std::pair<int, int> ScriptModule::ExecuteBlock(int lineStart, int lineEnd)
@@ -1416,7 +1416,7 @@ void ScriptModule::OnModuleReferenceBound(IDrawableModule* target)
 
 void ScriptModule::Stop()
 {
-   double time = NextBufferTime();
+   double time = NextBufferTime(false);
 
    //run through any scheduled note offs for this pitch
    for (size_t i = 0; i < mScheduledNoteOutput.size(); ++i)

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -77,10 +77,10 @@ public:
    void RunCode(double time, std::string code);
 
    void OnPulse(double time, float velocity, int flags) override;
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldValue) override {}
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldValue, double time) override {}
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldValue) override;
+   void DropdownUpdated(DropdownList* list, int oldValue, double time) override;
 
    //ICodeEntryListener
    void ExecuteCode() override;
@@ -115,6 +115,7 @@ public:
    static bool sPythonInitialized;
    static bool sHasPythonEverSuccessfullyInitialized;
    static bool sHasLoadedUntrustedScript;
+   static double sMostRecentRunTime;
 
    ModulationChain* GetPitchBend(int pitch) { return &mPitchBends[pitch]; }
    ModulationChain* GetModWheel(int pitch) { return &mModWheels[pitch]; }
@@ -124,7 +125,7 @@ public:
 
 private:
    void PlayNote(double time, float pitch, float velocity, float pan, int noteOutputIndex, int lineNum);
-   void AdjustUIControl(IUIControl* control, float value, int lineNum);
+   void AdjustUIControl(IUIControl* control, float value, double time, int lineNum);
    std::pair<int, int> RunScript(double time, int lineStart = -1, int lineEnd = -1);
    void FixUpCode(std::string& code);
    void ScheduleNote(double time, float pitch, float velocity, float pan, int noteOutputIndex);
@@ -179,7 +180,6 @@ private:
    float mWidth{ 200 };
    float mHeight{ 20 };
    std::array<double, 20> mScheduledPulseTimes{};
-   static double sMostRecentRunTime;
    std::string mLastError;
    size_t mScriptModuleIndex;
    std::string mLastRunLiteralCode;
@@ -303,7 +303,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -383,7 +383,7 @@ PYBIND11_EMBEDDED_MODULE(notecanvas, m)
       })
       .def("clear", [](NoteCanvas& canvas)
       {
-         canvas.Clear();
+         canvas.Clear(NextBufferTime());
       })
       .def("fit", [](NoteCanvas& canvas)
       {
@@ -754,7 +754,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
          ScriptModule::sMostRecentLineExecutedModule->ClearContext();
          if (control != nullptr)
          {
-            control->SetValue(value);
+            control->SetValue(value, ScriptModule::sMostRecentRunTime);
          }
       })
       .def("get", [](IDrawableModule& module, std::string path)
@@ -776,7 +776,7 @@ PYBIND11_EMBEDDED_MODULE(module, m)
             float min, max;
             control->GetRange(min, max);
             float value = ofClamp(control->GetValue() + amount, min, max);
-            control->SetValue(value);
+            control->SetValue(value, ScriptModule::sMostRecentRunTime);
          }
       });
 }

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -383,7 +383,7 @@ PYBIND11_EMBEDDED_MODULE(notecanvas, m)
       })
       .def("clear", [](NoteCanvas& canvas)
       {
-         canvas.Clear(NextBufferTime());
+         canvas.Clear(NextBufferTime(false));
       })
       .def("fit", [](NoteCanvas& canvas)
       {

--- a/Source/ScriptStatus.cpp
+++ b/Source/ScriptStatus.cpp
@@ -109,7 +109,7 @@ void ScriptStatus::OnClicked(float x, float y, bool right)
    }
 }
 
-void ScriptStatus::ButtonClicked(ClickButton* button)
+void ScriptStatus::ButtonClicked(ClickButton* button, double time)
 {
    ScriptModule::UninitializePython();
    ScriptModule::InitializePythonIfNecessary();

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -44,7 +44,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -268,7 +268,7 @@ void SeaOfGrain::DropdownClicked(DropdownList* list)
 {
 }
 
-void SeaOfGrain::DropdownUpdated(DropdownList* list, int oldVal)
+void SeaOfGrain::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
@@ -304,7 +304,7 @@ void SeaOfGrain::LoadFile()
    }
 }
 
-void SeaOfGrain::ButtonClicked(ClickButton* button)
+void SeaOfGrain::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mLoadButton)
       LoadFile();
@@ -325,7 +325,7 @@ bool SeaOfGrain::MouseMoved(float x, float y)
    return IDrawableModule::MouseMoved(x, y);
 }
 
-void SeaOfGrain::CheckboxUpdated(Checkbox* checkbox)
+void SeaOfGrain::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mRecordInputCheckbox)
    {
@@ -343,13 +343,13 @@ void SeaOfGrain::GetModuleDimensions(float& width, float& height)
    height = mBufferY + mBufferH + 202;
 }
 
-void SeaOfGrain::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SeaOfGrain::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mDisplayOffsetSlider || slider == mDisplayLengthSlider)
       UpdateDisplaySamples();
 }
 
-void SeaOfGrain::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SeaOfGrain::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -69,16 +69,16 @@ public:
    bool MouseMoved(float x, float y) override;
 
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    //IFloatSliderListener
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    //IDropdownListener
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/Selector.cpp
+++ b/Source/Selector.cpp
@@ -76,15 +76,15 @@ void Selector::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modu
 {
    int range = (int)mControlCables.size() - 1;
    if (velocity > 0 && range > 0)
-      SetIndex(pitch % range);
+      SetIndex(pitch % range, time);
 }
 
-void Selector::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void Selector::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
-   SetIndex(mCurrentValue);
+   SetIndex(mCurrentValue, time);
 }
 
-void Selector::SetIndex(int index)
+void Selector::SetIndex(int index, double time)
 {
    mCurrentValue = index;
 
@@ -99,13 +99,13 @@ void Selector::SetIndex(int index)
             if (mCurrentValue == i)
                controlsToEnable.push_back(uicontrol);
             else
-               uicontrol->SetValue(0);
+               uicontrol->SetValue(0, time);
          }
       }
    }
 
    for (auto* control : controlsToEnable)
-      control->SetValue(1);
+      control->SetValue(1, time);
 }
 
 namespace

--- a/Source/Selector.h
+++ b/Source/Selector.h
@@ -42,7 +42,7 @@ public:
 
    void CreateUIControls() override;
 
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
@@ -61,7 +61,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
 
    void SyncList();
-   void SetIndex(int index);
+   void SetIndex(int index, double time);
 
    RadioButton* mSelector{ nullptr };
    int mCurrentValue{ 0 };

--- a/Source/SignalClamp.h
+++ b/Source/SignalClamp.h
@@ -47,7 +47,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SignalGenerator.cpp
+++ b/Source/SignalGenerator.cpp
@@ -277,7 +277,7 @@ void SignalGenerator::SetUpFromSaveData()
    SetFreqMode(mModuleSaveData.GetEnum<FreqMode>("freq_mode"));
 }
 
-void SignalGenerator::DropdownUpdated(DropdownList* list, int oldVal)
+void SignalGenerator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mOscSelector)
    {
@@ -288,7 +288,7 @@ void SignalGenerator::DropdownUpdated(DropdownList* list, int oldVal)
       SetFreqMode(mFreqMode);
 }
 
-void SignalGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SignalGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mPulseWidthSlider)
       mOsc.SetPulseWidth(mPulseWidth);
@@ -303,10 +303,10 @@ void SignalGenerator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
       mOsc.mOsc.SetSoften(mSoften);
 }
 
-void SignalGenerator::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SignalGenerator::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void SignalGenerator::CheckboxUpdated(Checkbox* checkbox)
+void SignalGenerator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }

--- a/Source/SignalGenerator.h
+++ b/Source/SignalGenerator.h
@@ -62,10 +62,10 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -208,7 +208,7 @@ void SingleOscillator::PlayNote(double time, int pitch, int velocity, int voiceI
       else
          mDebugLines[mDebugLinesPos].color = ofColor::red;
       ofLog() << mDebugLines[mDebugLinesPos].text;
-      ++mDebugLinesPos;
+      mDebugLinesPos = (mDebugLinesPos + 1) % (int)mDebugLines.size();
    }
 }
 

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -202,18 +202,13 @@ void SingleOscillator::PlayNote(double time, int pitch, int velocity, int voiceI
 
    if (mDrawDebug)
    {
-      std::vector<std::string> lines = ofSplitString(mDebugLines, "\n");
-      mDebugLines = "";
-      const int kNumDisplayLines = 10;
-      for (int i = 0; i < kNumDisplayLines - 1; ++i)
-      {
-         int lineIndex = (int)lines.size() - (kNumDisplayLines - 1) + i;
-         if (lineIndex >= 0)
-            mDebugLines += lines[lineIndex] + "\n";
-      }
-      std::string debugLine = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
-      mDebugLines += debugLine;
-      ofLog() << debugLine;
+      mDebugLines[mDebugLinesPos].text = "PlayNote(" + ofToString(time / 1000) + ", " + ofToString(pitch) + ", " + ofToString(velocity) + ", " + ofToString(voiceIdx) + ")";
+      if (velocity > 0)
+         mDebugLines[mDebugLinesPos].color = ofColor::lime;
+      else
+         mDebugLines[mDebugLinesPos].color = ofColor::red;
+      ofLog() << mDebugLines[mDebugLinesPos].text;
+      ++mDebugLinesPos;
    }
 }
 
@@ -307,7 +302,14 @@ void SingleOscillator::DrawModuleUnclipped()
    if (mDrawDebug)
    {
       mPolyMgr.DrawDebug(mWidth + 3, 0);
-      DrawTextNormal(mDebugLines, 0, mHeight + 15);
+      float y = mHeight + 15;
+      for (size_t i = 0; i < mDebugLines.size(); ++i)
+      {
+         const DebugLine& line = mDebugLines[(mDebugLinesPos + i) % mDebugLines.size()];
+         ofSetColor(line.color);
+         DrawTextNormal(line.text, 0, y);
+         y += 15;
+      }
    }
 }
 
@@ -345,7 +347,7 @@ void SingleOscillator::SetUpFromSaveData()
 }
 
 
-void SingleOscillator::DropdownUpdated(DropdownList* list, int oldVal)
+void SingleOscillator::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mMultSelector)
    {
@@ -360,11 +362,11 @@ void SingleOscillator::DropdownUpdated(DropdownList* list, int oldVal)
       mDrawOsc.SetType(mVoiceParams.mOscType);
 }
 
-void SingleOscillator::RadioButtonUpdated(RadioButton* list, int oldVal)
+void SingleOscillator::RadioButtonUpdated(RadioButton* list, int oldVal, double time)
 {
 }
 
-void SingleOscillator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SingleOscillator::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mShuffleSlider)
       mDrawOsc.SetShuffle(mVoiceParams.mShuffle);
@@ -372,11 +374,11 @@ void SingleOscillator::FloatSliderUpdated(FloatSlider* slider, float oldVal)
       mDrawOsc.SetPulseWidth(mVoiceParams.mPulseWidth);
 }
 
-void SingleOscillator::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SingleOscillator::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void SingleOscillator::CheckboxUpdated(Checkbox* checkbox)
+void SingleOscillator::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
       mPolyMgr.KillAll();

--- a/Source/SingleOscillator.h
+++ b/Source/SingleOscillator.h
@@ -63,11 +63,11 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void RadioButtonUpdated(RadioButton* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void RadioButtonUpdated(RadioButton* list, int oldVal, double time) override;
 
    bool HasDebugDraw() const override { return true; }
 
@@ -118,7 +118,14 @@ private:
 
    Oscillator mDrawOsc{ OscillatorType::kOsc_Square };
 
-   std::string mDebugLines;
+   struct DebugLine
+   {
+      std::string text;
+      ofColor color;
+   };
+
+   std::array<DebugLine, 20> mDebugLines;
+   int mDebugLinesPos{ 0 };
 };
 
 

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -32,7 +32,6 @@
 #include "ModularSynth.h"
 #include "IModulator.h"
 #include "Push2Control.h"
-#include "Profiler.h"
 
 FloatSlider::FloatSlider(IFloatSliderListener* owner, const char* label, int x, int y, int w, int h, float* var, float min, float max, int digits /* = -1 */)
 : mVar(var)
@@ -348,7 +347,7 @@ void FloatSlider::MouseReleased()
    mMouseDown = false;
    mRefY = -999;
    if (mRelative && (mModulator == nullptr || mModulator->Active() == false))
-      SetValue(0);
+      SetValue(0, NextBufferTime());
 }
 
 bool FloatSlider::MouseMoved(float x, float y)
@@ -403,7 +402,7 @@ void FloatSlider::SetValueForMouse(int x, int y)
 
    if (oldVal != *var)
    {
-      mOwner->FloatSliderUpdated(this, oldVal);
+      mOwner->FloatSliderUpdated(this, oldVal, NextBufferTime());
    }
 
    if (mModulator && mModulator->Active() && mModulator->CanAdjustRange())
@@ -437,9 +436,9 @@ void FloatSlider::SmoothUpdated()
    }
 }
 
-void FloatSlider::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void FloatSlider::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
-   SetValue(GetValueForMidiCC(slider));
+   SetValue(GetValueForMidiCC(slider), time);
 }
 
 float FloatSlider::GetValueForMidiCC(float slider) const
@@ -505,7 +504,7 @@ float FloatSlider::ValToPos(float val, bool ignoreSmooth) const
    return 0;
 }
 
-void FloatSlider::SetValue(float value)
+void FloatSlider::SetValue(float value, double time)
 {
    if (TheLFOController && TheLFOController->WantsBinding(this))
    {
@@ -534,7 +533,7 @@ void FloatSlider::SetValue(float value)
    DisableLFO();
    if (oldVal != *var)
    {
-      mOwner->FloatSliderUpdated(this, oldVal);
+      mOwner->FloatSliderUpdated(this, oldVal, time);
    }
 }
 
@@ -543,7 +542,7 @@ void FloatSlider::UpdateTouching()
    if (mRelative && (mModulator == nullptr || mModulator->Active() == false))
    {
       if (!mTouching)
-         SetValue(0);
+         SetValue(0, NextBufferTime());
       mRelativeOffset = -999;
    }
 }
@@ -635,7 +634,7 @@ void FloatSlider::DoCompute(int samplesIn /*= 0*/)
    }
 
    if (oldVal != *mVar)
-      mOwner->FloatSliderUpdated(this, oldVal);
+      mOwner->FloatSliderUpdated(this, oldVal, gTime + samplesIn * gInvSampleRateMs);
 }
 
 float* FloatSlider::GetModifyValue()
@@ -651,26 +650,26 @@ void FloatSlider::Double()
 {
    float doubl = *GetModifyValue() * 2.0f;
    if (doubl >= mMin && doubl <= mMax)
-      SetValue(doubl);
+      SetValue(doubl, NextBufferTime());
 }
 
 void FloatSlider::Halve()
 {
    float half = *GetModifyValue() * .5f;
    if (half >= mMin && half <= mMax)
-      SetValue(half);
+      SetValue(half, NextBufferTime());
 }
 
 void FloatSlider::Increment(float amount)
 {
    float val = *GetModifyValue() + amount;
    if (val >= mMin && val <= mMax)
-      SetValue(val);
+      SetValue(val, NextBufferTime());
 }
 
 void FloatSlider::ResetToOriginal()
 {
-   SetValue(mOriginalValue);
+   SetValue(mOriginalValue, NextBufferTime());
 }
 
 bool FloatSlider::CheckNeedsDraw()
@@ -702,7 +701,7 @@ void FloatSlider::TextEntryComplete(TextEntry* entry)
       float evaluated = 0;
       bool expressionValid = EvaluateExpression(mEntryString, *GetModifyValue(), evaluated);
       if (expressionValid && ((evaluated >= mMin && evaluated <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
-         SetValue(evaluated);
+         SetValue(evaluated, NextBufferTime());
    }
    if (entry == mMaxEntry)
    {
@@ -835,7 +834,7 @@ void FloatSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
    }
 
    if (shouldSetValue && (mModulator == nullptr || !mModulator->Active()))
-      SetValueDirect(var);
+      SetValueDirect(var, gTime);
 }
 
 IntSlider::IntSlider(IIntSliderListener* owner, const char* label, int x, int y, int w, int h, int* var, int min, int max)
@@ -1068,14 +1067,14 @@ void IntSlider::SetValueForMouse(int x, int y)
    if (oldVal != *mVar)
    {
       CalcSliderVal();
-      mOwner->IntSliderUpdated(this, oldVal);
+      mOwner->IntSliderUpdated(this, oldVal, NextBufferTime());
    }
 }
 
-void IntSlider::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void IntSlider::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
    slider = ofClamp(slider, 0, 1);
-   SetValue(GetValueForMidiCC(slider));
+   SetValue(GetValueForMidiCC(slider), time);
    mSliderVal = slider;
    mLastSetValue = *mVar;
 }
@@ -1086,7 +1085,7 @@ float IntSlider::GetValueForMidiCC(float slider) const
    return (int)round(ofMap(slider, 0, 1, mMin, mMax));
 }
 
-void IntSlider::SetValue(float value)
+void IntSlider::SetValue(float value, double time)
 {
    int oldVal = *mVar;
    *mVar = (int)ofClamp(value, mMin, mMax);
@@ -1094,7 +1093,7 @@ void IntSlider::SetValue(float value)
    {
       CalcSliderVal();
       gControlTactileFeedback = 1;
-      mOwner->IntSliderUpdated(this, oldVal);
+      mOwner->IntSliderUpdated(this, oldVal, time);
    }
 }
 
@@ -1117,26 +1116,26 @@ void IntSlider::Double()
 {
    int doubl = *mVar * 2;
    if (doubl >= mMin && doubl <= mMax)
-      SetValue(doubl);
+      SetValue(doubl, NextBufferTime());
 }
 
 void IntSlider::Halve()
 {
    int half = *mVar / 2;
    if (half >= mMin && half <= mMax)
-      SetValue(half);
+      SetValue(half, NextBufferTime());
 }
 
 void IntSlider::Increment(float amount)
 {
    int val = *mVar + (int)amount;
    if (val >= mMin && val <= mMax)
-      SetValue(val);
+      SetValue(val, NextBufferTime());
 }
 
 void IntSlider::ResetToOriginal()
 {
-   SetValue(mOriginalValue);
+   SetValue(mOriginalValue, NextBufferTime());
 }
 
 bool IntSlider::CheckNeedsDraw()
@@ -1169,7 +1168,7 @@ void IntSlider::TextEntryComplete(TextEntry* entry)
       bool expressionValid = EvaluateExpression(mEntryString, *mVar, evaluated);
       int evaluatedInt = round(evaluated);
       if (expressionValid && ((evaluatedInt >= mMin && evaluatedInt <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
-         SetValue(evaluatedInt);
+         SetValue(evaluatedInt, NextBufferTime());
    }
    if (entry == mMaxEntry)
    {
@@ -1229,5 +1228,5 @@ void IntSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
    }
 
    if (shouldSetValue)
-      SetValueDirect(var);
+      SetValueDirect(var, gTime);
 }

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -347,7 +347,7 @@ void FloatSlider::MouseReleased()
    mMouseDown = false;
    mRefY = -999;
    if (mRelative && (mModulator == nullptr || mModulator->Active() == false))
-      SetValue(0, NextBufferTime());
+      SetValue(0, NextBufferTime(false));
 }
 
 bool FloatSlider::MouseMoved(float x, float y)
@@ -402,7 +402,7 @@ void FloatSlider::SetValueForMouse(int x, int y)
 
    if (oldVal != *var)
    {
-      mOwner->FloatSliderUpdated(this, oldVal, NextBufferTime());
+      mOwner->FloatSliderUpdated(this, oldVal, NextBufferTime(false));
    }
 
    if (mModulator && mModulator->Active() && mModulator->CanAdjustRange())
@@ -542,7 +542,7 @@ void FloatSlider::UpdateTouching()
    if (mRelative && (mModulator == nullptr || mModulator->Active() == false))
    {
       if (!mTouching)
-         SetValue(0, NextBufferTime());
+         SetValue(0, NextBufferTime(false));
       mRelativeOffset = -999;
    }
 }
@@ -650,26 +650,26 @@ void FloatSlider::Double()
 {
    float doubl = *GetModifyValue() * 2.0f;
    if (doubl >= mMin && doubl <= mMax)
-      SetValue(doubl, NextBufferTime());
+      SetValue(doubl, NextBufferTime(false));
 }
 
 void FloatSlider::Halve()
 {
    float half = *GetModifyValue() * .5f;
    if (half >= mMin && half <= mMax)
-      SetValue(half, NextBufferTime());
+      SetValue(half, NextBufferTime(false));
 }
 
 void FloatSlider::Increment(float amount)
 {
    float val = *GetModifyValue() + amount;
    if (val >= mMin && val <= mMax)
-      SetValue(val, NextBufferTime());
+      SetValue(val, NextBufferTime(false));
 }
 
 void FloatSlider::ResetToOriginal()
 {
-   SetValue(mOriginalValue, NextBufferTime());
+   SetValue(mOriginalValue, NextBufferTime(false));
 }
 
 bool FloatSlider::CheckNeedsDraw()
@@ -701,7 +701,7 @@ void FloatSlider::TextEntryComplete(TextEntry* entry)
       float evaluated = 0;
       bool expressionValid = EvaluateExpression(mEntryString, *GetModifyValue(), evaluated);
       if (expressionValid && ((evaluated >= mMin && evaluated <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
-         SetValue(evaluated, NextBufferTime());
+         SetValue(evaluated, NextBufferTime(false));
    }
    if (entry == mMaxEntry)
    {
@@ -1067,7 +1067,7 @@ void IntSlider::SetValueForMouse(int x, int y)
    if (oldVal != *mVar)
    {
       CalcSliderVal();
-      mOwner->IntSliderUpdated(this, oldVal, NextBufferTime());
+      mOwner->IntSliderUpdated(this, oldVal, NextBufferTime(false));
    }
 }
 
@@ -1116,26 +1116,26 @@ void IntSlider::Double()
 {
    int doubl = *mVar * 2;
    if (doubl >= mMin && doubl <= mMax)
-      SetValue(doubl, NextBufferTime());
+      SetValue(doubl, NextBufferTime(false));
 }
 
 void IntSlider::Halve()
 {
    int half = *mVar / 2;
    if (half >= mMin && half <= mMax)
-      SetValue(half, NextBufferTime());
+      SetValue(half, NextBufferTime(false));
 }
 
 void IntSlider::Increment(float amount)
 {
    int val = *mVar + (int)amount;
    if (val >= mMin && val <= mMax)
-      SetValue(val, NextBufferTime());
+      SetValue(val, NextBufferTime(false));
 }
 
 void IntSlider::ResetToOriginal()
 {
-   SetValue(mOriginalValue, NextBufferTime());
+   SetValue(mOriginalValue, NextBufferTime(false));
 }
 
 bool IntSlider::CheckNeedsDraw()
@@ -1168,7 +1168,7 @@ void IntSlider::TextEntryComplete(TextEntry* entry)
       bool expressionValid = EvaluateExpression(mEntryString, *mVar, evaluated);
       int evaluatedInt = round(evaluated);
       if (expressionValid && ((evaluatedInt >= mMin && evaluatedInt <= mMax) || (GetKeyModifiers() & kModifier_Shift)))
-         SetValue(evaluatedInt, NextBufferTime());
+         SetValue(evaluatedInt, NextBufferTime(false));
    }
    if (entry == mMaxEntry)
    {

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -41,7 +41,7 @@ class IFloatSliderListener
 {
 public:
    virtual ~IFloatSliderListener() {}
-   virtual void FloatSliderUpdated(FloatSlider* slider, float oldVal) = 0;
+   virtual void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) = 0;
 };
 
 class FloatSlider : public IUIControl, public ITextEntryListener, public IAudioPoller
@@ -105,9 +105,9 @@ public:
    bool CheckNeedsDraw() override;
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override;
    std::string GetDisplayValue(float val) const override;
    float GetMidiValue() const override;
@@ -199,7 +199,7 @@ class IIntSliderListener
 {
 public:
    virtual ~IIntSliderListener() {}
-   virtual void IntSliderUpdated(IntSlider* slider, int oldVal) = 0;
+   virtual void IntSliderUpdated(IntSlider* slider, int oldVal, double time) = 0;
 };
 
 class IntSlider : public IUIControl, public ITextEntryListener
@@ -230,9 +230,9 @@ public:
    bool CheckNeedsDraw() override;
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return mMax - mMin + 1; }

--- a/Source/SliderSequencer.cpp
+++ b/Source/SliderSequencer.cpp
@@ -125,19 +125,19 @@ void SliderSequencer::DrawModule()
    }
 }
 
-void SliderSequencer::CheckboxUpdated(Checkbox* checkbox)
+void SliderSequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void SliderSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SliderSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SliderSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void SliderSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void SliderSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void SliderSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/SliderSequencer.h
+++ b/Source/SliderSequencer.h
@@ -76,10 +76,10 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/SlowLayers.cpp
+++ b/Source/SlowLayers.cpp
@@ -164,25 +164,25 @@ void SlowLayers::GetModuleDimensions(float& width, float& height)
    height = 155;
 }
 
-void SlowLayers::ButtonClicked(ClickButton* button)
+void SlowLayers::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mClearButton)
       ::Clear(mBuffer, MAX_BUFFER_SIZE);
 }
 
-void SlowLayers::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void SlowLayers::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void SlowLayers::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void SlowLayers::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
-void SlowLayers::DropdownUpdated(DropdownList* list, int oldVal)
+void SlowLayers::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 
-void SlowLayers::CheckboxUpdated(Checkbox* checkbox)
+void SlowLayers::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/SlowLayers.h
+++ b/Source/SlowLayers.h
@@ -59,11 +59,11 @@ public:
 
    bool CheckNeedsDraw() override { return true; }
 
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SpectralDisplay.h
+++ b/Source/SpectralDisplay.h
@@ -55,7 +55,7 @@ public:
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
 private:
    //IDrawableModule

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -586,7 +586,7 @@ bool StepSequencer::OnPush2Control(MidiMessageType type, int controlIndex, float
          float val = midiValue / 16320.0f;
          float oldStrength = mStrength;
          mStrength = val;
-         FloatSliderUpdated(mStrengthSlider, oldStrength);
+         FloatSliderUpdated(mStrengthSlider, oldStrength, gTime);
       }
       else
       {
@@ -873,13 +873,13 @@ void StepSequencer::RandomizeRow(int row)
    }
 }
 
-void StepSequencer::CheckboxUpdated(Checkbox* checkbox)
+void StepSequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
-void StepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void StepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mStrengthSlider)
    {
@@ -902,11 +902,11 @@ void StepSequencer::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void StepSequencer::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void StepSequencer::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 
-void StepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void StepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mNumMeasuresSlider)
    {
@@ -929,7 +929,7 @@ void StepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
    }
 }
 
-void StepSequencer::ButtonClicked(ClickButton* button)
+void StepSequencer::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mShiftLeftButton || button == mShiftRightButton)
    {
@@ -957,7 +957,7 @@ void StepSequencer::ButtonClicked(ClickButton* button)
    }
 }
 
-void StepSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void StepSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mPresetDropdown)
       SetPreset(mPreset);

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -166,12 +166,12 @@ public:
    bool HasExternalPulseSource() const override { return mHasExternalPulseSource; }
    void ResetExternalPulseSource() override { mHasExternalPulseSource = false; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;

--- a/Source/Stutter.cpp
+++ b/Source/Stutter.cpp
@@ -298,7 +298,7 @@ void Stutter::OnTimeEvent(double time)
    }
 }
 
-void Stutter::SetEnabled(bool enabled)
+void Stutter::SetEnabled(double time, bool enabled)
 {
    if (enabled != mEnabled)
    {
@@ -308,7 +308,7 @@ void Stutter::SetEnabled(bool enabled)
          mMutex.lock();
          mStutterStack.clear();
          mMutex.unlock();
-         StopStutter(gTime + gBufferSizeMs);
+         StopStutter(time);
       }
    }
 }

--- a/Source/Stutter.h
+++ b/Source/Stutter.h
@@ -84,7 +84,7 @@ public:
    void DrawStutterBuffer(float x, float y, float width, float height);
    void StartStutter(double time, StutterParams stutter);
    void EndStutter(double time, StutterParams stutter);
-   void SetEnabled(bool enabled);
+   void SetEnabled(double time, bool enabled);
 
    //IAudioEffect
    void ProcessAudio(double time, ChannelBuffer* buffer);

--- a/Source/StutterControl.cpp
+++ b/Source/StutterControl.cpp
@@ -234,7 +234,7 @@ void StutterControl::OnControllerPageSelected()
 void StutterControl::OnGridButton(int x, int y, float velocity, IGridController* grid)
 {
    int index = x + y * grid->NumCols();
-   double time = NextBufferTime();
+   double time = NextBufferTime(false);
    if (index < kNumStutterTypes)
    {
       mStutter[index] = velocity > 0;

--- a/Source/StutterControl.cpp
+++ b/Source/StutterControl.cpp
@@ -208,12 +208,11 @@ StutterParams StutterControl::GetStutter(StutterControl::StutterType type)
    return StutterParams(kInterval_None, 1);
 }
 
-void StutterControl::CheckboxUpdated(Checkbox* checkbox)
+void StutterControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mStutterProcessor.SetEnabled(Enabled());
+      mStutterProcessor.SetEnabled(time, Enabled());
 
-   double time = gTime + gBufferSizeMs;
    for (int i = 0; i < kNumStutterTypes; ++i)
    {
       if (checkbox == mStutterCheckboxes[i])
@@ -223,7 +222,7 @@ void StutterControl::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void StutterControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void StutterControl::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
@@ -235,7 +234,7 @@ void StutterControl::OnControllerPageSelected()
 void StutterControl::OnGridButton(int x, int y, float velocity, IGridController* grid)
 {
    int index = x + y * grid->NumCols();
-   double time = gTime + gBufferSizeMs;
+   double time = NextBufferTime();
    if (index < kNumStutterTypes)
    {
       mStutter[index] = velocity > 0;

--- a/Source/StutterControl.h
+++ b/Source/StutterControl.h
@@ -58,8 +58,8 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation) override;
    void SendCC(int control, int value, int voiceIdx) override {}
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SustainPedal.cpp
+++ b/Source/SustainPedal.cpp
@@ -46,7 +46,7 @@ void SustainPedal::DrawModule()
    mSustainCheckbox->Draw();
 }
 
-void SustainPedal::CheckboxUpdated(Checkbox* checkbox)
+void SustainPedal::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mSustainCheckbox)
    {
@@ -56,7 +56,7 @@ void SustainPedal::CheckboxUpdated(Checkbox* checkbox)
          {
             if (mIsNoteBeingSustained[i])
             {
-               PlayNoteOutput(gTime + gBufferSize * gInvSampleRateMs, i, 0, -1);
+               PlayNoteOutput(time, i, 0, -1);
                mIsNoteBeingSustained[i] = false;
             }
          }

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -43,7 +43,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -754,6 +754,14 @@ void LoadStateValidate(bool assertion)
       throw LoadStateException();
 }
 
+double NextBufferTime(bool includeLookahead)
+{
+   double time = gTime + gBufferSizeMs;
+   if (includeLookahead)
+      time += TheTransport->GetEventLookaheadMs();
+   return time;
+}
+
 float GetLeftPanGain(float pan)
 {
    return 1 - ofClamp(pan, -1, 1);

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -218,11 +218,7 @@ float GetLeftPanGain(float pan);
 float GetRightPanGain(float pan);
 void DrawFallbackText(const char* text, float posX, float posY);
 bool EvaluateExpression(std::string expression, float currentValue, float& output);
-
-inline static double NextBufferTime()
-{
-   return gTime + gBufferSizeMs;
-}
+double NextBufferTime(bool includeLookahead);
 
 inline static float RandomSample()
 {

--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -219,6 +219,11 @@ float GetRightPanGain(float pan);
 void DrawFallbackText(const char* text, float posX, float posY);
 bool EvaluateExpression(std::string expression, float currentValue, float& output);
 
+inline static double NextBufferTime()
+{
+   return gTime + gBufferSizeMs;
+}
+
 inline static float RandomSample()
 {
    return gRandomBipolarDist(gRandom);

--- a/Source/TakeRecorder.h
+++ b/Source/TakeRecorder.h
@@ -51,8 +51,8 @@ public:
    void Process(double time) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -513,7 +513,7 @@ void TextEntry::SetText(std::string text)
    mCaretPosition2 = 0;
 }
 
-void TextEntry::SetFromMidiCC(float slider, bool setViaModulator /*= false*/)
+void TextEntry::SetFromMidiCC(float slider, double time, bool setViaModulator)
 {
    if (mType == kTextEntry_Int)
    {
@@ -556,7 +556,7 @@ float TextEntry::GetMidiValue() const
    return 0;
 }
 
-void TextEntry::SetValue(float value)
+void TextEntry::SetValue(float value, double time)
 {
    if (mType == kTextEntry_Int)
    {

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -94,10 +94,10 @@ public:
    void GetDimensions(float& width, float& height) override;
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override;
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
    float GetMidiValue() const override;
-   void SetValue(float value) override;
+   void SetValue(float value, double time) override;
    float GetValue() const override;
    int GetNumValues() override;
    std::string GetDisplayValue(float val) const override;

--- a/Source/TimelineControl.cpp
+++ b/Source/TimelineControl.cpp
@@ -92,7 +92,7 @@ void TimelineControl::Resize(float width, float height)
    mLoopEndSlider->PositionTo(mLoopStartSlider, kAnchor_Below);
 }
 
-void TimelineControl::CheckboxUpdated(Checkbox* checkbox)
+void TimelineControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mLoopCheckbox)
    {
@@ -105,7 +105,7 @@ void TimelineControl::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void TimelineControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void TimelineControl::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mTimeSlider)
    {
@@ -113,7 +113,7 @@ void TimelineControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void TimelineControl::IntSliderUpdated(IntSlider* slider, int oldVal)
+void TimelineControl::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
    if (slider == mLoopStartSlider || slider == mLoopEndSlider)
    {

--- a/Source/TimelineControl.h
+++ b/Source/TimelineControl.h
@@ -40,9 +40,9 @@ public:
 
    void CreateUIControls() override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
 
    bool IsResizable() const override { return true; }
    void Resize(float width, float height) override;

--- a/Source/TimerDisplay.cpp
+++ b/Source/TimerDisplay.cpp
@@ -43,7 +43,7 @@ TimerDisplay::~TimerDisplay()
 {
 }
 
-void TimerDisplay::ButtonClicked(ClickButton* button)
+void TimerDisplay::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetButton)
       mStartTime = gTime;

--- a/Source/TimerDisplay.h
+++ b/Source/TimerDisplay.h
@@ -41,7 +41,7 @@ public:
 
    void CreateUIControls() override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -537,7 +537,7 @@ void TitleBar::GetModuleDimensions(float& width, float& height)
       height = 36;
 }
 
-void TitleBar::CheckboxUpdated(Checkbox* checkbox)
+void TitleBar::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
@@ -550,7 +550,7 @@ void TitleBar::DropdownClicked(DropdownList* list)
       mSpawnLists.SetUpPrefabsDropdown();
 }
 
-void TitleBar::DropdownUpdated(DropdownList* list, int oldVal)
+void TitleBar::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mLoadLayoutDropdown)
    {
@@ -563,7 +563,7 @@ void TitleBar::DropdownUpdated(DropdownList* list, int oldVal)
       spawnList->OnSelection(list);
 }
 
-void TitleBar::ButtonClicked(ClickButton* button)
+void TitleBar::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mSaveLayoutButton)
    {
@@ -625,7 +625,7 @@ void NewPatchConfirmPopup::DrawModule()
    mCancelButton->Draw();
 }
 
-void NewPatchConfirmPopup::ButtonClicked(ClickButton* button)
+void NewPatchConfirmPopup::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mConfirmButton)
       TheSynth->ReloadInitialLayout();

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -108,7 +108,7 @@ public:
       height = mHeight;
    }
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
 private:
    int mWidth{ 200 };
@@ -140,11 +140,11 @@ public:
 
    void OnWindowClosed() override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    static bool sShowInitialHelpOverlay;
 

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -270,7 +270,7 @@ void Transport::Reset(float rewindAmount)
    mMeasureTime = -rewindAmount;
 }
 
-void Transport::ButtonClicked(ClickButton* button)
+void Transport::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mResetButton)
       Reset();
@@ -634,22 +634,22 @@ void Transport::OnDrumEvent(NoteInterval drumEvent)
    }
 }
 
-void Transport::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void Transport::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void Transport::CheckboxUpdated(Checkbox* checkbox)
+void Transport::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mSetTempoCheckbox)
    {
       if (mSetTempoBool)
       {
-         mStartRecordTime = gTime;
+         mStartRecordTime = time;
       }
       else if (mStartRecordTime != -1)
       {
          int numBars = 1;
-         float recordedTime = gTime - mStartRecordTime;
+         float recordedTime = time - mStartRecordTime;
          int beats = numBars * GetTimeSigTop();
          float minutes = recordedTime / 1000.0f / 60.0f;
          SetTempo(beats / minutes);
@@ -658,7 +658,7 @@ void Transport::CheckboxUpdated(Checkbox* checkbox)
    }
 }
 
-void Transport::DropdownUpdated(DropdownList* list, int oldVal)
+void Transport::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
 }
 

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -158,10 +158,10 @@ public:
    void KeyPressed(int key, bool isRepeat) override;
    bool IsSingleton() const override { return true; }
 
-   void ButtonClicked(ClickButton* button) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/TransposeFrom.cpp
+++ b/Source/TransposeFrom.cpp
@@ -72,10 +72,10 @@ void TransposeFrom::DrawModule()
    mRetriggerCheckbox->Draw();
 }
 
-void TransposeFrom::CheckboxUpdated(Checkbox* checkbox)
+void TransposeFrom::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 int TransposeFrom::GetTransposeAmount() const
@@ -111,18 +111,17 @@ void TransposeFrom::PlayNote(double time, int pitch, int velocity, int voiceIdx,
 
 void TransposeFrom::OnScaleChanged()
 {
-   OnRootChanged();
+   OnRootChanged(gTime);
 }
 
-void TransposeFrom::DropdownUpdated(DropdownList* slider, int oldVal)
+void TransposeFrom::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
-   if (slider == mRootSelector && mEnabled && mRetrigger)
-      OnRootChanged();
+   if (list == mRootSelector && mEnabled && mRetrigger)
+      OnRootChanged(time);
 }
 
-void TransposeFrom::OnRootChanged()
+void TransposeFrom::OnRootChanged(double time)
 {
-   double time = gTime + gBufferSizeMs;
    for (int pitch = 0; pitch < 128; ++pitch)
    {
       if (mInputNotes[pitch].mOn)

--- a/Source/TransposeFrom.h
+++ b/Source/TransposeFrom.h
@@ -52,8 +52,8 @@ public:
    //IScaleListener
    void OnScaleChanged() override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
@@ -77,7 +77,7 @@ private:
    bool Enabled() const override { return mEnabled; }
 
    int GetTransposeAmount() const;
-   void OnRootChanged();
+   void OnRootChanged(double time);
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/TremoloEffect.cpp
+++ b/Source/TremoloEffect.cpp
@@ -118,7 +118,7 @@ float TremoloEffect::GetEffectAmount()
    return mAmount;
 }
 
-void TremoloEffect::DropdownUpdated(DropdownList* list, int oldVal)
+void TremoloEffect::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
       mLFO.SetPeriod(mInterval);
@@ -126,11 +126,11 @@ void TremoloEffect::DropdownUpdated(DropdownList* list, int oldVal)
       mLFO.SetType(mOscType);
 }
 
-void TremoloEffect::CheckboxUpdated(Checkbox* checkbox)
+void TremoloEffect::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void TremoloEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void TremoloEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mOffsetSlider)
       mLFO.SetOffset(mOffset);

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -50,11 +50,11 @@ public:
    std::string GetType() override { return "tremolo"; }
 
    //IDropdownListener
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
 private:
    //IDrawableModule

--- a/Source/UIGrid.h
+++ b/Source/UIGrid.h
@@ -105,8 +105,8 @@ public:
    ofVec2f GetCellPosition(int col, int row);
 
    //IUIControl
-   void SetFromMidiCC(float slider, bool setViaModulator = false) override {}
-   void SetValue(float value) override {}
+   void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
+   void SetValue(float value, double time) override {}
    bool IsSliderControl() override { return false; }
    bool IsButtonControl() override { return false; }
 

--- a/Source/UnstableModWheel.cpp
+++ b/Source/UnstableModWheel.cpp
@@ -172,11 +172,11 @@ void UnstableModWheel::FillModulationBuffer(double time, int voiceIdx)
    mModulation.GetModWheel(voiceIdx)->FillBuffer(gWorkBuffer);
 }
 
-void UnstableModWheel::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void UnstableModWheel::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void UnstableModWheel::CheckboxUpdated(Checkbox* checkbox)
+void UnstableModWheel::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/UnstableModWheel.h
+++ b/Source/UnstableModWheel.h
@@ -52,8 +52,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/UnstablePitch.cpp
+++ b/Source/UnstablePitch.cpp
@@ -172,11 +172,11 @@ void UnstablePitch::FillModulationBuffer(double time, int voiceIdx)
    mModulation.GetPitchBend(voiceIdx)->FillBuffer(gWorkBuffer);
 }
 
-void UnstablePitch::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void UnstablePitch::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void UnstablePitch::CheckboxUpdated(Checkbox* checkbox)
+void UnstablePitch::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/UnstablePitch.h
+++ b/Source/UnstablePitch.h
@@ -74,8 +74,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/UnstablePressure.cpp
+++ b/Source/UnstablePressure.cpp
@@ -172,11 +172,11 @@ void UnstablePressure::FillModulationBuffer(double time, int voiceIdx)
    mModulation.GetPressure(voiceIdx)->FillBuffer(gWorkBuffer);
 }
 
-void UnstablePressure::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void UnstablePressure::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
 }
 
-void UnstablePressure::CheckboxUpdated(Checkbox* checkbox)
+void UnstablePressure::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/UnstablePressure.h
+++ b/Source/UnstablePressure.h
@@ -52,8 +52,8 @@ public:
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -379,7 +379,7 @@ void UserPrefsEditor::Save()
       juce::JUCEApplicationBase::quit();
 }
 
-void UserPrefsEditor::ButtonClicked(ClickButton* button)
+void UserPrefsEditor::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mSaveButton)
    {
@@ -391,11 +391,11 @@ void UserPrefsEditor::ButtonClicked(ClickButton* button)
       SetShowing(false);
 }
 
-void UserPrefsEditor::CheckboxUpdated(Checkbox* checkbox)
+void UserPrefsEditor::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void UserPrefsEditor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void UserPrefsEditor::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (!TheSynth->IsLoadingState())
    {
@@ -416,7 +416,7 @@ void UserPrefsEditor::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void UserPrefsEditor::IntSliderUpdated(IntSlider* slider, int oldVal)
+void UserPrefsEditor::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
@@ -424,7 +424,7 @@ void UserPrefsEditor::TextEntryComplete(TextEntry* entry)
 {
 }
 
-void UserPrefsEditor::DropdownUpdated(DropdownList* list, int oldVal)
+void UserPrefsEditor::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == UserPrefs.devicetype.GetDropdown())
    {
@@ -442,7 +442,7 @@ void UserPrefsEditor::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void UserPrefsEditor::RadioButtonUpdated(RadioButton* radio, int oldVal)
+void UserPrefsEditor::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
 }
 

--- a/Source/UserPrefsEditor.h
+++ b/Source/UserPrefsEditor.h
@@ -51,13 +51,13 @@ public:
    void Show();
    void CreatePrefsFileIfNonexistent();
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void ButtonClicked(ClickButton* button) override;
-   void RadioButtonUpdated(RadioButton* radio, int oldVal) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
    bool IsSaveable() override { return false; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -952,7 +952,7 @@ std::vector<IUIControl*> VSTPlugin::ControlsToIgnoreInSaveState() const
    return ignore;
 }
 
-void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal)
+void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mPresetFileSelector)
    {
@@ -1019,7 +1019,7 @@ void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void VSTPlugin::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void VSTPlugin::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (int i = 0; i < mParameterSliders.size(); ++i)
    {
@@ -1030,15 +1030,15 @@ void VSTPlugin::FloatSliderUpdated(FloatSlider* slider, float oldVal)
    }
 }
 
-void VSTPlugin::IntSliderUpdated(IntSlider* slider, int oldVal)
+void VSTPlugin::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 
-void VSTPlugin::CheckboxUpdated(Checkbox* checkbox)
+void VSTPlugin::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 
-void VSTPlugin::ButtonClicked(ClickButton* button)
+void VSTPlugin::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mOpenEditorButton)
       mWantOpenVstWindow = true;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -87,11 +87,11 @@ public:
    void SendMidi(const juce::MidiMessage& message) override;
 
    void DropdownClicked(DropdownList* list) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void ButtonClicked(ClickButton* button) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void OnUIControlRequested(const char* name) override;
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/ValueSetter.cpp
+++ b/Source/ValueSetter.cpp
@@ -82,28 +82,28 @@ void ValueSetter::OnPulse(double time, float velocity, int flags)
    if (velocity > 0 && mEnabled)
    {
       ComputeSliders((time - gTime) * gSampleRateMs);
-      Go();
+      Go(time);
    }
 }
 
-void ValueSetter::ButtonClicked(ClickButton* button)
+void ValueSetter::ButtonClicked(ClickButton* button, double time)
 {
-   if (button == mButton && mLastClickTime != gTime)
+   if (button == mButton && mLastClickTime != time)
    {
-      mLastClickTime = gTime;
-      Go();
+      mLastClickTime = time;
+      Go(time);
    }
 }
 
-void ValueSetter::Go()
+void ValueSetter::Go(double time)
 {
-   mControlCable->AddHistoryEvent(gTime, true);
-   mControlCable->AddHistoryEvent(gTime + 15, false);
+   mControlCable->AddHistoryEvent(time, true);
+   mControlCable->AddHistoryEvent(time + 15, false);
 
    for (size_t i = 0; i < mTargets.size(); ++i)
    {
       if (mTargets[i] != nullptr)
-         mTargets[i]->SetValue(mValue);
+         mTargets[i]->SetValue(mValue, time);
    }
 }
 

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -50,13 +50,13 @@ public:
    //IPulseReceiver
    void OnPulse(double time, float velocity, int flags) override;
 
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
    void TextEntryComplete(TextEntry* entry) override {}
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
@@ -72,7 +72,7 @@ private:
    }
    bool Enabled() const override { return mEnabled; }
 
-   void Go();
+   void Go(double time);
 
    PatchCableSource* mControlCable{ nullptr };
    std::array<IUIControl*, IDrawableModule::kMaxOutputsPerPatchCableSource> mTargets{};

--- a/Source/ValueStream.h
+++ b/Source/ValueStream.h
@@ -48,7 +48,7 @@ public:
 
    void OnTransportAdvanced(float amount) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    //IDrawableModule
    void Init() override;

--- a/Source/VelocityScaler.h
+++ b/Source/VelocityScaler.h
@@ -46,7 +46,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/VelocitySetter.cpp
+++ b/Source/VelocitySetter.cpp
@@ -52,7 +52,7 @@ void VelocitySetter::DrawModule()
    mRandomnessSlider->Draw();
 }
 
-void VelocitySetter::CheckboxUpdated(Checkbox* checkbox)
+void VelocitySetter::CheckboxUpdated(Checkbox* checkbox, double time)
 {
 }
 

--- a/Source/VelocitySetter.h
+++ b/Source/VelocitySetter.h
@@ -46,8 +46,8 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/VelocityStepSequencer.cpp
+++ b/Source/VelocityStepSequencer.cpp
@@ -105,10 +105,10 @@ void VelocityStepSequencer::DrawModule()
    ofPopStyle();
 }
 
-void VelocityStepSequencer::CheckboxUpdated(Checkbox* checkbox)
+void VelocityStepSequencer::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void VelocityStepSequencer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
@@ -152,11 +152,11 @@ void VelocityStepSequencer::OnMidiControl(MidiControl& control)
    }
 }
 
-void VelocityStepSequencer::ButtonClicked(ClickButton* button)
+void VelocityStepSequencer::ButtonClicked(ClickButton* button, double time)
 {
 }
 
-void VelocityStepSequencer::DropdownUpdated(DropdownList* list, int oldVal)
+void VelocityStepSequencer::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mIntervalSelector)
    {
@@ -169,7 +169,7 @@ void VelocityStepSequencer::DropdownUpdated(DropdownList* list, int oldVal)
    }
 }
 
-void VelocityStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal)
+void VelocityStepSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
 }
 

--- a/Source/VelocityStepSequencer.h
+++ b/Source/VelocityStepSequencer.h
@@ -67,12 +67,12 @@ public:
    void OnMidiControl(MidiControl& control) override;
 
    //IButtonListener
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void DropdownUpdated(DropdownList* list, int oldVal) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/VelocityToCV.h
+++ b/Source/VelocityToCV.h
@@ -57,7 +57,7 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/VelocityToChance.cpp
+++ b/Source/VelocityToChance.cpp
@@ -155,7 +155,7 @@ void VelocityToChance::Reseed()
    mSeed = gRandom() % 10000;
 }
 
-void VelocityToChance::ButtonClicked(ClickButton* button)
+void VelocityToChance::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mPrevSeedButton)
       mSeed = (mSeed - 1 + 10000) % 10000;

--- a/Source/VelocityToChance.h
+++ b/Source/VelocityToChance.h
@@ -45,11 +45,11 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
-   void CheckboxUpdated(Checkbox* checkbox) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
-   void ButtonClicked(ClickButton* button) override;
+   void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/VinylTempoControl.cpp
+++ b/Source/VinylTempoControl.cpp
@@ -114,7 +114,7 @@ bool VinylTempoControl::CanStartVinylControl()
    return !mVinylProcessor.GetStopped() && fabsf(mVinylProcessor.GetPitch()) > .001f;
 }
 
-void VinylTempoControl::CheckboxUpdated(Checkbox* checkbox)
+void VinylTempoControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mUseVinylControlCheckbox)
    {

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -77,7 +77,7 @@ public:
    bool Active() const override { return mEnabled; }
    bool CanAdjustRange() const override { return false; }
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;

--- a/Source/Vocoder.cpp
+++ b/Source/Vocoder.cpp
@@ -258,7 +258,7 @@ void Vocoder::DrawModule()
    mGate.Draw();
 }
 
-void Vocoder::CheckboxUpdated(Checkbox* checkbox)
+void Vocoder::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
    {

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -57,9 +57,9 @@ public:
    //IAudioSource
    void Process(double time) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/VolcaBeatsControl.cpp
+++ b/Source/VolcaBeatsControl.cpp
@@ -208,7 +208,7 @@ void VolcaBeatsControl::PlayNote(double time, int pitch, int velocity, int voice
       PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
-void VolcaBeatsControl::FloatSliderUpdated(FloatSlider* slider, float oldVal)
+void VolcaBeatsControl::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    if (slider == mClapSpeedSlider)
       SendCC(50, (int)(mClapSpeed * 127));

--- a/Source/VolcaBeatsControl.h
+++ b/Source/VolcaBeatsControl.h
@@ -51,7 +51,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override;
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/Source/WaveformViewer.h
+++ b/Source/WaveformViewer.h
@@ -56,8 +56,8 @@ public:
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
-   void IntSliderUpdated(IntSlider* slider, int oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
    void TextEntryComplete(TextEntry* entry) override {}
 
    //INoteReceiver

--- a/Source/Waveshaper.h
+++ b/Source/Waveshaper.h
@@ -49,7 +49,7 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IFloatSliderListener
-   void FloatSliderUpdated(FloatSlider* slider, float oldVal) override {}
+   void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    //ITextEntryListener
    void TextEntryComplete(TextEntry* entry) override;

--- a/Source/WhiteKeys.cpp
+++ b/Source/WhiteKeys.cpp
@@ -39,10 +39,10 @@ void WhiteKeys::DrawModule()
       return;
 }
 
-void WhiteKeys::CheckboxUpdated(Checkbox* checkbox)
+void WhiteKeys::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mNoteOutput.Flush(gTime);
+      mNoteOutput.Flush(time);
 }
 
 void WhiteKeys::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -43,7 +43,7 @@ public:
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
-   void CheckboxUpdated(Checkbox* checkbox) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(nanovg EXCLUDE_FROM_ALL)
 add_subdirectory(oddsound-mts EXCLUDE_FROM_ALL)
 add_subdirectory(psmove EXCLUDE_FROM_ALL)
 add_subdirectory(push2 EXCLUDE_FROM_ALL)
+add_subdirectory(readerwriterqueue EXCLUDE_FROM_ALL)
 
 set(PYBIND11_NOPYTHON TRUE)
 if(NOT BESPOKE_SYSTEM_PYBIND11)


### PR DESCRIPTION
this allows modulators to trigger controls with sample-accurate timing, rather than just grossly quantizing to the most recent rendering block, as it did before

in testing, I found that this change uncovered cases where stuck notes would happen, in places where they didn't before. to repair this, I made a long-overdue thread safety fix to queue up any notes triggered outside of the audio thread to wait until the next audio processing frame