### PR TITLE
make modulators send non-normalized values to non-floatslider controls

### DIFF
--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -96,7 +96,7 @@ void IModulator::Poll()
       float blend = exp2(kBlendRate / ofGetFrameRate()); //framerate-independent blend
       mSmoothedValue = mSmoothedValue * blend + mLastPollValue * (1 - blend);
       if (RequiresManualPolling())
-         mUIControlTarget->SetValue(mLastPollValue);  
+         mUIControlTarget->SetValue(mLastPollValue);
    }
 }
 

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -96,7 +96,7 @@ void IModulator::Poll()
       float blend = exp2(kBlendRate / ofGetFrameRate()); //framerate-independent blend
       mSmoothedValue = mSmoothedValue * blend + mLastPollValue * (1 - blend);
       if (RequiresManualPolling())
-         mUIControlTarget->SetFromMidiCC(mLastPollValue, true);
+         mUIControlTarget->SetValue(mLastPollValue);  
    }
 }
 

--- a/Source/NoteCounter.cpp
+++ b/Source/NoteCounter.cpp
@@ -41,6 +41,8 @@ void NoteCounter::Init()
    IDrawableModule::Init();
 
    mTransportListenerInfo = TheTransport->AddListener(this, mInterval, OffsetInfo(0, true), true);
+
+   Reseed();
 }
 
 void NoteCounter::CreateUIControls()


### PR DESCRIPTION
so that controls can get direct values rather than just mapping 0-1 values. fixes the very strange behavior that people were getting when mapping modulators to textentry boxes