### PR TITLE
security fix: allow users to review python scripts before running them

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -830,6 +830,7 @@ target_link_libraries(BespokeSynth PRIVATE
     juce::juce_audio_devices
     juce::juce_audio_formats
     juce::juce_audio_processors
+    juce::juce_cryptography
     juce::juce_gui_basics
     juce::juce_opengl
     juce::juce_osc

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -263,23 +263,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
    else
       gModuleDrawAlpha = 100;
 
-   bool dimModule = false;
-
-   if (TheSynth->GetGroupSelectedModules().empty() == false)
-   {
-      if (!VectorContains(GetModuleParent(), TheSynth->GetGroupSelectedModules()))
-         dimModule = true;
-   }
-
-   if (PatchCable::sActivePatchCable &&
-       (PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_Modulator && PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_UIControl && PatchCable::sActivePatchCable->GetConnectionType() != kConnectionType_ValueSetter) &&
-       !PatchCable::sActivePatchCable->IsValidTarget(this))
-   {
-      dimModule = true;
-   }
-
-   if (TheSynth->GetHeldSample() != nullptr && !CanDropSample())
-      dimModule = true;
+   bool dimModule = TheSynth->ShouldDimModule(this);
 
    if (dimModule)
       gModuleDrawAlpha *= .2f;

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -43,6 +43,7 @@ class QuickSpawnMenu;
 class ADSRDisplay;
 class UserPrefsEditor;
 class Minimap;
+class ScriptWarningPopup;
 
 enum LogEventType
 {
@@ -105,7 +106,7 @@ public:
 
    bool IsReady();
    bool IsAudioPaused() const { return mAudioPaused; }
-   void ToggleAudioPaused() { mAudioPaused = !mAudioPaused; }
+   void SetAudioPaused(bool paused) { mAudioPaused = paused; }
 
    void AddMidiDevice(MidiDevice* device);
    void ArrangeAudioSourceDependencies();
@@ -204,6 +205,7 @@ public:
    EffectFactory* GetEffectFactory() { return &mEffectFactory; }
    const std::vector<IDrawableModule*>& GetGroupSelectedModules() const { return mGroupSelectedModules; }
    bool ShouldAccentuateActiveModules() const;
+   bool ShouldDimModule(IDrawableModule* module);
    LocationZoomer* GetLocationZoomer() { return &mZoomer; }
    IDrawableModule* GetModuleAtCursor(int offsetX = 0, int offsetY = 0);
 

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -34,6 +34,7 @@
 #include "PerformanceTimer.h"
 #include "SynthGlobals.h"
 #include "QuickSpawnMenu.h"
+#include "Prefab.h"
 
 #include "juce_core/juce_core.h"
 
@@ -604,6 +605,8 @@ void ModuleContainer::SaveState(FileStreamOut& out)
 
 void ModuleContainer::LoadState(FileStreamIn& in)
 {
+   Prefab::sLastLoadWasPrefab = Prefab::sLoadingPrefab;
+
    bool wasLoadingState = TheSynth->IsLoadingState();
    TheSynth->SetIsLoadingState(true);
 

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -489,6 +489,7 @@ ModuleFactory::ModuleFactory()
    REGISTER_HIDDEN(Razor, razor, kModuleCategory_Synth);
    REGISTER_HIDDEN(MidiCapturer, midicapturer, kModuleCategory_Note);
    REGISTER_HIDDEN(ScriptReferenceDisplay, scriptingreference, kModuleCategory_Other);
+   REGISTER_HIDDEN(ScriptWarningPopup, scriptwarning, kModuleCategory_Other);
    REGISTER_HIDDEN(MultitrackRecorderTrack, multitrackrecordertrack, kModuleCategory_Audio);
 }
 

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -33,7 +33,7 @@
 
 //static
 bool Prefab::sLoadingPrefab = false;
-//static
+bool Prefab::sLastLoadWasPrefab = false;
 IDrawableModule* Prefab::sJustReleasedModule = nullptr;
 
 Prefab::Prefab()

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -64,6 +64,7 @@ public:
    void LoadPrefab(std::string loadPath);
 
    static bool sLoadingPrefab;
+   static bool sLastLoadWasPrefab;
    static IDrawableModule* sJustReleasedModule;
 
 private:

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -602,7 +602,7 @@ void TitleBar::ButtonClicked(ClickButton* button)
       TheSynth->PushModalFocusItem(&mNewPatchConfirmPopup);
    }
    if (button == mPlayPauseButton)
-      TheSynth->ToggleAudioPaused();
+      TheSynth->SetAudioPaused(!TheSynth->IsAudioPaused());
 }
 
 void NewPatchConfirmPopup::CreateUIControls()

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -283,7 +283,7 @@ void Transport::ButtonClicked(ClickButton* button)
    if (button == mDecreaseTempoButton)
       AdjustTempo(-1);
    if (button == mPlayPauseButton)
-      TheSynth->ToggleAudioPaused();
+      TheSynth->SetAudioPaused(!TheSynth->IsAudioPaused());
 }
 
 TransportListenerInfo* Transport::AddListener(ITimeListener* listener, NoteInterval interval, OffsetInfo offsetInfo, bool useEventLookahead)

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -168,6 +168,8 @@ namespace VSTLookup
       auto types = TheSynth->GetKnownPluginList().getTypes();
       for (int i = 0; i < types.size(); ++i)
       {
+         if (types[i].pluginFormatName == juce::AudioUnitPluginFormat::getFormatName())
+            continue; //"fileOrIdentifier" is not a valid path, can't check
          juce::File vst(types[i].fileOrIdentifier);
          if (vst.getFileNameWithoutExtension().toStdString() == vstName)
             return types[i].fileOrIdentifier.toStdString();

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -168,8 +168,10 @@ namespace VSTLookup
       auto types = TheSynth->GetKnownPluginList().getTypes();
       for (int i = 0; i < types.size(); ++i)
       {
+#if BESPOKE_MAC
          if (types[i].pluginFormatName == juce::AudioUnitPluginFormat::getFormatName())
             continue; //"fileOrIdentifier" is not a valid path, can't check
+#endif
          juce::File vst(types[i].fileOrIdentifier);
          if (vst.getFileNameWithoutExtension().toStdString() == vstName)
             return types[i].fileOrIdentifier.toStdString();


### PR DESCRIPTION
to protect users who download and open BSKs and prefab files from theoretical malicious users. until all scripts in a file are marked as trusted, no python scripts execute. trusted scripts are stored, so users only need to approve them once.

fixes #911