### PR TITLE
fix issues related to modulator range

### DIFF
--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -228,7 +228,7 @@ void FloatSliderLFOControl::SetOwner(FloatSlider* owner)
    mUIControlTarget = owner;
 
    if (mSliderTarget != nullptr)
-      InitializeRange();
+      InitializeRange(mSliderTarget->GetValue(), mSliderTarget->GetMin(), mSliderTarget->GetMax(), mSliderTarget->GetMode());
 }
 
 void FloatSliderLFOControl::RandomizeSettings()

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -60,11 +60,20 @@ void IModulator::OnModulatorRepatch()
 
          mUIControlTarget = newTarget;
          mSliderTarget = dynamic_cast<FloatSlider*>(mUIControlTarget);
+         IntSlider* intSlider = dynamic_cast<IntSlider*>(mUIControlTarget);
 
          if (mSliderTarget != nullptr)
          {
             mSliderTarget->SetModulator(this);
-            InitializeRange();
+            InitializeRange(mSliderTarget->GetValue(), mSliderTarget->GetMin(), mSliderTarget->GetMax(), mSliderTarget->GetMode());
+         }
+         else if (intSlider != nullptr)
+         {
+            InitializeRange(intSlider->GetValue(), intSlider->GetMin(), intSlider->GetMax(), FloatSlider::kNormal);
+         }
+         else
+         {
+            InitializeRange(mUIControlTarget->GetValue(), 0, 1, FloatSlider::kNormal);
          }
       }
    }
@@ -112,38 +121,39 @@ void IModulator::OnRemovedFrom(IUIControl* control)
    OnModulatorRepatch();
 }
 
-void IModulator::InitializeRange()
+void IModulator::InitializeRange(float currentValue, float min, float max, FloatSlider::Mode sliderMode)
 {
-   if (mSliderTarget != nullptr)
+   if (!TheSynth->IsLoadingState())
    {
-      if (!TheSynth->IsLoadingState())
+      if (!TheSynth->IsLoadingModule())
       {
-         if (!TheSynth->IsLoadingModule())
+         if (InitializeWithZeroRange())
          {
-            if (InitializeWithZeroRange())
-            {
-               GetMin() = mSliderTarget->GetValue();
-               GetMax() = mSliderTarget->GetValue();
-            }
-            else
-            {
-               GetMin() = mSliderTarget->GetMin();
-               GetMax() = mSliderTarget->GetMax();
-            }
+            GetMin() = currentValue;
+            GetMax() = currentValue;
+         }
+         else
+         {
+            GetMin() = min;
+            GetMax() = max;
+         }
+
+         if (mMinSlider)
+         {
+            mMinSlider->SetExtents(min, max);
+            mMinSlider->SetMode(sliderMode);
+         }
+
+         if (mMaxSlider)
+         {
+            mMaxSlider->SetExtents(min, max);
+            mMaxSlider->SetMode(sliderMode);
          }
       }
-
-      if (mMinSlider)
-      {
-         mMinSlider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
-         mMinSlider->SetMode(mSliderTarget->GetMode());
-         mMinSlider->SetVar(&GetMin());
-      }
-      if (mMaxSlider)
-      {
-         mMaxSlider->SetExtents(mSliderTarget->GetMin(), mSliderTarget->GetMax());
-         mMaxSlider->SetMode(mSliderTarget->GetMode());
-         mMaxSlider->SetVar(&GetMax());
-      }
    }
+
+   if (mMinSlider)
+      mMinSlider->SetVar(&GetMin());
+   if (mMaxSlider)
+      mMaxSlider->SetVar(&GetMax());
 }

--- a/Source/IModulator.h
+++ b/Source/IModulator.h
@@ -49,7 +49,7 @@ public:
    void OnRemovedFrom(IUIControl* control);
 
 protected:
-   void InitializeRange();
+   void InitializeRange(float currentValue, float min, float max, FloatSlider::Mode sliderMode);
    bool RequiresManualPolling() { return mUIControlTarget != nullptr && mSliderTarget == nullptr; }
 
    float mDummyMin;

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -731,7 +731,7 @@ void FloatSlider::OnTransportAdvanced(float amount)
 
 namespace
 {
-   const int kFloatSliderSaveStateRev = 5;
+   const int kFloatSliderSaveStateRev = 6;
 }
 
 void FloatSlider::SaveState(FileStreamOut& out)
@@ -749,6 +749,7 @@ void FloatSlider::SaveState(FileStreamOut& out)
 
    out << mMin;
    out << mMax;
+   out << (int)mMode;
 
    bool hasLFO = mLFOControl && mLFOControl->Active();
    out << hasLFO;
@@ -808,6 +809,13 @@ void FloatSlider::LoadState(FileStreamIn& in, bool shouldSetValue)
    {
       in >> mMin;
       in >> mMax;
+   }
+
+   if (rev >= 6)
+   {
+      int modeInt;
+      in >> modeInt;
+      mMode = (Mode)modeInt;
    }
 
    if (rev >= 5)

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -212,6 +212,8 @@ public:
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override { mMouseDown = false; }
    bool IsMouseDown() const override { return mMouseDown; }
+   int GetMin() const { return mMin; }
+   int GetMax() const { return mMax; }
    void SetExtents(int min, int max)
    {
       mMin = min;


### PR DESCRIPTION
- fix modulator range not being set when attaching a modulator to a non-floatslider control
- fix modulator range not loading properly from a savestate