### PR TITLE
Fix some thread deadlocks with VST window creation

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -597,9 +597,12 @@ void VSTPlugin::Poll()
    {
       if (mPlugin != nullptr)
       {
-         if (mWindow == nullptr)
-            mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateVSTWindow(this, VSTWindow::Normal));
-         mWindow->ShowWindow();
+         juce::Timer::callAfterDelay(0, [this]() {
+                                        if (mWindow == nullptr)
+                                           mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateVSTWindow(this, VSTWindow::Normal));
+
+                                        mWindow->ShowWindow();
+                                     });
 
          //if (mWindow->GetNSViewComponent())
          //   mWindowOverlay = new NSWindowOverlay(mWindow->GetNSViewComponent()->getView());

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -597,7 +597,8 @@ void VSTPlugin::Poll()
    {
       if (mPlugin != nullptr)
       {
-         juce::Timer::callAfterDelay(0, [this]() {
+         juce::Timer::callAfterDelay(1, [this]()
+                                     {
                                         if (mWindow == nullptr)
                                            mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateVSTWindow(this, VSTWindow::Normal));
 


### PR DESCRIPTION
VCV Rack Pro would deadlock on creation of the UI window in bespoke since 3e1d28441. There are two thigns to fix this

1. Upgrade JUCE 7.0.1 to 7.0.2 and
2. Make sure to create the UI on the correct thread and not interleaved with a modal polling event by having the window creation done in a juce::Timer::callback scheduled onto ui thread.