### PR TITLE
fix deadlock when loading VCV Rack plugin and opening GUI

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -345,20 +345,14 @@ std::string VSTPlugin::GetPluginName() const
 std::string VSTPlugin::GetPluginFormatName() const
 {
    if (mPlugin)
-   {
-      const auto& desc = dynamic_cast<juce::AudioPluginInstance*>(mPlugin.get())->getPluginDescription();
-      return ofToString(desc.pluginFormatName.toLowerCase());
-   }
+      return mPluginFormatName;
    return "plugin";
 }
 
 std::string VSTPlugin::GetPluginId() const
 {
    if (mPlugin)
-   {
-      const auto& desc = dynamic_cast<juce::AudioPluginInstance*>(mPlugin.get())->getPluginDescription();
-      return GetPluginName() + "_" + ofToString(desc.uniqueId);
-   }
+      return mPluginId;
    return "no plugin loaded";
 }
 
@@ -487,6 +481,8 @@ void VSTPlugin::LoadVST(juce::PluginDescription desc)
       mPlugin->setPlayHead(&mPlayhead);
 
       mPluginName = mPlugin->getName().toStdString();
+      mPluginFormatName = ofToString(desc.pluginFormatName.toLowerCase());
+      mPluginId = GetPluginName() + "_" + ofToString(desc.uniqueId);
 
       CreateParameterSliders();
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -136,6 +136,8 @@ private:
    bool mPluginReady{ false };
    std::unique_ptr<juce::AudioProcessor> mPlugin;
    std::string mPluginName;
+   std::string mPluginFormatName;
+   std::string mPluginId;
    std::unique_ptr<VSTWindow> mWindow;
    juce::MidiBuffer mMidiBuffer;
    juce::MidiBuffer mFutureMidiBuffer;


### PR DESCRIPTION
eliminated unnecessary plugin locks that were being made in order to draw the module's title label. these locks seemed to interact poorly with locks made during VCV Rack's GUI's initialization.