### PR TITLE
Handle param rename events from plugins

### DIFF
--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -197,7 +197,7 @@ void FloatSlider::Render()
    else
    {
       if (mShowName)
-         display = std::string(Name());
+         display = std::string(mHasOverrideDisplayName ? mOverrideDisplayName : Name());
       if (display.length() > 0) //only show a colon if there's a label
          display += ":";
       if (mFloatEntry)

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -92,6 +92,11 @@ public:
    float GetModulationRangeMin() const override { return mMin; }
    float GetModulationRangeMax() const override { return mMax; }
    void OnTransportAdvanced(float amount) override;
+   void SetOverrideDisplayName(std::string name)
+   {
+      mHasOverrideDisplayName = true;
+      mOverrideDisplayName = name;
+   }
 
    void Init() override;
 
@@ -185,6 +190,8 @@ private:
    int mLastComputeSamplesIn{ 0 };
    double* mLastComputeCacheTime;
    float* mLastComputeCacheValue;
+   bool mHasOverrideDisplayName{ false };
+   std::string mOverrideDisplayName{ "" };
 
    float mLastDisplayedValue{ std::numeric_limits<float>::max() };
 

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -517,7 +517,7 @@ void VSTPlugin::CreateParameterSliders()
 
    const auto& parameters = mPlugin->getParameters();
 
-   int numParameters = MIN(10000, parameters.size());
+   int numParameters = parameters.size();
    mParameterSliders.resize(numParameters);
    for (int i = 0; i < numParameters; ++i)
    {

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -520,7 +520,7 @@ const std::string VSTPlugin::getUniquifiedParameterName(int i, const juce::Array
    try
    {
       int append = i;
-      while (ParameterNameExists(name, i) || FindUIControl(name.c_str()))
+      while (ParameterNameExists(name, i) || FindUIControl(name.c_str(), false))
       {
          ++append;
          name = originalParamName + std::to_string(append);

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -120,8 +120,9 @@ private:
 
    //juce::AudioProcessorListener
    void audioProcessorParameterChanged(juce::AudioProcessor* processor, int parameterIndex, float newValue) override {}
-   void audioProcessorChanged(juce::AudioProcessor* processor, const ChangeDetails& details) override {}
+   void audioProcessorChanged(juce::AudioProcessor* processor, const ChangeDetails& details) override;
    void audioProcessorParameterChangeGestureBegin(juce::AudioProcessor* processor, int parameterIndex) override;
+   const std::string getUniquifiedParameterName(int parameterIndex, const juce::Array<juce::AudioProcessorParameter*>&);
 
    float mVol{ 1 };
    FloatSlider* mVolSlider{ nullptr };
@@ -142,6 +143,7 @@ private:
    juce::MidiBuffer mMidiBuffer;
    juce::MidiBuffer mFutureMidiBuffer;
    juce::CriticalSection mMidiInputLock;
+   std::atomic<bool> mRescanParameterNames{ false };
    int mNumInputChannels{ 2 };
    int mNumOutputChannels{ 2 };
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -94,6 +94,7 @@ public:
    void ButtonClicked(ClickButton* button, double time) override;
 
    void OnUIControlRequested(const char* name) override;
+   virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
@@ -116,13 +117,11 @@ private:
    std::string GetPluginId() const;
    void CreateParameterSliders();
    void RefreshPresetFiles();
-   bool ParameterNameExists(std::string name, int checkUntilIndex) const;
 
    //juce::AudioProcessorListener
    void audioProcessorParameterChanged(juce::AudioProcessor* processor, int parameterIndex, float newValue) override {}
    void audioProcessorChanged(juce::AudioProcessor* processor, const ChangeDetails& details) override;
    void audioProcessorParameterChangeGestureBegin(juce::AudioProcessor* processor, int parameterIndex) override;
-   const std::string getUniquifiedParameterName(int parameterIndex, const juce::Array<juce::AudioProcessorParameter*>&);
 
    float mVol{ 1 };
    FloatSlider* mVolSlider{ nullptr };
@@ -152,13 +151,15 @@ private:
 
    struct ParameterSlider
    {
+      VSTPlugin* mOwner{ nullptr };
       float mValue{ 0 };
       FloatSlider* mSlider{ nullptr };
       juce::AudioProcessorParameter* mParameter{ nullptr };
       bool mShowing{ false };
       bool mInSelectorList{ true };
-      std::string mName;
-      void MakeSlider(VSTPlugin* owner);
+      std::string mDisplayName;
+      std::string mID;
+      void MakeSlider();
    };
 
    std::vector<ParameterSlider> mParameterSliders;
@@ -169,6 +170,7 @@ private:
    float mPitchBendRange{ 2 };
    int mModwheelCC{ 1 }; //or 74 in Multidimensional Polyphonic Expression (MPE) spec
    std::string mOldVstPath{ "" }; //for loading save files that predate pluginId-style saving
+   int mParameterVersion{ 1 };
 
    struct ChannelModulations
    {


### PR DESCRIPTION
Parameter renames create a changed event, so use that event to make the subsequent poll rename the associated sliders. This makes VCVRack Pro basically usable for automation but I bet it also fixes the problems with F-Em and others.

One change: Since the rack parameter names are quite long (things like "Attack (Bog Audio ADSR module)") I changed the param name query from 32 to 64 characters in the newly introduced get-name function.