### PR TITLE
use a slider's override display name for the midi activity popup

### DIFF
--- a/Source/IClickable.cpp
+++ b/Source/IClickable.cpp
@@ -139,14 +139,16 @@ IDrawableModule* IClickable::GetModuleParent()
    return dynamic_cast<IDrawableModule*>(parent);
 }
 
-std::string IClickable::Path(bool ignoreContext)
+std::string IClickable::Path(bool ignoreContext, bool useDisplayName)
 {
    if (mName[0] == 0) //must have a name
       return "";
 
-   std::string path = mName;
+   std::string name = useDisplayName ? GetDisplayName() : mName;
+
+   std::string path = name;
    if (mParent != nullptr)
-      path = mParent->Path(true) + "~" + mName;
+      path = mParent->Path(true) + "~" + name;
 
    if (!ignoreContext)
    {

--- a/Source/IClickable.h
+++ b/Source/IClickable.h
@@ -71,7 +71,7 @@ public:
    }
    const char* Name() const { return mName; }
    char* NameMutable() { return mName; }
-   std::string Path(bool ignoreContext = false);
+   std::string Path(bool ignoreContext = false, bool useDisplayName = false);
    virtual bool CheckNeedsDraw();
    virtual void SetShowing(bool showing) { mShowing = showing; }
    bool IsShowing() const { return mShowing; }
@@ -80,6 +80,15 @@ public:
    void DrawBeacon(int x, int y);
    IClickable* GetRootParent();
    IDrawableModule* GetModuleParent();
+   void SetOverrideDisplayName(std::string name)
+   {
+      mHasOverrideDisplayName = true;
+      mOverrideDisplayName = name;
+   }
+   std::string GetDisplayName()
+   {
+      return mHasOverrideDisplayName ? mOverrideDisplayName : mName;
+   }
 
    static void SetLoadContext(IClickable* context) { sPathLoadContext = context->Path() + "~"; }
    static void ClearLoadContext() { sPathLoadContext = ""; }
@@ -102,6 +111,8 @@ protected:
 private:
    char mName[MAX_TEXTENTRY_LENGTH]{};
    double mBeaconTime{ -999 };
+   bool mHasOverrideDisplayName{ false };
+   std::string mOverrideDisplayName{ "" };
 };
 
 #endif /* defined(__modularSynth__IClickable__) */

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -197,7 +197,7 @@ void FloatSlider::Render()
    else
    {
       if (mShowName)
-         display = std::string(mHasOverrideDisplayName ? mOverrideDisplayName : Name());
+         display = GetDisplayName();
       if (display.length() > 0) //only show a colon if there's a label
          display += ":";
       if (mFloatEntry)
@@ -951,7 +951,7 @@ void IntSlider::Render()
 
    std::string display;
    if (mShowName)
-      display = std::string(Name());
+      display = GetDisplayName();
    if (display.length() > 0) //only show a colon if there's a label
       display += ":";
    if (mIntEntry)

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -92,11 +92,6 @@ public:
    float GetModulationRangeMin() const override { return mMin; }
    float GetModulationRangeMax() const override { return mMax; }
    void OnTransportAdvanced(float amount) override;
-   void SetOverrideDisplayName(std::string name)
-   {
-      mHasOverrideDisplayName = true;
-      mOverrideDisplayName = name;
-   }
 
    void Init() override;
 
@@ -190,8 +185,6 @@ private:
    int mLastComputeSamplesIn{ 0 };
    double* mLastComputeCacheTime;
    float* mLastComputeCacheValue;
-   bool mHasOverrideDisplayName{ false };
-   std::string mOverrideDisplayName{ "" };
 
    float mLastDisplayedValue{ std::numeric_limits<float>::max() };
 

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -493,7 +493,7 @@ void TitleBar::DrawModuleUnclipped()
       {
          drawControl = MidiController::sLastActivityUIControl;
          if (drawControl != nullptr)
-            displayString = drawControl->Path() + ": " + drawControl->GetDisplayValue(drawControl->GetValue());
+            displayString = drawControl->Path(false, true) + ": " + drawControl->GetDisplayValue(drawControl->GetValue());
       }
 
       if (!displayString.empty() && drawControl != nullptr)


### PR DESCRIPTION
to make it easier to use despite plugin sliders all being named things like "param_5193123"