### PR TITLE
change up notesequencer grid to make it easier to vary note length

### DIFF
--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -37,7 +37,6 @@
 
 NoteStepSequencer::NoteStepSequencer()
 {
-
    for (int i = 0; i < NSS_MAX_STEPS; ++i)
    {
       mVels[i] = ofRandom(1) < .5f ? 127 : 0;

--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -41,7 +41,7 @@ NoteStepSequencer::NoteStepSequencer()
    for (int i = 0; i < NSS_MAX_STEPS; ++i)
    {
       mVels[i] = ofRandom(1) < .5f ? 127 : 0;
-      mNoteLengths[i] = 1;
+      mNoteLengths[i] = ofRandom(1) < .5f ? .5f : 1;
    }
 
    RandomizePitches(false);
@@ -58,11 +58,9 @@ void NoteStepSequencer::CreateUIControls()
    UIBLOCK_SHIFTX(58);
    BUTTON(mRandomizePitchButton, "pitch");
    UIBLOCK_SHIFTRIGHT();
-   BUTTON(mRandomizeVelocityButton, "vel");
+   BUTTON(mRandomizeAllButton, "all");
    UIBLOCK_SHIFTRIGHT();
-   BUTTON(mRandomizeLengthButton, "len");
-   UIBLOCK_SHIFTRIGHT();
-   UIBLOCK_SHIFTX(5);
+   UIBLOCK_SHIFTX(30);
    UICONTROL_CUSTOM(mGridControlTarget, new GridControlTarget(UICONTROL_BASICS("grid")));
    UIBLOCK_SHIFTRIGHT();
    INTSLIDER(mGridControlOffsetXSlider, "x offset", &mGridControlOffsetX, 0, 16);
@@ -96,9 +94,10 @@ void NoteStepSequencer::CreateUIControls()
    FLOATSLIDER(mRandomizeVelocityDensitySlider, "rand vel density", &mRandomizeVelocityDensity, 0, 1);
    ENDUIBLOCK0();
 
-   mGrid = new UIGrid("notegrid", 5, 55, 210, 80, 8, 24, this);
-   mVelocityGrid = new UIGrid("velocitygrid", 5, 117, 200, 45, 8, 1, this);
+   mGrid = new UIGrid("notegrid", 5, 55, 210, 110, 8, 24, this);
+   mVelocityGrid = new UIGrid("velocitygrid", 5, 147, 200, 45, 8, 1, this);
    mLoopResetPointSlider = new IntSlider(this, "loop reset", -1, -1, 100, 15, &mLoopResetPoint, 0, mLength);
+   mGrid->SetClickValueSubdivisions(mStepLengthSubdivisions);
 
    for (int i = 0; i < NSS_MAX_STEPS; ++i)
    {
@@ -144,8 +143,7 @@ void NoteStepSequencer::CreateUIControls()
 
    mLoopResetPointSlider->SetShowing(mHasExternalPulseSource);
 
-   mRandomizeLengthButton->PositionTo(mRandomizePitchButton, kAnchor_Right);
-   mRandomizeVelocityButton->PositionTo(mRandomizeLengthButton, kAnchor_Right);
+   mRandomizeAllButton->PositionTo(mRandomizePitchButton, kAnchor_Right);
 
    for (int i = 0; i < NSS_MAX_STEPS; ++i)
    {
@@ -208,8 +206,7 @@ void NoteStepSequencer::DrawModule()
    mShiftForwardButton->Draw();
    mClearButton->Draw();
    mRandomizePitchButton->Draw();
-   mRandomizeLengthButton->Draw();
-   mRandomizeVelocityButton->Draw();
+   mRandomizeAllButton->Draw();
    mLoopResetPointSlider->Draw();
    mGridControlTarget->Draw();
    mGridControlOffsetXSlider->Draw();
@@ -582,7 +579,6 @@ void NoteStepSequencer::Step(double time, float velocity, int pulseFlags)
    if (mVels[mArpIndex] <= 1)
    {
       mLastPitch = -1;
-      mLastVel = 0;
    }
    else
    {
@@ -602,10 +598,8 @@ void NoteStepSequencer::Step(double time, float velocity, int pulseFlags)
          if (mShowStepControls && mArpIndex < (int)mStepCables.size())
             SendNoteToCable(mArpIndex, time, outPitch, mVels[mArpIndex] * velocity);
          mLastPitch = outPitch;
-         mLastVel = mVels[mArpIndex];
          mLastStepIndex = mArpIndex;
          mLastNoteLength = mNoteLengths[mArpIndex];
-         mLastNoteStartTime = time;
          mLastNoteEndTime = time + mLastNoteLength * TheTransport->GetDuration(mInterval);
          mLastStepPlayTime[mArpIndex] = time;
          mAlreadyDidNoteOff = false;
@@ -620,7 +614,6 @@ void NoteStepSequencer::Step(double time, float velocity, int pulseFlags)
       if (offPitch == mLastPitch)
       {
          mLastPitch = -1;
-         mLastVel = 0;
       }
    }
 
@@ -873,8 +866,10 @@ void NoteStepSequencer::ButtonClicked(ClickButton* button, double time)
       RandomizePitches(GetKeyModifiers() & kModifier_Shift);
       SyncGridToSeq();
    }
-   if (button == mRandomizeLengthButton)
+   if (button == mRandomizeAllButton)
    {
+      RandomizePitches(GetKeyModifiers() & kModifier_Shift);
+
       for (int i = 0; i < mLength; ++i)
       {
          if (ofRandom(1) <= mRandomizeLengthChance)
@@ -882,13 +877,7 @@ void NoteStepSequencer::ButtonClicked(ClickButton* button, double time)
             float newLength = ofClamp(ofRandom(2), FLT_EPSILON, 1);
             mNoteLengths[i] = ofLerp(mNoteLengths[i], newLength, mRandomizeLengthRange);
          }
-      }
-      SyncGridToSeq();
-   }
-   if (button == mRandomizeVelocityButton)
-   {
-      for (int i = 0; i < mLength; ++i)
-      {
+
          if (ofRandom(1) <= mRandomizeVelocityChance)
          {
             int newVelocity = 0;
@@ -1088,6 +1077,7 @@ void NoteStepSequencer::LoadLayout(const ofxJSONElement& moduleInfo)
    mModuleSaveData.LoadInt("gridrows", moduleInfo, 15, 1, 127, K(isTextField));
    mModuleSaveData.LoadInt("gridsteps", moduleInfo, 8, 1, NSS_MAX_STEPS, K(isTextField));
    mModuleSaveData.LoadBool("stepcontrols", moduleInfo, false);
+   mModuleSaveData.LoadInt("steplengthsubdivisions", moduleInfo, 2, 1, 8, K(isTextField));
 
    SetUpFromSaveData();
 }
@@ -1098,9 +1088,11 @@ void NoteStepSequencer::SetUpFromSaveData()
    SetMidiController(mModuleSaveData.GetString("controller"));
    mNoteRange = mModuleSaveData.GetInt("gridrows");
    mShowStepControls = mModuleSaveData.GetBool("stepcontrols");
+   mStepLengthSubdivisions = mModuleSaveData.GetInt("steplengthsubdivisions");
    UpdateVelocityGridPos();
    SyncGridToSeq();
    SetUpStepControls();
+   mGrid->SetClickValueSubdivisions(mStepLengthSubdivisions);
 }
 
 void NoteStepSequencer::SaveState(FileStreamOut& out)

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -160,14 +160,11 @@ private:
    int mArpIndex{ -1 };
 
    DropdownList* mIntervalSelector{ nullptr };
-   Checkbox* mRepeatIsHoldCheckbox{ nullptr };
    UIGrid* mGrid{ nullptr };
    UIGrid* mVelocityGrid{ nullptr };
    int mLastPitch{ -1 };
-   int mLastVel{ 0 };
    int mLastStepIndex{ -1 };
    float mLastNoteLength{ 1 };
-   double mLastNoteStartTime{ 0 };
    double mLastNoteEndTime{ 0 };
    bool mAlreadyDidNoteOff{ false };
    int mOctave{ 3 };
@@ -176,6 +173,7 @@ private:
    DropdownList* mNoteModeSelector{ nullptr };
    IntSlider* mLoopResetPointSlider{ nullptr };
    int mLoopResetPoint{ 0 };
+   int mStepLengthSubdivisions{ 2 };
 
    int mLength{ 8 };
    IntSlider* mLengthSlider{ nullptr };
@@ -191,8 +189,7 @@ private:
    ClickButton* mClearButton{ nullptr };
 
    ClickButton* mRandomizePitchButton{ nullptr };
-   ClickButton* mRandomizeLengthButton{ nullptr };
-   ClickButton* mRandomizeVelocityButton{ nullptr };
+   ClickButton* mRandomizeAllButton{ nullptr };
    float mRandomizePitchChance{ 1 };
    int mRandomizePitchVariety{ 4 };
    float mRandomizeLengthChance{ 1 };

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -23,8 +23,7 @@
 //
 //
 
-#ifndef __modularSynth__NoteStepSequencer__
-#define __modularSynth__NoteStepSequencer__
+#pragma once
 
 #include <iostream>
 #include "INoteReceiver.h"
@@ -219,6 +218,3 @@ private:
    IntSlider* mGridControlOffsetXSlider{ nullptr };
    IntSlider* mGridControlOffsetYSlider{ nullptr };
 };
-
-
-#endif /* defined(__modularSynth__NoteStepSequencer__) */

--- a/Source/UIGrid.h
+++ b/Source/UIGrid.h
@@ -91,6 +91,8 @@ public:
    void SetMomentary(bool momentary) { mMomentary = momentary; }
    const std::array<float, MAX_GRID_SIZE * MAX_GRID_SIZE>& GetData() const { return mData; }
    void SetData(std::array<float, MAX_GRID_SIZE * MAX_GRID_SIZE>& data) { mData = data; }
+   void SetClickValueSubdivisions(int subdivisions) { mClickSubdivisions = subdivisions; }
+   float GetSubdividedValue(float position) const;
 
    enum GridMode
    {
@@ -152,6 +154,7 @@ private:
    bool mFlip{ false };
    float mStrength{ 1 };
    int mCurrentHover{ -1 };
+   float mCurrentHoverAmount{ 1 };
    UIGridListener* mListener{ nullptr };
    std::array<float, MAX_GRID_SIZE> mDrawOffset{};
    GridMode mGridMode{ GridMode::kNormal };
@@ -159,6 +162,7 @@ private:
    bool mRequireShiftForMultislider{ false };
    bool mShouldDrawValue{ false };
    bool mMomentary{ false };
+   int mClickSubdivisions{ 1 };
 };
 
 #endif /* defined(__modularSynth__Grid__) */


### PR DESCRIPTION
now you can set step length by clicking in the first half or second half of a grid square. you can also change this subdivision in the triangle menu, rather than only having 2 lengths. if you set "steplengthsubdivisions" to 1, it will behave how it did before this change.