### PR TITLE
notesequencer cleanup

### DIFF
--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -140,6 +140,8 @@ private:
    float ExtraWidth() const;
    float ExtraHeight() const;
    void RandomizePitches(bool fifths);
+   void RandomizeVelocities();
+   void RandomizeLengths();
    void Step(double time, float velocity, int pulseFlags);
    void SendNoteToCable(int index, double time, int pitch, int velocity);
 
@@ -187,8 +189,10 @@ private:
    ClickButton* mShiftForwardButton{ nullptr };
    ClickButton* mClearButton{ nullptr };
 
-   ClickButton* mRandomizePitchButton{ nullptr };
    ClickButton* mRandomizeAllButton{ nullptr };
+   ClickButton* mRandomizePitchButton{ nullptr };
+   ClickButton* mRandomizeLengthButton{ nullptr };
+   ClickButton* mRandomizeVelocityButton{ nullptr };
    float mRandomizePitchChance{ 1 };
    int mRandomizePitchVariety{ 4 };
    float mRandomizeLengthChance{ 1 };

--- a/Source/UIGrid.cpp
+++ b/Source/UIGrid.cpp
@@ -337,7 +337,7 @@ bool UIGrid::MouseMoved(float x, float y)
       cell.mRow = mHoldRow;
    }
 
-   if (mGridMode == kHorislider && CanAdjustMultislider())
+   if (mClick && mGridMode == kHorislider && CanAdjustMultislider())
    {
       if (cell.mCol > mHoldCol)
          clickWidth = 1;
@@ -350,7 +350,9 @@ bool UIGrid::MouseMoved(float x, float y)
    {
       mCurrentHover = cell.mCol + cell.mRow * mCols;
 
-      if (mClickSubdivisions != -1)
+      if (mGridMode == kHorislider && CanAdjustMultislider())
+         mCurrentHoverAmount = clickWidth;
+      else if (mClickSubdivisions != -1)
          mCurrentHoverAmount = GetSubdividedValue(clickWidth);
       else
          mCurrentHoverAmount = 1;
@@ -389,7 +391,7 @@ bool UIGrid::MouseMoved(float x, float y)
 
          if (CanAdjustMultislider())
             val = clickWidth;
-         if (mClickSubdivisions != 1)
+         else if (mClickSubdivisions != 1)
             val = GetSubdividedValue(clickWidth);
 
          mData[dataIndex] = val;

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -476,6 +476,7 @@ notesinger~output a note based on a detected pitch
 
 notesequencer~looping sequence of notes at an interval. pair with a "pulser" module for more interesting step control. hold "shift" to adjust step length.
 ~interval~note length
+~random~randomize pitch, length, and velocity of all steps.
 ~pitch~randomize pitches in the sequence. hold shift to constrain the randomization to only pick roots and fifths.
 ~len~randomize the length of each step's note.
 ~vel~randomize the velocity of each step's note.
@@ -493,7 +494,7 @@ notesequencer~looping sequence of notes at an interval. pair with a "pulser" mod
 ~x offset~x offset of attached grid controller
 ~y offset~y offset of attached grid controller
 ~rand pitch chance~when clicking the random pitch button, what is the chance that a step gets changed?
-~rand pitch range~when clicking the random pitch button, how far will the pitch change?
+~rand pitch variety~how many different random pitches should we generate?
 ~rand len chance~when clicking the random length button, what is the chance that a step gets changed?
 ~rand len range~when clicking the random length button, how much will the length change?
 ~rand vel chance~when clicking the random velocity button, what is the chance that a step gets changed?


### PR DESCRIPTION
restore length and velocity randomization buttons that were removed in #956, and change new "all" button to just "random"
fix shift-dragging on grid not allowing you to set high-res length when subdivisions are enabled
fix #813 (I think!)
