### PR TITLE
change default zoom level and ui scale of bespoke to 1.3

### DIFF
--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -696,10 +696,10 @@ void SongBuilder::LoadLayout(const ofxJSONElement& moduleInfo)
       mScenes.push_back(new SongScene("off"));
       mScenes.push_back(new SongScene("intro"));
       mScenes.push_back(new SongScene("verse"));
+      mScenes.push_back(new SongScene("prechorus"));
       mScenes.push_back(new SongScene("chorus"));
       mScenes.push_back(new SongScene("bridge"));
       mScenes.push_back(new SongScene("outro"));
-      mScenes.push_back(new SongScene("done"));
       for (auto* scene : mScenes)
          scene->CreateUIControls(this);
 

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -301,8 +301,8 @@ public:
    UserPrefBool set_manual_window_position{ "set_manual_window_position", false, UserPrefCategory::General };
    UserPrefTextEntryInt position_x{ "position_x", 200, -10000, 10000, 5, UserPrefCategory::General };
    UserPrefTextEntryInt position_y{ "position_y", 200, -10000, 10000, 5, UserPrefCategory::General };
-   UserPrefFloat zoom{ "zoom", 1, .25f, 2, UserPrefCategory::General };
-   UserPrefFloat ui_scale{ "ui_scale", 1, .25f, 2, UserPrefCategory::General };
+   UserPrefFloat zoom{ "zoom", 1.3f, .25f, 2, UserPrefCategory::General };
+   UserPrefFloat ui_scale{ "ui_scale", 1.3f, .25f, 2, UserPrefCategory::General };
    UserPrefFloat grid_snap_size{ "grid_snap_size", 30, 5, 150, UserPrefCategory::General };
    UserPrefFloat scroll_multiplier_vertical{ "scroll_multiplier_vertical", 1, -2, 2, UserPrefCategory::General };
    UserPrefFloat scroll_multiplier_horizontal{ "scroll_multiplier_horizontal", 1, -2, 2, UserPrefCategory::General };


### PR DESCRIPTION
I thought I had done this months ago! whoops. won't affect users who already have launched bespoke, but when a userprefs.json is created, it will use 1.3 as the zoom level, which is how I've been using bespoke for the past few months.

also snuck in a change to the default scenes for songbuilder