### PR TITLE
raise the ceiling for maximum json layout size

### DIFF
--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -149,9 +149,9 @@ FileStreamIn& FileStreamIn::operator>>(std::string& var)
    }
 
    if (TheSynth->IsLoadingModule())
-      LoadStateValidate(len < 99999); //probably garbage beyond this point
+      LoadStateValidate(len < sMaxStringLength); //probably garbage beyond this point
    else
-      assert(len < 99999); //probably garbage beyond this point
+      assert(len < sMaxStringLength); //probably garbage beyond this point
 
    var.resize(len);
    mStream->read(var.data(), len);

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -76,6 +76,7 @@ public:
    bool OpenedOk() const;
    bool Eof() const;
    static bool s32BitMode;
+   static const int sMaxStringLength = 999999;  //the primary thing that might hit this limit is the json layout file (one user has had a file that exceeded a length of 100000)
 
 private:
    std::unique_ptr<juce::FileInputStream> mStream;

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -76,7 +76,7 @@ public:
    bool OpenedOk() const;
    bool Eof() const;
    static bool s32BitMode;
-   static const int sMaxStringLength = 999999;  //the primary thing that might hit this limit is the json layout file (one user has had a file that exceeded a length of 100000)
+   static const int sMaxStringLength = 999999; //the primary thing that might hit this limit is the json layout file (one user has had a file that exceeded a length of 100000)
 
 private:
    std::unique_ptr<juce::FileInputStream> mStream;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2717,7 +2717,7 @@ void ModularSynth::LoadState(std::string file)
    //this should definitely be removed if anything about the structure of the BSK format changes.
    uint64_t firstLength[1];
    in.Peek(firstLength, sizeof(uint64_t));
-   if (firstLength[0] >= 99999)
+   if (firstLength[0] >= FileStreamIn::sMaxStringLength)
       FileStreamIn::s32BitMode = true;
 
    std::string jsonString;

--- a/Source/ofxJSONElement.cpp
+++ b/Source/ofxJSONElement.cpp
@@ -37,11 +37,12 @@ bool ofxJSONElement::parse(std::string jsonString)
 {
    CharReaderBuilder rb;
    auto reader = std::unique_ptr<Json::CharReader>(rb.newCharReader());
+   Json::String errors;
    if (!reader->parse(jsonString.c_str(),
                       jsonString.c_str() + jsonString.size(),
-                      this, nullptr))
+                      this, &errors))
    {
-      ofLog() << "Unable to parse string";
+      ofLog() << "Unable to parse string: " << errors;
       return false;
    }
    return true;


### PR DESCRIPTION
a user had a >100000 string length, which was breaking load. will I have to raise this limit again someday? probably.