### PR TITLE
script module: only automatically turn on scheduling lookahead when a note cable is connected

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -98,8 +98,6 @@ ScriptModule::ScriptModule()
    sScriptModules.push_back(this);
 
    OSCReceiver::addListener(this);
-
-   Transport::sDoEventLookahead = true; //scripts require lookahead to be able to schedule on time
 }
 
 ScriptModule::~ScriptModule()
@@ -466,6 +464,12 @@ void ScriptModule::DrawModuleUnclipped()
    }
 
    ofPopStyle();
+}
+
+void ScriptModule::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)
+{
+   if (cableSource->GetTarget() != nullptr && cableSource->GetConnectionType() == kConnectionType_Note)
+      Transport::sDoEventLookahead = true; //scripts that output notes require lookahead to be able to schedule on time
 }
 
 bool ScriptModule::MouseMoved(float x, float y)

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -156,6 +156,9 @@ private:
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 
+   //IPatchable
+   void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
+
    ClickButton* mPythonInstalledConfirmButton{ nullptr };
    DropdownList* mLoadScriptSelector{ nullptr };
    ClickButton* mLoadScriptButton{ nullptr };


### PR DESCRIPTION
this way, utility scripts don't enable lookahead unnecessarily