### PR TITLE
fix issue where presets didn't load properly if pointed at large grids

### DIFF
--- a/Source/Presets.cpp
+++ b/Source/Presets.cpp
@@ -599,12 +599,15 @@ void Presets::LoadState(FileStreamIn& in, int rev)
          presetData.mLFOSettings.LoadState(in);
          in >> presetData.mGridCols;
          in >> presetData.mGridRows;
-         // Check if the loaded values are within an accaptable range.
-         // This is done because mGridCols and mGridRows could previously be saved with random values since they were not properly initialized.
-         if (presetData.mGridCols < 0 || presetData.mGridCols > maxGridSide)
-            presetData.mGridCols = 0;
-         if (presetData.mGridRows < 0 || presetData.mGridRows > maxGridSide)
-            presetData.mGridRows = 0;
+         if (rev < 3)
+         {
+            // Check if the loaded values are within an acceptable range.
+            // This is done because mGridCols and mGridRows could previously be saved with random values since they were not properly initialized.
+            if (presetData.mGridCols < 0 || presetData.mGridCols > 1000)
+               presetData.mGridCols = 0;
+            if (presetData.mGridRows < 0 || presetData.mGridRows > 1000)
+               presetData.mGridRows = 0;
+         }
          presetData.mGridContents.resize(size_t(presetData.mGridCols) * presetData.mGridRows);
          for (int k = 0; k < presetData.mGridCols * presetData.mGridRows; ++k)
             in >> presetData.mGridContents[k];

--- a/Source/Presets.h
+++ b/Source/Presets.h
@@ -75,7 +75,7 @@ public:
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;
    bool LoadOldControl(FileStreamIn& in, std::string& oldName) override;
-   int GetModuleSaveStateRev() const override { return 2; }
+   int GetModuleSaveStateRev() const override { return 3; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
    void UpdateOldControlName(std::string& oldName) override;
 


### PR DESCRIPTION
caused by mixup between the size of the preset grid and the size of a targeted grid. any grid larger than 20x20 in either dimension wouldn't be able to load.