### PR TITLE
add (computationally expensive) mode to recalculate EQ params per-sample

### DIFF
--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -115,4 +115,5 @@ private:
    std::array<float, 1024> mFrequencyResponse{};
    bool mNeedToUpdateFrequencyResponseGraph{ true };
    float mDrawGain{ 1 };
+   bool mLiteCpuModulation{ true };
 };

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -580,7 +580,7 @@ void ModuleContainer::SaveState(FileStreamOut& out)
    int savedModules = 0;
    for (auto* module : mModules)
    {
-      if (module != TheSaveDataPanel && module != TheTitleBar)
+      if (module->IsSaveable())
          ++savedModules;
    }
 
@@ -591,7 +591,7 @@ void ModuleContainer::SaveState(FileStreamOut& out)
 
    for (auto* module : mModules)
    {
-      if (module != TheSaveDataPanel && module != TheTitleBar)
+      if (module->IsSaveable())
       {
          //ofLog() << "Saving " << module->Name();
          out << std::string(module->Name());

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -609,7 +609,7 @@ void FloatSlider::DoCompute(int samplesIn /*= 0*/)
    float oldVal = *mVar;
 
    const bool kUseCache = true;
-   if (kUseCache && samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] == gTime)
+   if (kUseCache && IsAudioThread() && samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] == gTime)
    {
       *mVar = mLastComputeCacheValue[samplesIn];
    }
@@ -626,7 +626,7 @@ void FloatSlider::DoCompute(int samplesIn /*= 0*/)
       if (mIsSmoothing)
          *mVar = mRamp.Value(gTime + samplesIn * gInvSampleRateMs);
 
-      if (samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] != gTime)
+      if (IsAudioThread() && samplesIn >= 0 && samplesIn < gBufferSize && mLastComputeCacheTime[samplesIn] != gTime)
       {
          mLastComputeCacheValue[samplesIn] = *mVar;
          mLastComputeCacheTime[samplesIn] = gTime;


### PR DESCRIPTION
also:
- fix issue where minimap was trying to save state when it shouldn't
- only cache modulated slider values on the audio thread, to avoid thread safety issues