### PR TITLE
fix randomly-occurring dc offset on modules that use switch-and-ramp

### DIFF
--- a/Source/QuickSpawnMenu.cpp
+++ b/Source/QuickSpawnMenu.cpp
@@ -115,7 +115,7 @@ void QuickSpawnMenu::KeyPressed(int key, bool isRepeat)
    if (!IsShowing())
       ResetAppearPos();
 
-   if (!IsShowing() && PatchCable::sActivePatchCable != nullptr)
+   if (!IsShowing() && PatchCable::sActivePatchCable != nullptr && key >= 'a' && key <= 'z')
       PatchCable::sActivePatchCable->ShowQuickspawnForCable();
 
    if ((!IsShowing() || mMenuMode == MenuMode::SingleLetter) && key >= 0 && key < CHAR_MAX && ((key >= 'a' && key <= 'z') || key == ';') && !isRepeat && GetKeyModifiers() == kModifier_None)

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -504,7 +504,6 @@ void SamplePlayer::UpdateSample(Sample* sample, bool ownsSample)
    sample->SetLooping(mLoop);
    sample->SetRate(mSpeed);
    mSample = sample;
-   mVolume = 1;
    mPlay = false;
    mOwnsSample = ownsSample;
    mZoomLevel = 1;

--- a/Source/SwitchAndRamp.cpp
+++ b/Source/SwitchAndRamp.cpp
@@ -25,6 +25,13 @@
 
 #include "SwitchAndRamp.h"
 
+SwitchAndRamp::SwitchAndRamp()
+{
+   mSwitching.fill(false);
+   mLastOutput.fill(0);
+   mOffset.fill(0);
+}
+
 void SwitchAndRamp::StartSwitch()
 {
    mSwitching.fill(true);

--- a/Source/SwitchAndRamp.h
+++ b/Source/SwitchAndRamp.h
@@ -30,6 +30,7 @@
 class SwitchAndRamp
 {
 public:
+   SwitchAndRamp();
    void StartSwitch();
    float Process(int channel, float input, float rampSpeed = .005f);
 


### PR DESCRIPTION
fixes #1016

also fixed:
- sampleplayer not correctly restoring saved volume
- space bar triggering quickspawn menu while holding patch cable