### PR TITLE
Notestepper chord mode toggle addition. Resolves: #1068.

### DIFF
--- a/Source/NoteStepper.cpp
+++ b/Source/NoteStepper.cpp
@@ -86,7 +86,7 @@ void NoteStepper::PlayNote(double time, int pitch, int velocity, int voiceIdx, M
    int selectedDestination = 0;
    if (velocity > 0)
    {
-      if (time > mLastNoteOnTime + 10) //slop, to make a chord count as a single step
+      if (time > mLastNoteOnTime + 10 || !mAllowChords) //slop, to make a chord count as a single step
          mCurrentDestinationIndex = (mCurrentDestinationIndex + 1) % mLength;
 
       selectedDestination = mCurrentDestinationIndex;
@@ -125,11 +125,14 @@ void NoteStepper::ButtonClicked(ClickButton* button, double time)
 
 void NoteStepper::LoadLayout(const ofxJSONElement& moduleInfo)
 {
+   mModuleSaveData.LoadBool("allow_chords", moduleInfo, false);
+
    SetUpFromSaveData();
 }
 
 void NoteStepper::SetUpFromSaveData()
 {
+   mAllowChords = mModuleSaveData.GetBool("allow_chords");
 }
 
 void NoteStepper::SaveLayout(ofxJSONElement& moduleInfo)

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -78,4 +78,5 @@ private:
    int mLength{ 4 };
    IntSlider* mLengthSlider{ nullptr };
    double mLastNoteOnTime{ -9999 };
+   bool mAllowChords{ false };
 };


### PR DESCRIPTION
Added option to the notestepper module to toggle allow chord mode. With this on the behavior is as it used to be. With it off the notestepper module can be used to split chord notes into separate note cables.

Resolves: #1068.