### PR TITLE
Allow multiple instances of sampleplayers to download different youtube videos at the same time.

### DIFF
--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -676,6 +676,10 @@ void SamplePlayer::OnYoutubeDownloadComplete(std::string filename, std::string t
       UpdateSample(new Sample(), true);
       mErrorString = "couldn't download sample. do you have youtube-dl and ffmpeg installed,\nwith their paths set in userprefs.json?";
    }
+
+   auto file = juce::File(ofToDataPath(filename));
+   if (file.existsAsFile())
+      file.deleteFile();
 }
 
 void SamplePlayer::RunProcess(const StringArray& args)

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -624,16 +624,16 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    if (mSample)
       mSample->SetPlayPosition(0);
 
-   auto tempDownloadName = juce::String(this->GetDisplayName() + "_youtube.m4a").retainCharacters("abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_.");
+   auto tempDownloadName = ofToString(this) + "_youtube.m4a";
    {
-      auto file = juce::File(ofToDataPath(tempDownloadName.toStdString()));
+      auto file = juce::File(ofToDataPath(tempDownloadName));
       if (file.existsAsFile())
          file.deleteFile();
    }
 
-   auto tempConvertedName = juce::String(this->GetDisplayName() + "_youtube.wav").retainCharacters("abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_.");
+   auto tempConvertedName = ofToString(this) + "_youtube.wav";
    {
-      auto file = juce::File(ofToDataPath(tempConvertedName.toStdString()));
+      auto file = juce::File(ofToDataPath(tempConvertedName));
       if (file.existsAsFile())
          file.deleteFile();
    }
@@ -650,13 +650,13 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    args.add("--ffmpeg-location");
    args.add(UserPrefs.ffmpeg_path.Get());
    args.add("-o");
-   args.add(ofToDataPath(tempDownloadName.toStdString()));
+   args.add(ofToDataPath(tempDownloadName));
 
    mRunningProcessType = RunningProcessType::DownloadYoutube;
 
    mOnRunningProcessComplete = [this, tempConvertedName, title]
    {
-      OnYoutubeDownloadComplete(tempConvertedName.toStdString(), title);
+      OnYoutubeDownloadComplete(tempConvertedName, title);
    };
 
    RunProcess(args);

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -624,16 +624,16 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    if (mSample)
       mSample->SetPlayPosition(0);
 
-   const char* tempDownloadName = "youtube.m4a";
+   auto tempDownloadName = juce::String(this->GetDisplayName() + "_youtube.m4a").retainCharacters("abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_.");
    {
-      auto file = juce::File(ofToDataPath(tempDownloadName));
+      auto file = juce::File(ofToDataPath(tempDownloadName.toStdString()));
       if (file.existsAsFile())
          file.deleteFile();
    }
 
-   const char* tempConvertedName = "youtube.wav";
+   auto tempConvertedName = juce::String(this->GetDisplayName() + "_youtube.wav").retainCharacters("abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_.");
    {
-      auto file = juce::File(ofToDataPath(tempConvertedName));
+      auto file = juce::File(ofToDataPath(tempConvertedName.toStdString()));
       if (file.existsAsFile())
          file.deleteFile();
    }
@@ -650,13 +650,13 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    args.add("--ffmpeg-location");
    args.add(UserPrefs.ffmpeg_path.Get());
    args.add("-o");
-   args.add(ofToDataPath(tempDownloadName));
+   args.add(ofToDataPath(tempDownloadName.toStdString()));
 
    mRunningProcessType = RunningProcessType::DownloadYoutube;
 
    mOnRunningProcessComplete = [this, tempConvertedName, title]
    {
-      OnYoutubeDownloadComplete(tempConvertedName, title);
+      OnYoutubeDownloadComplete(tempConvertedName.toStdString(), title);
    };
 
    RunProcess(args);


### PR DESCRIPTION
I know this isn't entirely fool proof since in theory people can still have the same named sampleplayer (i.e. in a prefab).

Maybe I should use the full module path instead?