### PR TITLE
Make the `notedelayer` module pass through the notes if it is disabled. Resolves: #190.

### DIFF
--- a/Source/NoteDelayer.cpp
+++ b/Source/NoteDelayer.cpp
@@ -105,7 +105,10 @@ void NoteDelayer::OnTransportAdvanced(float amount)
 void NoteDelayer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
 {
    if (!mEnabled)
+   {
+      PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation); // Passthrough notes.
       return;
+   }
 
    if (velocity > 0)
       mLastNoteOnTime = time;


### PR DESCRIPTION
Not sure if this is the desired behavior though but it does match with most other note modules.