### PR TITLE
Improved IntSlider and FloatSlider accuracy especially when zoomed in. Fixes: #228.

### DIFF
--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -358,7 +358,7 @@ bool FloatSlider::MouseMoved(float x, float y)
    return mMouseDown;
 }
 
-void FloatSlider::SetValueForMouse(int x, int y)
+void FloatSlider::SetValueForMouse(float x, float y)
 {
    float* var = GetModifyValue();
    float fX = x;
@@ -1067,7 +1067,7 @@ bool IntSlider::MouseMoved(float x, float y)
    return mMouseDown;
 }
 
-void IntSlider::SetValueForMouse(int x, int y)
+void IntSlider::SetValueForMouse(float x, float y)
 {
    int oldVal = *mVar;
    *mVar = (int)round(ofMap(x + mX, mX + 1, mX + mWidth - 1, mMin, mMax));

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -147,7 +147,7 @@ protected:
 
 private:
    void OnClicked(float x, float y, bool right) override;
-   void SetValueForMouse(int x, int y);
+   void SetValueForMouse(float x, float y);
    float* GetModifyValue();
    bool AdjustSmooth() const;
    void SmoothUpdated();
@@ -277,7 +277,7 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   void SetValueForMouse(int x, int y);
+   void SetValueForMouse(float x, float y);
    void CalcSliderVal();
 
    int mWidth;


### PR DESCRIPTION
The conversion to int type was too soon in the process thus reducing accuracy significantly especially when zoomed in. Simply using float's instead of int's in `SetValueForMouse` makes it so much more accurate.