### PR TITLE
Add the seconds to the file name of saved loops and samples. Resolves: #318.

### DIFF
--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -1022,7 +1022,7 @@ void Looper::ButtonClicked(ClickButton* button, double time)
       mWantBakeVolume = true;
    if (button == mSaveButton)
    {
-      Sample::WriteDataToFile(ofGetTimestampString("loops/loop_%Y-%m-%d_%H-%M.wav").c_str(), mBuffer, mLoopLength);
+      Sample::WriteDataToFile(ofGetTimestampString("loops/loop_%Y-%m-%d_%H-%M-%S.wav").c_str(), mBuffer, mLoopLength);
    }
    if (button == mCommitButton && mRecorder)
       mRecorder->Commit(this);

--- a/Source/SampleCapturer.cpp
+++ b/Source/SampleCapturer.cpp
@@ -202,7 +202,7 @@ void SampleCapturer::ButtonClicked(ClickButton* button, double time)
 
    if (button == mSaveButton)
    {
-      FileChooser chooser("Save sample as...", File(ofToDataPath(ofGetTimestampString("samples/%Y-%m-%d_%H-%M.wav"))), "*.wav", true, false, TheSynth->GetFileChooserParent());
+      FileChooser chooser("Save sample as...", File(ofToDataPath(ofGetTimestampString("samples/%Y-%m-%d_%H-%M-%S.wav"))), "*.wav", true, false, TheSynth->GetFileChooserParent());
       if (chooser.browseForFileToSave(true))
          Sample::WriteDataToFile(chooser.getResult().getFullPathName().toStdString(), &mSamples[mCurrentSampleIndex].mBuffer, mSamples[mCurrentSampleIndex].mRecordingLength);
    }


### PR DESCRIPTION
Add the seconds to the file name of saved loops and samples from the samplecapturer so that one can create more than one sample per minute. Resolves: #318.