### PR TITLE
Changed the behavior or DropdownList's so that they close when you click them again. Resolves: #649.

### DIFF
--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -367,6 +367,13 @@ void DropdownList::OnClicked(float x, float y, bool right)
    if (mElements.empty())
       return;
 
+   auto a = TheSynth->GetTopModalFocusItem();
+   if (a == &mModalList)
+   {
+      TheSynth->PopModalFocusItem();
+      return;
+   }
+
    mModalList.SetUpModal();
 
    ofVec2f modalPos = GetModalListPosition();

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1510,7 +1510,8 @@ void ModularSynth::MousePressed(int intX, int intY, int button, const juce::Mous
          bool clicked = GetTopModalFocusItem()->TestClick(modalX, modalY, rightButton);
          if (!clicked)
          {
-            FloatSliderLFOControl* lfo = dynamic_cast<FloatSliderLFOControl*>(GetTopModalFocusItem());
+            auto lfo = dynamic_cast<FloatSliderLFOControl*>(GetTopModalFocusItem());
+            auto dropdown = dynamic_cast<DropdownListModal*>(GetTopModalFocusItem());
             if (lfo) //if it's an LFO, don't dismiss it if you're adjusting the slider
             {
                FloatSlider* slider = lfo->GetOwner();
@@ -1521,6 +1522,13 @@ void ModularSynth::MousePressed(int intX, int intY, int button, const juce::Mous
 
                if (x < uiX || y < uiY || x > uiX + w || y > uiY + h)
                   PopModalFocusItem();
+            }
+            else if (dropdown)
+            {
+               if (dynamic_cast<DropdownList*>(gHoveredUIControl) != dropdown->GetOwner())
+               {
+                  PopModalFocusItem();
+               }
             }
             else //otherwise, always dismiss if you click outside it
             {


### PR DESCRIPTION
Changed the behavior or DropdownList's so that they close when you click them again. Resolves: #649.

I'm not entirely sure why the drop down lists in the titlebar menu don't behave the same so I have a sneaking suspicion my solution isn't the right one even though it works for everything else (that I've tested).