### PR TITLE
Made the pulsebutton send pulses a sample later so that things like the `notecreator` work with it. Resolves: #656.

### DIFF
--- a/Source/PulseButton.cpp
+++ b/Source/PulseButton.cpp
@@ -59,7 +59,7 @@ void PulseButton::ButtonClicked(ClickButton* button, double time)
 {
    if (button == mButton)
    {
-      double scheduledTime = gTime + TheTransport->GetEventLookaheadMs();
+      double scheduledTime = NextBufferTime(true);
       if (mForceImmediate)
          scheduledTime = time;
       DispatchPulse(GetPatchCableSource(), scheduledTime, 1, 0);


### PR DESCRIPTION
Strangely though when `force_immediate` was enabled it did work fine.

Maybe this is a case of floating point inaccuracies when `time + 0` is done? (`0` for not having no lookahead buffer).