### PR TITLE
Fixed a division by zero if Pitch Per Octave was set to 0 (either by hand or through modulation). Resolves: #676.

### DIFF
--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -62,7 +62,7 @@ void Scale::CreateUIControls()
    mScaleSelector = new DropdownList(this, "scale", 58, 5, &mScaleIndex);
    mScaleDegreeSlider = new IntSlider(this, "degree", HIDDEN_UICONTROL, HIDDEN_UICONTROL, 115, 15, &mScaleDegree, -7, 7);
    mIntonationSelector = new DropdownList(this, "intonation", 58, 24, (int*)(&mIntonation));
-   mPitchesPerOctaveEntry = new TextEntry(this, "PPO", 4, 24, 2, &mPitchesPerOctave, 0, 99);
+   mPitchesPerOctaveEntry = new TextEntry(this, "PPO", 4, 24, 2, &mPitchesPerOctave, 1, 99);
    mReferenceFreqEntry = new TextEntry(this, "tuning", 4, 43, 3, &mReferenceFreq, 1, 999);
    mReferencePitchEntry = new TextEntry(this, "note", 76, 43, 3, &mReferencePitch, 0, 127);
    mLoadSCLButton = new ClickButton(this, "load SCL", 4, 62);

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -122,7 +122,7 @@ public:
    int GetNumScaleTypes() { return (int)mScales.size(); }
    std::string GetScaleName(int index) { return mScales[index].mName; }
    int NumTonesInScale() const { return mScale.NumTonesInScale(); }
-   int GetPitchesPerOctave() const { return mPitchesPerOctave; }
+   int GetPitchesPerOctave() const { return MAX(1, mPitchesPerOctave); }
 
    float PitchToFreq(float pitch);
    float FreqToPitch(float freq);


### PR DESCRIPTION
Fixed a division by zero if Pitch Per Octave was set to 0 (either by hand or through modulation). Resolves: #676.

There is quite a bit of code that assumes PPO can't be zero.