### PR TITLE
Added a little distinguishable additional graphic to the module receiving pips.

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -373,24 +373,29 @@ void IDrawableModule::Render()
    ofPushStyle();
    const float kPipWidth = 8;
    const float kPipSpacing = 2;
+   const float kHalfPipWidth = kPipWidth / 2;
+   const float kExtrasOffset = 1.25;
    float receiveIndicatorX = w - (kPipWidth + kPipSpacing);
    ofFill();
 
    if (CanReceiveAudio())
    {
       ofSetColor(GetColor(kModuleCategory_Audio));
+      ofArc(receiveIndicatorX + kHalfPipWidth, -titleBarHeight - kExtrasOffset, kHalfPipWidth, PI, TWO_PI);
       ofRect(receiveIndicatorX, -titleBarHeight - 2, kPipWidth, 3, 1.0f);
       receiveIndicatorX -= kPipWidth + kPipSpacing;
    }
    if (CanReceiveNotes())
    {
       ofSetColor(GetColor(kModuleCategory_Note));
+      ofTriangle(receiveIndicatorX, -titleBarHeight - kExtrasOffset - kHalfPipWidth, receiveIndicatorX + kHalfPipWidth, -titleBarHeight - kExtrasOffset, receiveIndicatorX + kPipWidth, -titleBarHeight - kExtrasOffset - kHalfPipWidth);
       ofRect(receiveIndicatorX, -titleBarHeight - 2, kPipWidth, 3, 1.0f);
       receiveIndicatorX -= kPipWidth + kPipSpacing;
    }
    if (CanReceivePulses())
    {
       ofSetColor(GetColor(kModuleCategory_Pulse));
+      ofRect(receiveIndicatorX + kPipSpacing, -titleBarHeight - 4 - kExtrasOffset, kPipWidth - kPipSpacing * 2, 4, 0.0f);
       ofRect(receiveIndicatorX, -titleBarHeight - 2, kPipWidth, 3, 1.0f);
       receiveIndicatorX -= kPipWidth + kPipSpacing;
    }

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -254,6 +254,16 @@ void ofCircle(float x, float y, float radius)
       nvgStroke(gNanoVG);
 }
 
+void ofArc(float x, float y, float radius, float angle0, float angle1, int dir /* = NVG_CW */)
+{
+   nvgBeginPath(gNanoVG);
+   nvgArc(gNanoVG, x, y, radius, angle0, angle1, dir);
+   if (sStyleStack.GetStyle().fill)
+      nvgFill(gNanoVG);
+   else
+      nvgStroke(gNanoVG);
+}
+
 void ofRect(float x, float y, float width, float height, float cornerRadius /*=3*/)
 {
    nvgBeginPath(gNanoVG);

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -258,6 +258,7 @@ void ofSetColorGradient(const ofColor& colorA, const ofColor& colorB, ofVec2f gr
 void ofFill();
 void ofNoFill();
 void ofCircle(float x, float y, float radius);
+void ofArc(float x, float y, float radius, float angle0, float angle1, int dir = 2 /* NVG_CW */);
 void ofRect(float x, float y, float width, float height, float cornerRadius = 3);
 void ofRect(const ofRectangle& rect, float cornerRadius = 3);
 float ofClamp(float val, float a, float b);


### PR DESCRIPTION
At 2x zoom:
![image](https://user-images.githubusercontent.com/211381/214932782-18240d03-3a92-4b02-afe3-f779423042fe.png)

At 1x zoom:
![image](https://user-images.githubusercontent.com/211381/214932859-cb9931a2-98b9-4e88-9dc7-8f807511f0cd.png)

At 8x zoom:
![image](https://user-images.githubusercontent.com/211381/214932921-241047cc-73d3-429e-8cf4-08edfed08ed0.png)


I was trying to strike a balance between how distracting and how distinguishable they are and I hope I did it but well, this is all opinion based and people will like different things. I do know that this should for the most part eliminate confusion between note and pulse receiver pips and help the color blind folks a little.