### PR TITLE
Fixed incorrect location of grid icon on patch sources when modules are inside a prefab. Resolves: #816.

### DIFF
--- a/Source/PatchCableSource.cpp
+++ b/Source/PatchCableSource.cpp
@@ -340,7 +340,7 @@ void PatchCableSource::Render()
             ofPushStyle();
             ofNoFill();
             ofSetColor(IDrawableModule::GetColor(kModuleCategory_Other));
-            GridControlTarget::DrawGridIcon(mX + 7, mY - 6);
+            GridControlTarget::DrawGridIcon(cableX + 7, cableY - 6);
             ofPopStyle();
          }
       }


### PR DESCRIPTION
Fixed incorrect location of grid icon on patch sources when modules are inside a prefab. Resolves: #816.