### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/Source/BeatBloks.cpp
+++ b/Source/BeatBloks.cpp
@@ -267,7 +267,7 @@ void BeatBloks::FilesDropped(std::vector<std::string> files, int x, int y)
    if (!hasCached) //have to look it up with echonest
    {
       char command[2048];
-      sprintf(command, "export ECHO_NEST_API_KEY=SUZ3W7PAIVQQXZCAW; export PATH=/usr/local/bin:$PATH; python \"%s\" \"%s\"", ofToDataPath("get_echonest_remix_data.py").c_str(), files[0].c_str());
+      snprintf(command, sizeof(command), "export ECHO_NEST_API_KEY=SUZ3W7PAIVQQXZCAW; export PATH=/usr/local/bin:$PATH; python \"%s\" \"%s\"", ofToDataPath("get_echonest_remix_data.py").c_str(), files[0].c_str());
       output = popen(command, "r");
       cachedFile = fopen(ofToDataPath(cachedFilename).c_str(), "w");
    }

--- a/Source/CFMessaging/KontrolKommunicator.cpp
+++ b/Source/CFMessaging/KontrolKommunicator.cpp
@@ -497,7 +497,7 @@ void KontrolKommunicator::Output(std::string str)
 std::string KontrolKommunicator::FormatString(std::string format, int number)
 {
    char buffer[100];
-   sprintf(buffer, format.c_str(), number);
+   snprintf(buffer, sizeof(buffer), format.c_str(), number);
    return (std::string)buffer;
 }
 

--- a/Source/CFMessaging/NIMessage.cpp
+++ b/Source/CFMessaging/NIMessage.cpp
@@ -63,7 +63,7 @@ std::string TypeForMessageID(uint32_t messageId)
          return MessageIdToStringTable[i].className;
    }
    char messageIdStr[16];
-   sprintf(messageIdStr, "0x%08x", messageId);
+   snprintf(messageIdStr, sizeof(messageIdStr), "0x%08x", messageId);
    return std::string("Unknown message type ") + messageIdStr;
 }
 

--- a/Source/OpenFrameworksPort.cpp
+++ b/Source/OpenFrameworksPort.cpp
@@ -527,17 +527,17 @@ std::string ofGetTimestampString(std::string in)
    Time time = Time::getCurrentTime();
    ofStringReplace(in, "%Y", ofToString(time.getYear()));
    char buff[16];
-   sprintf(buff, "%02d", time.getMonth() + 1);
+   snprintf(buff, sizeof(buff), "%02d", time.getMonth() + 1);
    ofStringReplace(in, "%m", buff);
-   sprintf(buff, "%02d", time.getDayOfMonth());
+   snprintf(buff, sizeof(buff), "%02d", time.getDayOfMonth());
    ofStringReplace(in, "%d", buff);
-   sprintf(buff, "%02d", time.getHours());
+   snprintf(buff, sizeof(buff), "%02d", time.getHours());
    ofStringReplace(in, "%H", buff);
-   sprintf(buff, "%02d", time.getMinutes());
+   snprintf(buff, sizeof(buff), "%02d", time.getMinutes());
    ofStringReplace(in, "%M", buff);
-   sprintf(buff, "%02d", time.getSeconds());
+   snprintf(buff, sizeof(buff), "%02d", time.getSeconds());
    ofStringReplace(in, "%S", buff);
-   sprintf(buff, "%03d", time.getMilliseconds());
+   snprintf(buff, sizeof(buff), "%03d", time.getMilliseconds());
    ofStringReplace(in, "%i", buff);
    return in;
 }

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -11637,8 +11637,8 @@ void DumpUnfreedMemory()
       const AllocInfo* info = element.second;
       if (info && info->allocated)
       {
-         sprintf(buf, "%-90s:  LINE %5d,  ADDRESS %08x  %8d unfreed",
-                 info->file, info->line, info->address, info->size);
+         snprintf(buf, sizeof(buf), "%-90s:  LINE %5d,  ADDRESS %08x  %8d unfreed",
+                  info->file, info->line, info->address, info->size);
          ofLog() << buf;
          totalSize += info->size;
 
@@ -11648,12 +11648,12 @@ void DumpUnfreedMemory()
    ofLog() << "-----------------------------------------------------------";
    for (auto fileInfo : perFileTotal)
    {
-      sprintf(buf, "%-90s:  %10d unfreed",
-              fileInfo.first.c_str(), fileInfo.second);
+      snprintf(buf, sizeof(buf), "%-90s:  %10d unfreed",
+               fileInfo.first.c_str(), fileInfo.second);
       ofLog() << buf;
    }
    ofLog() << "-----------------------------------------------------------";
-   sprintf(buf, "Total Unfreed: %d bytes", totalSize);
+   snprintf(buf, sizeof(buf), "Total Unfreed: %d bytes", totalSize);
    ofLog() << buf;
 };
 


### PR DESCRIPTION
This replaces `sprintf` with its safer alternative `snprintf`.

Since Xcode 14, using `sprintf` results in the following deprecation warning:

warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]