### PR TITLE
add looperrecorder option to disable auto-advancing to the next looper

### DIFF
--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -82,7 +82,7 @@ void Looper::CreateUIControls()
    mHalveSpeedButton = new ClickButton(this, ".5x", 147, 43);
    mUndoButton = new ClickButton(this, "undo", -1, -1);
    mLoopPosOffsetSlider = new FloatSlider(this, "offset", -1, -1, 130, 15, &mLoopPosOffset, 0, mLoopLength);
-   mWriteOffsetButton = new ClickButton(this, "set", -1, -1);
+   mWriteOffsetButton = new ClickButton(this, "apply", -1, -1);
    mScratchSpeedSlider = new FloatSlider(this, "scrspd", -1, -1, 130, 15, &mScratchSpeed, -2, 2);
    mAllowScratchCheckbox = new Checkbox(this, "scr", -1, -1, &mAllowScratch);
    mFourTetSlider = new FloatSlider(this, "fourtet", 4, 65, 65, 15, &mFourTet, 0, 1, 1);
@@ -1210,29 +1210,12 @@ void Looper::PlayNote(double time, int pitch, int velocity, int voiceIdx, Modula
    //jump around in loop
    if (velocity > 0)
    {
-      int chop = pitch - 36;
-      if (chop == 3)
-      {
-         mLoopPosOffset = 0;
-         mLoopPosOffsetSlider->DisableLFO();
-      }
-      if (chop >= 9 && chop < 16 && chop % 2 == 1)
-      {
-         mChopMeasure = (chop / 2 - 4) % mNumBars;
-         float sampsPerBar = TheTransport->MsPerBar() / 1000.0f * gSampleRate;
-         mLoopPosOffset = -mLoopPos + mChopMeasure * sampsPerBar;
-         mLoopPosOffsetSlider->DisableLFO();
-      }
-      if (chop >= 0 && chop < 16 && chop % 2 == 0)
-      {
-         int slice = chop / 2;
-         float measurePos = slice / 8.0f;
-         float sampsPerBar = TheTransport->MsPerBar() / 1000.0f * gSampleRate;
-         mLoopPosOffset = -mLoopPos + (mChopMeasure + measurePos) * sampsPerBar;
-         if (mLoopPosOffset < 0)
-            mLoopPosOffset += mLoopLength;
-         mLoopPosOffsetSlider->DisableLFO();
-      }
+      float measurePos = fmod(pitch / 16.0f, mNumBars);
+      float sampsPerBar = TheTransport->MsPerBar() / 1000.0f * gSampleRate;
+      mLoopPosOffset = (measurePos - fmod(TheTransport->GetMeasureTime(time), mNumBars)) * sampsPerBar;
+      if (mLoopPosOffset < 0)
+         mLoopPosOffset += mLoopLength;
+      mLoopPosOffsetSlider->DisableLFO();
    }
 }
 

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -189,9 +189,6 @@ private:
    bool mReplaceOnCommit{ false };
    float mLoopPosOffset{ 0 };
    FloatSlider* mLoopPosOffsetSlider{ nullptr };
-   bool mAllowChop{ false };
-   Checkbox* mAllowChopCheckbox{ nullptr };
-   int mChopMeasure{ 0 };
    ClickButton* mWriteOffsetButton{ nullptr };
    float mScratchSpeed{ 1 };
    bool mAllowScratch{ false };

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -68,7 +68,9 @@ void LooperRecorder::CreateUIControls()
    //BUTTON(mShiftMeasureButton, "shift"); UIBLOCK_SHIFTUP(); UIBLOCK_SHIFTX(30);
    //BUTTON(mHalfShiftButton, "half"); UIBLOCK_NEWLINE();
    //BUTTON(mShiftDownbeatButton, "downbeat");
+   UIBLOCK_SHIFTDOWN();
    INTSLIDER(mNextCommitTargetSlider, "target", &mNextCommitTargetIndex, 0, 3);
+   CHECKBOX(mAutoAdvanceThroughLoopersCheckbox, "auto-advance", &mAutoAdvanceThroughLoopers);
    UIBLOCK_NEWCOLUMN();
    UIBLOCK_PUSHSLIDERWIDTH(80);
    DROPDOWN(mModeSelector, "mode", ((int*)(&mRecorderMode)), 60);
@@ -245,7 +247,7 @@ void LooperRecorder::SyncCablesToLoopers()
          if (i < mLoopers.size())
             looper = mLoopers[i];
          mLooperPatchCables[i]->SetTarget(looper);
-         mLooperPatchCables[i]->SetManualPosition(160 + i * 12, 117);
+         mLooperPatchCables[i]->SetManualPosition(160 + i * 12, 120);
          mLooperPatchCables[i]->SetOverrideCableDir(ofVec2f(0, 1), PatchCableSource::Side::kBottom);
          ofColor color = mLooperPatchCables[i]->GetColor();
          color.a *= .3f;
@@ -320,6 +322,7 @@ void LooperRecorder::DrawModule()
    mFreeRecordingCheckbox->Draw();
    mCancelFreeRecordButton->Draw();
    mNextCommitTargetSlider->Draw();
+   mAutoAdvanceThroughLoopersCheckbox->Draw();
 
    if (mSpeed != 1)
    {
@@ -391,7 +394,16 @@ void LooperRecorder::DrawModule()
    if (mDrawDebug)
       mRecordBuffer.Draw(0, 162, 800, 100);
 
-   DrawTextNormal("loopers:", 155, 109);
+   DrawTextNormal("loopers:", 155, 112);
+   if (mNextCommitTargetIndex < (int)mLooperPatchCables.size())
+   {
+      ofPushStyle();
+      ofSetColor(255, 255, 255);
+      ofVec2f cablePos = mLooperPatchCables[mNextCommitTargetIndex]->GetPosition();
+      cablePos -= GetPosition();
+      ofCircle(cablePos.x, cablePos.y, 5);
+      ofPopStyle();
+   }
 }
 
 void LooperRecorder::RemoveLooper(Looper* looper)
@@ -704,11 +716,14 @@ void LooperRecorder::ButtonClicked(ClickButton* button, double time)
       mNumBars = numBars;
       if (mNextCommitTargetIndex < (int)mLoopers.size())
          Commit(mLoopers[mNextCommitTargetIndex]);
-      for (int i = 0; i < (int)mLoopers.size(); ++i)
+      if (mAutoAdvanceThroughLoopers)
       {
-         mNextCommitTargetIndex = (mNextCommitTargetIndex + 1) % mLoopers.size();
-         if (mLoopers[mNextCommitTargetIndex] != nullptr)
-            break;
+         for (int i = 0; i < (int)mLoopers.size(); ++i)
+         {
+            mNextCommitTargetIndex = (mNextCommitTargetIndex + 1) % mLoopers.size();
+            if (mLoopers[mNextCommitTargetIndex] != nullptr)
+               break;
+         }
       }
    }
 }

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -122,7 +122,7 @@ private:
    bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 235 };
-   float mHeight{ 125 };
+   float mHeight{ 126 };
    RollingBuffer mRecordBuffer;
    std::vector<Looper*> mLoopers;
    int mNumBars{ 1 };
@@ -158,6 +158,8 @@ private:
    ClickButton* mCommit8BarsButton{ nullptr };
    IntSlider* mNextCommitTargetSlider{ nullptr };
    int mNextCommitTargetIndex{ 0 };
+   Checkbox* mAutoAdvanceThroughLoopersCheckbox{ nullptr };
+   bool mAutoAdvanceThroughLoopers{ true };
 
    bool mFreeRecording{ false };
    Checkbox* mFreeRecordingCheckbox{ nullptr };

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -55,7 +55,7 @@ public:
    //IDrawableModule
    void Init() override;
    bool IsResizable() const override { return true; }
-   void Resize(float w, float h);
+   void Resize(float w, float h) override;
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //IClickable

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -843,6 +843,7 @@ looperrecorder~command center to manage recording into multiple loopers, and all
 ~2xtempo~double global transport tempo, while keeping connected loopers sounding the same
 ~.5tempo~halve global transport tempo, while keeping connected loopers sounding the same
 ~target~looper to commit audio to when using the on-buffer capture buttons to the left
+~auto-advance~automatically advance to the next looper when committing
 ~mode~recorder mode: use "record" to record input and allow it to be committed to buffers when you're ready to loop, use "overdub" to record input and play the loop at our specified length, and use "loop" to play the current loop without adding input
 ~clear~clear the recorded buffer
 ~free rec~enable to start recording a loop with no predetermined length. disable to end recording, adjust global transport to match the loop length, and switch the recorder's mode to "loop"
@@ -872,7 +873,7 @@ looper~loop input audio. use with a "looperrecorder" for full functionality.
 ~.5x~make loop play at half speed
 ~undo~undo last loop commit
 ~offset~amount to offset looper's playhead from transport position
-~set~shift the contents of the looper so the current offset is the start of the buffer
+~apply~shift the contents of the looper so the current offset is the start of the buffer
 ~scrspd~playback speed, used with "scr" is enabled. modulate quickly for a vinyl-like scratching effect.
 ~scr~allow loop to be scratched by adjusting "scrspd"
 ~fourtet~use a textural trick I saw four tet illustrate in a video once: slice the audio into chunks, and for each chunk it at double speed followed by playing it in reverse at double speed. this slider adjusts the mix between the original audio and this "fourtetified" audio.


### PR DESCRIPTION
also fixed up some confusing ancient code for chopping up looper contents with midi note input, and made it more direct

fixes #994