### PR TITLE
bring back envelope "free release level", which I mistakenly removed in #849

### DIFF
--- a/Source/ADSR.cpp
+++ b/Source/ADSR.cpp
@@ -55,6 +55,7 @@ void ::ADSR::Set(const ADSR& other)
    mSustainStage = other.mSustainStage;
    mMaxSustain = other.mMaxSustain;
    mHasSustainStage = other.mHasSustainStage;
+   mFreeReleaseLevel = other.mFreeReleaseLevel;
 }
 
 void ::ADSR::Start(double time, float target, float a, float d, float s, float r, float timeScale /*=1*/)
@@ -242,8 +243,7 @@ void ::ADSR::SaveState(FileStreamOut& out)
    out << mMaxSustain;
    out << mNumStages;
    out << mHasSustainStage;
-   bool dummyBool;
-   out << dummyBool;
+   out << mFreeReleaseLevel;
    out << MAX_ADSR_STAGES;
    for (int i = 0; i < MAX_ADSR_STAGES; ++i)
    {
@@ -266,8 +266,7 @@ void ::ADSR::LoadState(FileStreamIn& in)
    in >> mMaxSustain;
    in >> mNumStages;
    in >> mHasSustainStage;
-   bool dummyBool;
-   in >> dummyBool;
+   in >> mFreeReleaseLevel;
    int maxNumStages;
    in >> maxNumStages;
    assert(maxNumStages == MAX_ADSR_STAGES);

--- a/Source/ADSR.h
+++ b/Source/ADSR.h
@@ -115,6 +115,7 @@ public:
    float& GetMaxSustain() { return mMaxSustain; }
    int& GetSustainStage() { return mSustainStage; }
    bool& GetHasSustainStage() { return mHasSustainStage; }
+   bool& GetFreeReleaseLevel() { return mFreeReleaseLevel; }
 
    void SaveState(FileStreamOut& out);
    void LoadState(FileStreamIn& in);
@@ -131,5 +132,6 @@ private:
    Stage mStages[MAX_ADSR_STAGES];
    int mNumStages{ 0 };
    bool mHasSustainStage{ false };
+   bool mFreeReleaseLevel{ false };
    float mTimeScale{ 1 };
 };

--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -39,6 +39,7 @@ CurveLooper::CurveLooper()
    mEnvelopeControl.SetADSR(&mAdsr);
    mEnvelopeControl.SetViewLength(kAdsrTime);
    mEnvelopeControl.SetFixedLengthMode(true);
+   mAdsr.GetFreeReleaseLevel() = true;
    mAdsr.SetNumStages(2);
    mAdsr.GetHasSustainStage() = false;
    mAdsr.GetStageData(0).target = .5f;

--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -322,7 +322,7 @@ void EnvelopeControl::MouseMoved(float x, float y)
             mAdsr->GetStageData(mHighlightPoint + 1).time = mClickAdsr.GetStageData(mHighlightPoint + 1).time - timeAdjustment;
          }
 
-         if (mHighlightPoint < mAdsr->GetNumStages() - 1)
+         if (mHighlightPoint < mAdsr->GetNumStages() - 1 || mAdsr->GetFreeReleaseLevel())
             stage.target = ofClamp(originalStage.target + ((mClickStart.y - y) / mDimensions.y), 0, 1);
          else
             stage.target = 0;
@@ -405,6 +405,7 @@ void EnvelopeEditor::CreateUIControls()
    UIBLOCK_SHIFTRIGHT();
    BUTTON(mPinButton, "pin");
    UIBLOCK_SHIFTRIGHT();
+   CHECKBOX(mFreeReleaseLevelCheckbox, "free release", &dummyBool);
    ENDUIBLOCK0();
 
    UIBLOCK(3, mHeight - 70);
@@ -437,6 +438,7 @@ void EnvelopeEditor::SetADSRDisplay(ADSRDisplay* adsrDisplay)
    mADSRDisplay = adsrDisplay;
    mADSRViewLengthSlider->SetVar(&adsrDisplay->GetMaxTime());
    mMaxSustainSlider->SetVar(&adsrDisplay->GetADSR()->GetMaxSustain());
+   mFreeReleaseLevelCheckbox->SetVar(&adsrDisplay->GetADSR()->GetFreeReleaseLevel());
 
    for (int i = 0; i < (int)mStageControls.size(); ++i)
    {
@@ -478,6 +480,7 @@ void EnvelopeEditor::DrawModule()
 
    mADSRViewLengthSlider->Draw();
    mMaxSustainSlider->Draw();
+   mFreeReleaseLevelCheckbox->Draw();
    if (!mPinned)
       mPinButton->Draw();
 
@@ -502,6 +505,10 @@ void EnvelopeEditor::DrawModule()
          mStageControls[i].mCurveSlider->Draw();
          mStageControls[i].mSustainCheckbox->Draw();
       }
+
+      //move release level checkbox below final stage control
+      ofVec2f pos = mStageControls[numStages - 1].mSustainCheckbox->GetPosition(K(local));
+      mFreeReleaseLevelCheckbox->SetPosition(pos.x, pos.y);
    }
 }
 

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -142,6 +142,7 @@ private:
    bool mPinned{ false };
    FloatSlider* mADSRViewLengthSlider{ nullptr };
    FloatSlider* mMaxSustainSlider{ nullptr };
+   Checkbox* mFreeReleaseLevelCheckbox{ nullptr };
    PatchCableSource* mTargetCable{ nullptr };
    std::array<StageControls, 10> mStageControls{};
 };

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -32,6 +32,7 @@
 
 EnvelopeModulator::EnvelopeModulator()
 {
+   mAdsr.GetFreeReleaseLevel() = true;
 }
 
 void EnvelopeModulator::CreateUIControls()

--- a/Source/ModulatorCurve.cpp
+++ b/Source/ModulatorCurve.cpp
@@ -41,6 +41,7 @@ ModulatorCurve::ModulatorCurve()
    mEnvelopeControl.SetADSR(&mAdsr);
    mEnvelopeControl.SetViewLength(kAdsrTime);
    mEnvelopeControl.SetFixedLengthMode(true);
+   mAdsr.GetFreeReleaseLevel() = true;
    mAdsr.SetNumStages(2);
    mAdsr.GetHasSustainStage() = false;
    mAdsr.GetStageData(0).target = 0;

--- a/Source/VelocityCurve.cpp
+++ b/Source/VelocityCurve.cpp
@@ -38,6 +38,7 @@ VelocityCurve::VelocityCurve()
    mEnvelopeControl.SetADSR(&mAdsr);
    mEnvelopeControl.SetViewLength(kAdsrTime);
    mEnvelopeControl.SetFixedLengthMode(true);
+   mAdsr.GetFreeReleaseLevel() = true;
    mAdsr.SetNumStages(2);
    mAdsr.GetHasSustainStage() = false;
    mAdsr.GetStageData(0).target = 0;


### PR DESCRIPTION
fixes #1131, so curveloopers work properly again