### PR TITLE
Remove an additional save buffer halving the memory needed for the `record audio` buffer.

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -96,8 +96,6 @@ ModularSynth::~ModularSynth()
    DeleteAllModules();
 
    delete mGlobalRecordBuffer;
-   delete[] mSaveOutputBuffer[0];
-   delete[] mSaveOutputBuffer[1];
    mAudioPluginFormatManager.reset();
    mKnownPluginList.reset();
 
@@ -237,8 +235,6 @@ void ModularSynth::Setup(juce::AudioDeviceManager* globalAudioDeviceManager, juc
 
    mGlobalRecordBuffer = new RollingBuffer(UserPrefs.record_buffer_length_minutes.Get() * 60 * gSampleRate);
    mGlobalRecordBuffer->SetNumChannels(2);
-   mSaveOutputBuffer[0] = new float[mGlobalRecordBuffer->Size()];
-   mSaveOutputBuffer[1] = new float[mGlobalRecordBuffer->Size()];
 
    juce::File(ofToDataPath("savestate")).createDirectory();
    juce::File(ofToDataPath("savestate/autosave")).createDirectory();
@@ -3231,13 +3227,7 @@ void ModularSynth::SaveOutput()
 
    assert(mRecordingLength <= mGlobalRecordBuffer->Size());
 
-   for (int i = 0; i < mRecordingLength; ++i)
-   {
-      mSaveOutputBuffer[0][i] = mGlobalRecordBuffer->GetSample((int)mRecordingLength - i - 1, 0);
-      mSaveOutputBuffer[1][i] = mGlobalRecordBuffer->GetSample((int)mRecordingLength - i - 1, 1);
-   }
-
-   Sample::WriteDataToFile(filename, mSaveOutputBuffer, (int)mRecordingLength, 2);
+   Sample::WriteDataToFile(filename, mGlobalRecordBuffer->GetRawBuffer(), mRecordingLength);
 
    //mOutputBufferMeasurePos.ReadChunk(mSaveOutputBuffer, mRecordingLength);
    //Sample::WriteDataToFile(filenamePos.c_str(), mSaveOutputBuffer, mRecordingLength, 1);

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -389,8 +389,6 @@ private:
 
    Sample* mHeldSample{ nullptr };
 
-   float* mSaveOutputBuffer[2];
-
    IDrawableModule* mLastClickedModule{ nullptr };
    bool mInitialized{ false };
 


### PR DESCRIPTION
I tested this a bunch and the behavior seems to be mostly identical but with much less memory usage.

I initially thought this buffer was there for threading the actual writing to file but the entire code that does the saving is scoped mutexed so this is not the case.

I think this fix is fine but am not super certain as my knowledge of Bespoke is still limited.

Some before and after memory:

![Taskmgr_20230217_173936](https://user-images.githubusercontent.com/211381/219712301-c5841fdc-20f3-4d83-a2c8-0b42541d3c56.png)
![Taskmgr_20230216_203251](https://user-images.githubusercontent.com/211381/219711963-5a135547-c042-4a1b-9196-58e4a46dbdb8.png)
![Taskmgr_20230216_204242](https://user-images.githubusercontent.com/211381/219711989-fa98daf6-bae5-4817-828e-633955722f76.png)
