### PR TITLE
Add grid connections only after layout is loaded

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -114,11 +114,6 @@ void MidiController::Init()
    mConnections.clear();
 
    mHasCreatedConnectionUIControls = false;
-   // Only add non-grid connections, because the persisted layout has not been loaded yet.
-   // The grid connections will be added in LoadState.
-   for (int i = 0; i < mConnectionsJson.size(); ++i)
-      if (!mConnectionsJson[i].isMember("grid_index"))
-         AddControlConnection(mConnectionsJson[i]);
 
    TheTransport->AddAudioPoller(this);
 }
@@ -2422,12 +2417,8 @@ void MidiController::LoadState(FileStreamIn& in, int rev)
 {
    IDrawableModule::LoadState(in, rev);
 
-   // Add grid connections here instead of in Init, because the controller
-   // layout file is selected and loaded in IDrawableModule::LoadState,
-   // so the mGrids are only now available to add connections.
    for (int i = 0; i < mConnectionsJson.size(); ++i)
-      if (mConnectionsJson[i].isMember("grid_index"))
-         AddControlConnection(mConnectionsJson[i]);
+      AddControlConnection(mConnectionsJson[i]);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -114,8 +114,11 @@ void MidiController::Init()
    mConnections.clear();
 
    mHasCreatedConnectionUIControls = false;
+   // Only add non-grid connections, because the persisted layout has not been loaded yet.
+   // The grid connections will be added in LoadState.
    for (int i = 0; i < mConnectionsJson.size(); ++i)
-      AddControlConnection(mConnectionsJson[i]);
+      if (!mConnectionsJson[i].isMember("grid_index"))
+         AddControlConnection(mConnectionsJson[i]);
 
    TheTransport->AddAudioPoller(this);
 }
@@ -2418,6 +2421,13 @@ void MidiController::SaveState(FileStreamOut& out)
 void MidiController::LoadState(FileStreamIn& in, int rev)
 {
    IDrawableModule::LoadState(in, rev);
+
+   // Add grid connections here instead of in Init, because the controller
+   // layout file is selected and loaded in IDrawableModule::LoadState,
+   // so the mGrids are only now available to add connections.
+   for (int i = 0; i < mConnectionsJson.size(); ++i)
+      if (mConnectionsJson[i].isMember("grid_index"))
+         AddControlConnection(mConnectionsJson[i]);
 
    if (!ModuleContainer::DoesModuleHaveMoreSaveData(in))
       return; //this was saved before we added versioning, bail out


### PR DESCRIPTION
This fixes a problem I had, when trying to save/load grid connections on multiple pages of a midi controller (#879 sounds related).
Turns out this is only a problem if a custom layout is used for the controller.

## The issue
When a controller layout other than the one named exactly like the midi device is used in a saved state, connections on pages that were not active when saving are not restored.

This happens because, the grid connections were added in `Init`. At that point, the controller uses the default layout (i.e. the one named like the device or the actual default without any grids). Afterwards the UI State is loaded in `LoadState`, and then the selection from the layout dropdown is restored causing `mGrids` to be (re-)set to the correct setup.

## The fix
Now, we load the grids in `LoadState` after the UI has restored the state of the layout dropdown, so grid connections are always loaded into the correct grids.

I did this very conservatively here, only changing the order for grid connections, because I was not sure if moving the `AddControlConnection` call into `LoadState` for non-grid connections could cause other problems.
This caused some not-so-pretty copy-pasting. If it is safe to just move all `AddControlConnection` calls to `LoadState` that would seem a bit nicer.
