### PR TITLE
Set correct size for mConnectionsJson in SaveLayout

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2321,7 +2321,7 @@ void MidiController::UpdateControllerIndex()
 void MidiController::SaveLayout(ofxJSONElement& moduleInfo)
 {
    mConnectionsJson.clear();
-   mConnectionsJson.resize((int)mConnections.size());
+   mConnectionsJson.resize((int)mConnections.size() + (int)mGrids.size());
    int i = 0;
    for (auto iter = mConnections.begin(); iter != mConnections.end(); ++iter)
    {


### PR DESCRIPTION
I noticed this while debugging for #1173.
The grids are also added to `mConnectionsJson`, so we need to include them in the new Array size.