### PR TITLE
Enhance module control through OSC

### DIFF
--- a/Source/AbletonLink.h
+++ b/Source/AbletonLink.h
@@ -57,6 +57,7 @@ public:
 
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule
@@ -66,7 +67,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth;
    float mHeight;

--- a/Source/Amplifier.h
+++ b/Source/Amplifier.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       w = 120;
       h = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mGain{ 1 };
    FloatSlider* mGainSlider{ nullptr };

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -81,6 +81,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -89,7 +91,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    std::string GetArpNoteDisplay(int pitch);

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 106;
       h = 17 * 5 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mGain{ 1 };
    float* mModulationBuffer;

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -54,6 +54,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       w = 120;
       h = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mLevel{ 0 };
    float mMaxLevel{ 1 };

--- a/Source/AudioRouter.h
+++ b/Source/AudioRouter.h
@@ -61,11 +61,12 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return true; }
 
    int mRouteIndex{ 0 };
    RadioButton* mRouteSelector{ nullptr };

--- a/Source/AudioSend.h
+++ b/Source/AudioSend.h
@@ -61,6 +61,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -69,7 +71,6 @@ private:
       w = 86;
       h = 38;
    }
-   bool Enabled() const override { return mEnabled; }
 
    bool mCrossfade{ false };
    Checkbox* mCrossfadeCheckbox{ nullptr };

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 106;
       h = 17 * 3 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mGain{ 1 };
    float* mModulationBuffer{ nullptr };

--- a/Source/AudioToPulse.h
+++ b/Source/AudioToPulse.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/Autotalent.h
+++ b/Source/Autotalent.h
@@ -74,6 +74,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void UpdateShiftSlider();
 
@@ -84,7 +86,6 @@ private:
       width = 260;
       height = 360;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float* mWorkingBuffer;
 

--- a/Source/BandVocoder.h
+++ b/Source/BandVocoder.h
@@ -67,6 +67,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -75,7 +77,6 @@ private:
       w = 215;
       h = 130;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void CalcFilters();
 

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -86,6 +86,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    enum BlokType
    {
@@ -131,7 +133,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -134,10 +134,11 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    ChannelBuffer mWriteBuffer;

--- a/Source/BiquadFilterEffect.h
+++ b/Source/BiquadFilterEffect.h
@@ -69,11 +69,12 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& info) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override;
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
 
    void ResetFilter();
 

--- a/Source/BitcrushEffect.h
+++ b/Source/BitcrushEffect.h
@@ -51,6 +51,8 @@ public:
    void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -59,7 +61,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mCrush{ 1 };
    float mDownsample{ 1 };

--- a/Source/ButterworthFilterEffect.h
+++ b/Source/ButterworthFilterEffect.h
@@ -62,6 +62,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& info) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override
@@ -70,7 +72,6 @@ private:
       height = mHeight;
    }
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
 
    void ResetFilter();
 

--- a/Source/CanvasControls.h
+++ b/Source/CanvasControls.h
@@ -65,12 +65,13 @@ public:
    void SetUpFromSaveData() override;
    bool CanModuleTypeSaveState() const override { return false; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void PreDrawModule() override;
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return true; }
 
    float mWidth{ 200 };
    Canvas* mCanvas{ nullptr };

--- a/Source/Capo.h
+++ b/Source/Capo.h
@@ -56,6 +56,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct NoteInfo
    {
@@ -74,7 +76,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -73,6 +73,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    struct ProgressionChord
    {
@@ -129,7 +131,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 610;

--- a/Source/ChordDisplayer.h
+++ b/Source/ChordDisplayer.h
@@ -45,6 +45,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -53,5 +55,4 @@ private:
       width = 200;
       height = 20;
    }
-   bool Enabled() const override { return true; }
 };

--- a/Source/ChordHolder.h
+++ b/Source/ChordHolder.h
@@ -58,6 +58,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       width = 131;
       height = 21;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void Stop(double time);
 

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -62,7 +62,7 @@ public:
    void OnScaleChanged() override;
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   virtual bool Enabled() const override { return mEnabled; }
+   virtual bool IsEnabled() const override { return mEnabled; }
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -104,6 +104,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -113,7 +115,6 @@ private:
       height = 200;
    }
    void OnClicked(float x, float y, bool right) override;
-   bool Enabled() const override { return mEnabled; }
 
    std::vector<CircleSequencerRing*> mCircleSequencerRings;
 };

--- a/Source/ClipArranger.h
+++ b/Source/ClipArranger.h
@@ -59,11 +59,12 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    float MouseXToBufferPos(float mouseX);

--- a/Source/ClipLauncher.h
+++ b/Source/ClipLauncher.h
@@ -71,12 +71,13 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void RecalcPos(double time, int idx);
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    class SampleData

--- a/Source/ComboGridController.h
+++ b/Source/ComboGridController.h
@@ -60,6 +60,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    enum Arrangements
    {
@@ -72,7 +74,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
 
    unsigned int mRows{ 0 };

--- a/Source/CommentDisplay.h
+++ b/Source/CommentDisplay.h
@@ -49,10 +49,11 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
 
    char mComment[MAX_TEXTENTRY_LENGTH]{};

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -124,6 +124,8 @@ public:
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -132,7 +134,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mMix{ 1 };
    float mDrive{ 1 };

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -98,13 +98,14 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void Step(double time, int pulseFlags);
    void SetGridSize(float w, float h);
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/ControlTactileFeedback.h
+++ b/Source/ControlTactileFeedback.h
@@ -57,10 +57,11 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 80;

--- a/Source/ControllingSong.h
+++ b/Source/ControllingSong.h
@@ -70,10 +70,11 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 560;

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -72,12 +72,13 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    float GetPlaybackPosition();
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/DCOffset.h
+++ b/Source/DCOffset.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       w = 120;
       h = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mOffset{ 0 };
    FloatSlider* mOffsetSlider{ nullptr };

--- a/Source/DCRemoverEffect.h
+++ b/Source/DCRemoverEffect.h
@@ -48,11 +48,12 @@ public:
 
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override;
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
 
    BiquadFilter mBiquad[ChannelBuffer::kMaxNumChannels]{};
 };

--- a/Source/DebugAudioSource.h
+++ b/Source/DebugAudioSource.h
@@ -56,10 +56,11 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 80;

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -46,7 +46,7 @@ public:
 
 
    void CreateUIControls() override;
-   bool Enabled() const override { return mEnabled; }
+   bool IsEnabled() const override { return mEnabled; }
 
    void SetDelay(float delay);
    void SetShortMode(bool on);

--- a/Source/DistortionEffect.cpp
+++ b/Source/DistortionEffect.cpp
@@ -177,7 +177,7 @@ void DistortionEffect::GetModuleDimensions(float& width, float& height)
 
 void DistortionEffect::DrawModule()
 {
-   if (!Enabled())
+   if (!IsEnabled())
       return;
 
    mClipSlider->Draw();

--- a/Source/DistortionEffect.h
+++ b/Source/DistortionEffect.h
@@ -56,6 +56,8 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void DropdownUpdated(DropdownList* list, int oldVal, double time) override {}
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    enum DistortionType
    {
@@ -71,7 +73,6 @@ private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override;
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -102,6 +102,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct StoredDrumKit
    {
@@ -128,7 +130,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -84,6 +84,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct DrumSynthHitSerialData
    {
@@ -168,7 +170,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    std::array<DrumSynthHit*, DRUMSYNTH_PADS_HORIZONTAL * DRUMSYNTH_PADS_VERTICAL> mHits;

--- a/Source/EQEffect.h
+++ b/Source/EQEffect.h
@@ -62,11 +62,12 @@ public:
    void ButtonClicked(ClickButton* button, double time) override;
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override;
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -62,11 +62,12 @@ public:
    void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -77,11 +77,12 @@ public:
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
    virtual void UpdateOldControlName(std::string& oldName) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
    int GetRowHeight(int row) const;

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -85,7 +85,7 @@ public:
    void DrawModule() override;
 
    void SetEnabled(bool enabled) override {} //don't use this one
-   bool Enabled() const override { return true; }
+   bool IsEnabled() const override { return true; }
    bool HasTitleBar() const override { return mPinned; }
    bool IsSaveable() override { return mPinned; }
    void CreateUIControls() override;

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -53,7 +53,7 @@ public:
 
    void Start(double time, const ::ADSR& adsr);
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   bool Enabled() const override { return mEnabled; }
+   bool IsEnabled() const override { return mEnabled; }
 
    void CreateUIControls() override;
    void MouseReleased() override;

--- a/Source/EventCanvas.h
+++ b/Source/EventCanvas.h
@@ -80,11 +80,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void UpdateNumColumns();
    void SyncControlCablesToCanvas();

--- a/Source/FFTtoAdditive.h
+++ b/Source/FFTtoAdditive.h
@@ -66,6 +66,8 @@ public:
    virtual void SetUpFromSaveData() override;
 
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void DrawViz();
    float SinSample(float phase);
@@ -77,7 +79,6 @@ private:
       w = 235;
       h = 170;
    }
-   bool Enabled() const override { return mEnabled; }
 
    FFTData mFFTData;
 

--- a/Source/FMSynth.h
+++ b/Source/FMSynth.h
@@ -66,6 +66,8 @@ public:
 
    bool HasDebugDraw() const override { return true; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void UpdateHarmonicRatio();
 
@@ -77,7 +79,6 @@ private:
       width = 180;
       height = 203;
    }
-   bool Enabled() const override { return mEnabled; }
 
    PolyphonyMgr mPolyMgr;
    NoteInputBuffer mNoteInputBuffer;

--- a/Source/FeedbackModule.cpp
+++ b/Source/FeedbackModule.cpp
@@ -115,7 +115,7 @@ void FeedbackModule::Process(double time)
             //assert(abs(channel[i]) <= mSignalLimit);
          }
 
-         if (mDelay.Enabled())
+         if (mDelay.IsEnabled())
          {
             Add(mFeedbackTarget->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), bufferSize);
             mFeedbackVizBuffer.WriteChunk(GetBuffer()->GetChannel(ch), bufferSize, ch);

--- a/Source/FeedbackModule.h
+++ b/Source/FeedbackModule.h
@@ -58,6 +58,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       w = 115;
       h = 125;
    }
-   bool Enabled() const override { return mEnabled; }
 
    DelayEffect mDelay;
 

--- a/Source/FilterViz.h
+++ b/Source/FilterViz.h
@@ -54,12 +54,13 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void ButtonClicked(ClickButton* button, double time) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void GraphFilter();
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 300;

--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -481,7 +481,7 @@ FloatSliderLFOControl* LFOPool::GetLFO(FloatSlider* owner)
    int index = sNextLFOIndex;
    for (int i = 0; i < LFO_POOL_SIZE; ++i) //search for the next one that isn't enabled, but only one loop around
    {
-      if (!sLFOPool[index]->Enabled() && !sLFOPool[index]->IsPinned())
+      if (!sLFOPool[index]->IsEnabled() && !sLFOPool[index]->IsPinned())
          break; //found a disabled one
       index = (index + 1) % LFO_POOL_SIZE;
    }

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -71,12 +71,11 @@ public:
    LFOSettings* GetLFOSettings() { return &mLFOSettings; }
    void SetEnabled(bool enabled) override {} //don't use this one
    void SetLFOEnabled(bool enabled);
-   bool IsEnabled() const { return mEnabled; }
+   bool IsEnabled() const override { return mEnabled; }
    void SetRate(NoteInterval rate);
    void UpdateFromSettings();
    void SetOwner(FloatSlider* owner);
    FloatSlider* GetOwner() { return mTargets[0].mSliderTarget; }
-   bool Enabled() const override { return mEnabled; }
    bool HasTitleBar() const override { return mPinned; }
 
    bool IsSaveable() override { return mPinned; }

--- a/Source/FollowingSong.h
+++ b/Source/FollowingSong.h
@@ -67,10 +67,11 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 560;

--- a/Source/FormantFilterEffect.h
+++ b/Source/FormantFilterEffect.h
@@ -62,6 +62,8 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& info) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void GetModuleDimensions(float& width, float& height) override
@@ -70,7 +72,6 @@ private:
       height = mHeight;
    }
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
 
    void ResetFilters();
    void UpdateFilters();

--- a/Source/FourOnTheFloor.h
+++ b/Source/FourOnTheFloor.h
@@ -55,6 +55,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = 120;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
 
    bool mTwoOnTheFloor{ false };

--- a/Source/FreeverbEffect.h
+++ b/Source/FreeverbEffect.h
@@ -52,11 +52,12 @@ public:
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    revmodel mFreeverb;
    bool mNeedUpdate{ false };

--- a/Source/FreqDelay.h
+++ b/Source/FreqDelay.h
@@ -57,6 +57,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -65,7 +67,6 @@ private:
       width = 130;
       height = 120;
    }
-   bool Enabled() const override { return true; }
 
    ChannelBuffer mDryBuffer;
    float mDryWet{ 1 };

--- a/Source/FreqDomainBoilerplate.h
+++ b/Source/FreqDomainBoilerplate.h
@@ -61,6 +61,8 @@ public:
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -69,7 +71,6 @@ private:
       w = 235;
       h = 170;
    }
-   bool Enabled() const override { return mEnabled; }
 
    FFTData mFFTData;
 

--- a/Source/FubbleModule.h
+++ b/Source/FubbleModule.h
@@ -82,6 +82,8 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    float GetPlaybackTime(double time);
    ofRectangle GetFubbleRect();
@@ -95,7 +97,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
@@ -114,7 +115,7 @@ private:
 
       //IModulator
       virtual float Value(int samplesIn = 0) override;
-      virtual bool Active() const override { return mOwner->Enabled() && (mHasRecorded || mOwner->mIsRightClicking); }
+      virtual bool Active() const override { return mOwner->IsEnabled() && (mHasRecorded || mOwner->mIsRightClicking); }
 
       FubbleModule* mOwner{ nullptr };
       bool mIsHorizontal{ false };

--- a/Source/GainStageEffect.h
+++ b/Source/GainStageEffect.h
@@ -47,6 +47,8 @@ public:
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -55,7 +57,6 @@ private:
       width = 120;
       height = 20;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mGain{ 1 };
    FloatSlider* mGainSlider{ nullptr };

--- a/Source/GateEffect.h
+++ b/Source/GateEffect.h
@@ -53,6 +53,8 @@ public:
    void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -61,7 +63,6 @@ private:
       width = 120;
       height = 50;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mThreshold{ .1 };
    float mAttackTime{ 1 };

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -54,10 +54,11 @@ public:
    int GetModuleSaveStateRev() const override { return 0; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
 
    FloatSlider* mZoomSlider{ nullptr };

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -100,11 +100,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 4; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
    bool IsResizable() const override { return true; }

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -69,10 +69,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/GroupControl.h
+++ b/Source/GroupControl.h
@@ -52,10 +52,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    Checkbox* mGroupCheckbox{ nullptr };

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -59,10 +59,11 @@ public:
 
    static bool sShowTooltips;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
    bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
 

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -113,10 +113,10 @@ void IDrawableModule::Init()
    assert(mCanReceiveNotes == (dynamic_cast<INoteReceiver*>(this) != nullptr));
    assert(mCanReceivePulses == (dynamic_cast<IPulseReceiver*>(this) != nullptr));
 
-   bool wasEnabled = Enabled();
+   bool wasEnabled = IsEnabled();
    bool showEnableToggle = false;
    SetEnabled(!wasEnabled);
-   if (Enabled() == wasEnabled) //nothing changed
+   if (IsEnabled() == wasEnabled) //nothing changed
       showEnableToggle = false; //so don't show toggle, this module doesn't support it
    else
       showEnableToggle = true;
@@ -186,7 +186,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
 
    highlight = 0;
 
-   if (Enabled())
+   if (IsEnabled())
    {
       IAudioSource* audioSource = dynamic_cast<IAudioSource*>(this);
       if (audioSource)
@@ -234,7 +234,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
    }
 
    ofFill();
-   if (Enabled())
+   if (IsEnabled())
       ofSetColor(color.r * (.25f + highlight), color.g * (.25f + highlight), color.b * (.25f + highlight), 210);
    else
       ofSetColor(color.r * .2f, color.g * .2f, color.b * .2f, 120);
@@ -245,7 +245,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
    //gModuleShader.end();
    ofNoFill();
 
-   if (Enabled())
+   if (IsEnabled())
       gModuleDrawAlpha = 255;
    else
       gModuleDrawAlpha = 100;
@@ -323,7 +323,7 @@ void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleB
    }
 
    bool groupSelected = !TheSynth->GetGroupSelectedModules().empty() && VectorContains(this, TheSynth->GetGroupSelectedModules());
-   if ((Enabled() || groupSelected || TheSynth->GetMoveModule() == this) && mShouldDrawOutline)
+   if ((IsEnabled() || groupSelected || TheSynth->GetMoveModule() == this) && mShouldDrawOutline)
    {
       ofPushStyle();
       ofNoFill();

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -118,6 +118,7 @@ public:
    static float TitleBarHeight() { return mTitleBarHeight; }
    static ofColor GetColor(ModuleCategory type);
    virtual void SetEnabled(bool enabled) {}
+   virtual bool IsEnabled() const { return true; }
    virtual bool CanMinimize() { return true; }
    virtual void SampleDropped(int x, int y, Sample* sample) {}
    virtual bool CanDropSample() const { return false; }
@@ -219,7 +220,6 @@ private:
    virtual void PreDrawModule() {}
    virtual void DrawModule() = 0;
    virtual void DrawModuleUnclipped() {}
-   virtual bool Enabled() const { return true; }
    float GetMinimizedWidth();
    PatchCableOld GetPatchCableOld(IClickable* target);
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) {}

--- a/Source/InputChannel.h
+++ b/Source/InputChannel.h
@@ -55,6 +55,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = 64;
       height = 20;
    }
-   bool Enabled() const override { return mEnabled; }
 
    DropdownList* mChannelSelector{ nullptr };
    int mChannelSelectionIndex{ 0 };

--- a/Source/Inverter.h
+++ b/Source/Inverter.h
@@ -52,6 +52,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -60,5 +62,4 @@ private:
       w = 120;
       h = 12;
    }
-   bool Enabled() const override { return mEnabled; }
 };

--- a/Source/KarplusStrong.h
+++ b/Source/KarplusStrong.h
@@ -68,6 +68,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -77,7 +79,6 @@ private:
       width = 275;
       height = 126;
    }
-   bool Enabled() const override { return mEnabled; }
 
    PolyphonyMgr mPolyMgr;
    NoteInputBuffer mNoteInputBuffer;

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -55,6 +55,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override

--- a/Source/Kicker.h
+++ b/Source/Kicker.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 90;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 
    DrumPlayer* mDrumPlayer{ nullptr };
 };

--- a/Source/KompleteKontrol.h
+++ b/Source/KompleteKontrol.h
@@ -71,6 +71,8 @@ public:
 
    const int kNumKeys = 61;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    struct TextBox
    {
@@ -89,7 +91,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 100;

--- a/Source/LFOController.h
+++ b/Source/LFOController.h
@@ -61,10 +61,11 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void ButtonClicked(ClickButton* button, double time) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 130;

--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -173,7 +173,7 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
    if (pitch == CHORD_ENABLE_BUTTON)
    {
       if (bOn && mChorder)
-         mChorder->SetEnabled(!mChorder->Enabled());
+         mChorder->SetEnabled(!mChorder->IsEnabled());
       return;
    }
    if (pitch == CHORD_LATCH_BUTTON)
@@ -641,7 +641,7 @@ GridColor LaunchpadKeyboard::GetGridSquareColor(int x, int y)
    bool isInPentatonic = pitch >= 0 && TheScale->IsInPentatonic(pitch);
    bool isChordButton = pitch != INVALID_PITCH && pitch < 0;
    bool isPressedChordButton = isChordButton && IsChordButtonPressed(pitch);
-   bool isChorderEnabled = mChorder && mChorder->Enabled();
+   bool isChorderEnabled = mChorder && mChorder->IsEnabled();
 
    if (mLayout == kChord)
    {
@@ -666,7 +666,7 @@ GridColor LaunchpadKeyboard::GetGridSquareColor(int x, int y)
    }
    else if (pitch == CHORD_ENABLE_BUTTON)
    {
-      if (mChorder && mChorder->Enabled())
+      if (mChorder && mChorder->IsEnabled())
          color = kGridColor1Bright;
       else
          color = kGridColor1Dim;
@@ -747,7 +747,7 @@ void LaunchpadKeyboard::KeyReleased(int key)
 
 void LaunchpadKeyboard::Poll()
 {
-   bool chorderEnabled = mChorder && mChorder->Enabled();
+   bool chorderEnabled = mChorder && mChorder->IsEnabled();
    if (chorderEnabled != mWasChorderEnabled)
    {
       mWasChorderEnabled = chorderEnabled;

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -88,6 +88,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    enum LaunchpadLayout
    {
@@ -114,7 +116,6 @@ private:
       width = 120;
       height = 74;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void PlayKeyboardNote(double time, int pitch, int velocity);
    void UpdateLights(bool force = false);

--- a/Source/LaunchpadNoteDisplayer.h
+++ b/Source/LaunchpadNoteDisplayer.h
@@ -50,6 +50,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
 
 private:
    //IDrawableModule
@@ -60,7 +61,6 @@ private:
       width = 80;
       height = 0;
    }
-   bool Enabled() const override { return true; }
 
    LaunchpadKeyboard* mLaunchpad{ nullptr };
 };

--- a/Source/LinnstrumentControl.h
+++ b/Source/LinnstrumentControl.h
@@ -89,6 +89,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void InitController();
    void BuildControllerList();
@@ -102,7 +104,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = 190;

--- a/Source/Lissajous.h
+++ b/Source/Lissajous.h
@@ -58,6 +58,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 500 };
    float mHeight{ 500 };

--- a/Source/LiveGranulator.h
+++ b/Source/LiveGranulator.h
@@ -62,6 +62,8 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void Freeze();
 
@@ -72,7 +74,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mBufferLength;
    RollingBuffer mBuffer;

--- a/Source/LoopStorer.h
+++ b/Source/LoopStorer.h
@@ -78,10 +78,11 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    void SwapBuffer(int swapToIdx);

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -125,6 +125,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void DoShiftMeasure();
    void DoHalfShift();
@@ -145,7 +147,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    static const int BUFFER_X = 3;

--- a/Source/LooperGranulator.h
+++ b/Source/LooperGranulator.h
@@ -69,10 +69,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
 
    float mWidth{ 200 };

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -103,6 +103,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void SyncLoopLengths();
    void UpdateSpeed();
@@ -119,8 +121,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
-
    float mWidth{ 235 };
    float mHeight{ 126 };
    RollingBuffer mRecordBuffer;

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -61,11 +61,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void StepBy(double time, float velocity, int flags);
    void ResetStep();

--- a/Source/MPESmoother.h
+++ b/Source/MPESmoother.h
@@ -59,6 +59,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/MPETweaker.h
+++ b/Source/MPETweaker.h
@@ -55,6 +55,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/MacroSlider.h
+++ b/Source/MacroSlider.h
@@ -60,6 +60,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    const static int kMappingSpacing = 32;
 
@@ -70,7 +72,6 @@ private:
       width = 110;
       height = 25 + (int)mMappings.size() * kMappingSpacing;
    }
-   bool Enabled() const override { return mEnabled; }
 
    struct Mapping : public IModulator
    {
@@ -83,7 +84,7 @@ private:
 
       //IModulator
       virtual float Value(int samplesIn = 0) override;
-      virtual bool Active() const override { return mOwner->Enabled(); }
+      virtual bool Active() const override { return mOwner->IsEnabled(); }
 
       MacroSlider* mOwner{ nullptr };
       int mIndex{ 0 };

--- a/Source/Metronome.h
+++ b/Source/Metronome.h
@@ -63,10 +63,11 @@ public:
    virtual void SetUpFromSaveData() override;
 
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 80;

--- a/Source/MidiCapturer.h
+++ b/Source/MidiCapturer.h
@@ -75,6 +75,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -83,7 +85,6 @@ private:
       width = 300;
       height = 150;
    }
-   bool Enabled() const override { return true; }
 
    static const int kRingBufferLength = 1000;
    int mRingBufferPos{ 0 };

--- a/Source/MidiClockIn.h
+++ b/Source/MidiClockIn.h
@@ -59,6 +59,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void InitDevice();
    void BuildDeviceList();
@@ -66,7 +68,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = mWidth;

--- a/Source/MidiClockOut.h
+++ b/Source/MidiClockOut.h
@@ -60,13 +60,14 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void InitDevice();
    void BuildDeviceList();
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = mWidth;

--- a/Source/MidiControlChange.h
+++ b/Source/MidiControlChange.h
@@ -57,6 +57,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -65,7 +67,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -345,6 +345,8 @@ public:
    static double sLastBoundControlTime;
    static IUIControl* sLastBoundUIControl;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    enum MappingDisplayMode
    {
@@ -357,7 +359,6 @@ private:
    void DrawModule() override;
    void DrawModuleUnclipped() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 

--- a/Source/MidiOutput.h
+++ b/Source/MidiOutput.h
@@ -61,13 +61,14 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void InitController();
    void BuildControllerList();
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = 190;

--- a/Source/ModWheel.h
+++ b/Source/ModWheel.h
@@ -59,6 +59,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       width = 120;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mModWheel{ 0 };
    FloatSlider* mModWheelSlider{ nullptr };

--- a/Source/ModWheelToCV.h
+++ b/Source/ModWheelToCV.h
@@ -65,6 +65,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -73,7 +75,6 @@ private:
       width = 106;
       height = 17 * 2 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    ModulationChain* mModWheel{ nullptr };
 };

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -66,9 +66,10 @@ public:
    void TextEntryActivated(TextEntry* entry) override;
    void TextEntryComplete(TextEntry* entry) override;
 
+   bool IsEnabled() const override { return false; }
+
 private:
    void DrawModule() override {}
-   bool Enabled() const override { return false; }
 };
 
 class ModularSynth

--- a/Source/ModulationVisualizer.h
+++ b/Source/ModulationVisualizer.h
@@ -48,6 +48,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -56,7 +58,6 @@ private:
       width = 300;
       height = 100;
    }
-   bool Enabled() const override { return mEnabled; }
 
    struct VizVoice
    {

--- a/Source/ModulatorAccum.h
+++ b/Source/ModulatorAccum.h
@@ -69,6 +69,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -77,7 +79,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/ModulatorAdd.h
+++ b/Source/ModulatorAdd.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 106;
       h = 17 * 2 + 4;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mValue1{ 0 };
    float mValue2{ 0 };

--- a/Source/ModulatorAddCentered.h
+++ b/Source/ModulatorAddCentered.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 106;
       h = 17 * 3 + 4;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mValue1{ 0 };
    float mValue2{ 0 };

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -69,6 +69,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -77,7 +79,6 @@ private:
       w = 106;
       h = 121;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/ModulatorExpression.h
+++ b/Source/ModulatorExpression.h
@@ -62,11 +62,12 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mExpressionInput{ 0 };
    FloatSlider* mExpressionInputSlider{ nullptr };

--- a/Source/ModulatorGravity.h
+++ b/Source/ModulatorGravity.h
@@ -74,6 +74,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void Kick(float strength);
 
@@ -84,7 +86,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/ModulatorMult.h
+++ b/Source/ModulatorMult.h
@@ -61,6 +61,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -69,7 +71,6 @@ private:
       w = 106;
       h = 17 * 2 + 4;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mValue1{ 0 };
    float mValue2{ 0 };

--- a/Source/ModulatorSmoother.h
+++ b/Source/ModulatorSmoother.h
@@ -68,6 +68,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -76,7 +78,6 @@ private:
       w = 106;
       h = 17 * 2 + 4;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mInput{ 0 };
    float mSmooth{ .1 };

--- a/Source/ModulatorSubtract.h
+++ b/Source/ModulatorSubtract.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 106;
       h = 17 * 2 + 4;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mValue1{ 0 };
    float mValue2{ 0 };

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -70,13 +70,14 @@ public:
 
    bool IsSaveable() override { return false; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void ApplyChanges();
    void FillDropdownList(DropdownList* list, ModuleSaveData::SaveVal* save);
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
 
    IDrawableModule* mSaveModule{ nullptr };

--- a/Source/ModwheelToPressure.h
+++ b/Source/ModwheelToPressure.h
@@ -48,6 +48,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -56,7 +58,6 @@ private:
       width = 120;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 };
 
 #endif /* defined(__Bespoke__ModwheelToPressure__) */

--- a/Source/ModwheelToVibrato.h
+++ b/Source/ModwheelToVibrato.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = 138;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    NoteInterval mVibratoInterval{ NoteInterval::kInterval_16n };
    DropdownList* mIntervalSelector{ nullptr };

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -56,6 +56,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
    int GetMostRecentCurrentlyHeldPitch() const;
 
    double mHeldNotes[128];

--- a/Source/MultibandCompressor.h
+++ b/Source/MultibandCompressor.h
@@ -62,6 +62,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 210;
       h = 150;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void CalcFilters();
 

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -82,10 +82,11 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/Muter.h
+++ b/Source/Muter.h
@@ -52,6 +52,8 @@ public:
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -60,7 +62,6 @@ private:
       w = 80;
       h = 38;
    }
-   bool Enabled() const override { return true; }
 
    bool mPass{ false };
 

--- a/Source/Neighborhooder.h
+++ b/Source/Neighborhooder.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 120;
       height = 38;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mMinPitch{ 55 };
    int mPitchRange{ 16 };

--- a/Source/NoiseEffect.h
+++ b/Source/NoiseEffect.h
@@ -54,6 +54,8 @@ public:
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,8 +64,6 @@ private:
       width = 120;
       height = 60;
    }
-   bool Enabled() const override { return mEnabled; }
-
 
    float mAmount{ 0 };
    int mWidth{ 10 };

--- a/Source/NoteCanvas.h
+++ b/Source/NoteCanvas.h
@@ -88,11 +88,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    double GetCurPos(double time) const;
    void UpdateNumColumns();

--- a/Source/NoteChainNode.h
+++ b/Source/NoteChainNode.h
@@ -67,10 +67,11 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = 110;

--- a/Source/NoteChance.h
+++ b/Source/NoteChance.h
@@ -56,11 +56,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void Reseed();
 

--- a/Source/NoteCounter.h
+++ b/Source/NoteCounter.h
@@ -73,11 +73,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 2; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void Step(double time, float velocity, int pulseFlags);
    void Reseed();

--- a/Source/NoteCreator.h
+++ b/Source/NoteCreator.h
@@ -58,12 +58,13 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 protected:
    void TriggerNote(double time, float velocity);
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = mWidth;

--- a/Source/NoteDelayer.h
+++ b/Source/NoteDelayer.h
@@ -59,6 +59,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    struct NoteInfo
@@ -76,7 +77,6 @@ private:
       width = 108;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mDelay{ .25 };
    FloatSlider* mDelaySlider{ nullptr };

--- a/Source/NoteDisplayer.h
+++ b/Source/NoteDisplayer.h
@@ -47,6 +47,8 @@ public:
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -55,7 +57,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    void DrawNoteName(int pitch, float y) const;
 

--- a/Source/NoteEcho.h
+++ b/Source/NoteEcho.h
@@ -54,6 +54,8 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    void SendNoteToIndex(int index, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation);
 

--- a/Source/NoteExpressionRouter.h
+++ b/Source/NoteExpressionRouter.h
@@ -55,6 +55,8 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    static const int kMaxDestinations = 5;
    AdditionalNoteCable* mDestinationCables[kMaxDestinations]{ nullptr };

--- a/Source/NoteFilter.h
+++ b/Source/NoteFilter.h
@@ -48,11 +48,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    std::array<bool, 128> mGate;
    std::array<float, 128> mLastPlayTime;

--- a/Source/NoteFlusher.h
+++ b/Source/NoteFlusher.h
@@ -47,6 +47,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -55,7 +57,6 @@ private:
       width = 90;
       height = 18;
    }
-   bool Enabled() const override { return mEnabled; }
 
    ClickButton* mFlushButton{ nullptr };
 };

--- a/Source/NoteGate.h
+++ b/Source/NoteGate.h
@@ -49,11 +49,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return true; }
 
    bool mGate{ true };
    Checkbox* mGateCheckbox{ nullptr };

--- a/Source/NoteHocket.h
+++ b/Source/NoteHocket.h
@@ -59,6 +59,8 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    void SendNoteToIndex(int index, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation);
    void Reseed();

--- a/Source/NoteHumanizer.h
+++ b/Source/NoteHumanizer.h
@@ -59,6 +59,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule
@@ -68,7 +69,6 @@ private:
       width = 108;
       height = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mTime{ 33 };
    FloatSlider* mTimeSlider{ nullptr };

--- a/Source/NoteLatch.h
+++ b/Source/NoteLatch.h
@@ -50,6 +50,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -58,7 +60,6 @@ private:
       width = 90;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 
    bool mNoteState[128]{};
 };

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -76,6 +76,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    double GetCurPos(double time) const;
    NoteCanvasElement* AddNote(double measurePos, int pitch, int velocity, double length, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
@@ -89,7 +91,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    struct SavedPattern
    {

--- a/Source/NoteOctaver.h
+++ b/Source/NoteOctaver.h
@@ -56,6 +56,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    struct NoteInfo
@@ -73,7 +74,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/NotePanAlternator.h
+++ b/Source/NotePanAlternator.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 108;
       height = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    bool mFlip{ false };
    float mPanOne{ -1 };

--- a/Source/NotePanRandom.h
+++ b/Source/NotePanRandom.h
@@ -53,6 +53,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -61,7 +63,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mSpread{ 1 };
    FloatSlider* mSpreadSlider{ nullptr };

--- a/Source/NotePanner.h
+++ b/Source/NotePanner.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 108;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPan{ 0 };
    FloatSlider* mPanSlider{ nullptr };

--- a/Source/NoteQuantizer.h
+++ b/Source/NoteQuantizer.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = 80;
       height = 40;
    }
-   bool Enabled() const override { return true; }
    void OnEvent(double time, float strength);
 
    struct InputInfo

--- a/Source/NoteRangeFilter.h
+++ b/Source/NoteRangeFilter.h
@@ -53,6 +53,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -61,7 +63,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/NoteRatchet.h
+++ b/Source/NoteRatchet.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/NoteRouter.h
+++ b/Source/NoteRouter.h
@@ -59,11 +59,12 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return true; }
 
    bool IsIndexActive(int idx) const;
 

--- a/Source/NoteSinger.h
+++ b/Source/NoteSinger.h
@@ -79,6 +79,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule
@@ -88,7 +89,6 @@ private:
       width = 100;
       height = 50;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int GetPitchForBucket(int bucket);
 

--- a/Source/NoteSorter.h
+++ b/Source/NoteSorter.h
@@ -54,11 +54,12 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return true; }
 
    std::array<int, 128> mPitch;
    std::vector<TextEntry*> mPitchEntry;

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -124,11 +124,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 3; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    void UpdateGridControllerLights(bool force);
 

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -56,6 +56,8 @@ public:
    virtual void SetUpFromSaveData() override;
    virtual void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    void SendNoteToIndex(int index, double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation);
 

--- a/Source/NoteStreamDisplay.h
+++ b/Source/NoteStreamDisplay.h
@@ -55,6 +55,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return true; }
    bool IsElementActive(int index) const;
    float GetYPos(int pitch, float noteHeight) const;
 

--- a/Source/NoteStrummer.h
+++ b/Source/NoteStrummer.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = 200;
       height = 35;
    }
-   bool Enabled() const override { return true; }
 
    float mStrum{ 0 };
    float mLastStrumPos{ 0 };

--- a/Source/NoteSustain.h
+++ b/Source/NoteSustain.h
@@ -60,6 +60,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -68,7 +70,6 @@ private:
       width = 110;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    struct QueuedNoteOff
    {

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -97,11 +97,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 2; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    void UpdateGridControllerLights(bool force);
 

--- a/Source/NoteToFreq.h
+++ b/Source/NoteToFreq.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       width = 110;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPitch{ 0 };
    ModulationChain* mPitchBend{ nullptr };

--- a/Source/NoteToMs.h
+++ b/Source/NoteToMs.h
@@ -62,6 +62,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       width = 110;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPitch{ 0 };
    ModulationChain* mPitchBend{ nullptr };

--- a/Source/NoteToPulse.h
+++ b/Source/NoteToPulse.h
@@ -55,6 +55,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,5 +65,4 @@ private:
       width = 110;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 };

--- a/Source/NoteToggle.h
+++ b/Source/NoteToggle.h
@@ -52,10 +52,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    std::array<bool, 128> mHeldPitches{ false };

--- a/Source/NoteTransformer.h
+++ b/Source/NoteTransformer.h
@@ -53,6 +53,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -61,8 +63,6 @@ private:
       width = 120;
       height = 135;
    }
-   bool Enabled() const override { return mEnabled; }
-
 
    int mToneMod[7]{};
    IntSlider* mToneModSlider[7];

--- a/Source/NoteVibrato.h
+++ b/Source/NoteVibrato.h
@@ -60,6 +60,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -68,7 +70,6 @@ private:
       width = 138;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    NoteInterval mVibratoInterval{ NoteInterval::kInterval_16n };
    DropdownList* mIntervalSelector{ nullptr };

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -68,10 +68,11 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
 
    char* mLabels[OSC_OUTPUT_MAX_PARAMS];

--- a/Source/OutputChannel.h
+++ b/Source/OutputChannel.h
@@ -55,6 +55,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    int GetNumChannels() const { return mChannelSelectionIndex < mStereoSelectionOffset ? 1 : 2; }
 

--- a/Source/PSMoveController.h
+++ b/Source/PSMoveController.h
@@ -71,6 +71,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -79,7 +81,6 @@ private:
       width = 152;
       height = 140;
    }
-   bool Enabled() const override { return mEnabled; }
 
    PSMoveMgr mMoveMgr;
    Ramp mVibration;

--- a/Source/PanicButton.h
+++ b/Source/PanicButton.h
@@ -40,10 +40,11 @@ public:
    static bool AcceptsNotes() { return false; }
    static bool AcceptsPulses() { return false; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 300;

--- a/Source/Panner.h
+++ b/Source/Panner.h
@@ -62,6 +62,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -70,7 +72,6 @@ private:
       w = 120;
       h = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPan{ 0 };
    Ramp mPanRamp;

--- a/Source/PitchBender.h
+++ b/Source/PitchBender.h
@@ -59,6 +59,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       width = 120;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mBend;
    FloatSlider* mBendSlider;

--- a/Source/PitchChorus.h
+++ b/Source/PitchChorus.h
@@ -59,6 +59,8 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       w = 120;
       h = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    static const int kNumShifters = 5;
 

--- a/Source/PitchDive.h
+++ b/Source/PitchDive.h
@@ -55,6 +55,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -63,7 +65,6 @@ private:
       width = 120;
       height = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mStart;
    FloatSlider* mStartSlider;

--- a/Source/PitchPanner.h
+++ b/Source/PitchPanner.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 108;
       height = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mPitchLeft;
    IntSlider* mPitchLeftSlider;

--- a/Source/PitchRemap.h
+++ b/Source/PitchRemap.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct NoteInfo
    {
@@ -74,7 +76,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    struct Remap
    {

--- a/Source/PitchSetter.h
+++ b/Source/PitchSetter.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       width = 90;
       height = 20;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mPitch{ 36 };
    IntSlider* mPitchSlider{ nullptr };

--- a/Source/PitchShiftEffect.h
+++ b/Source/PitchShiftEffect.h
@@ -53,11 +53,12 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mRatio{ 1 };
    FloatSlider* mRatioSlider{ nullptr };

--- a/Source/PitchToCV.h
+++ b/Source/PitchToCV.h
@@ -64,6 +64,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -72,7 +74,6 @@ private:
       width = 106;
       height = 17 * 2 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPitch{ 0 };
    ModulationChain* mPitchBend{ nullptr };

--- a/Source/PitchToSpeed.h
+++ b/Source/PitchToSpeed.h
@@ -65,6 +65,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -73,7 +75,6 @@ private:
       width = 106;
       height = 17 * 2 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPitch{ 0 };
    ModulationChain* mPitchBend{ nullptr };

--- a/Source/PlaySequencer.h
+++ b/Source/PlaySequencer.h
@@ -89,11 +89,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    void SetGridSize(float w, float h);

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -93,6 +93,8 @@ public:
    void SaveState(FileStreamOut& out) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -102,7 +104,6 @@ private:
       height = mHeight;
    }
    void OnClicked(float x, float y, bool right) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 350 };
    float mHeight;

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -70,11 +70,12 @@ public:
    static bool sLastLoadWasPrefab;
    static IDrawableModule* sJustReleasedModule;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;

--- a/Source/Pressure.h
+++ b/Source/Pressure.h
@@ -59,6 +59,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       width = 120;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mPressure{ 0 };
    FloatSlider* mPressureSlider{ nullptr };

--- a/Source/PressureToCV.h
+++ b/Source/PressureToCV.h
@@ -64,6 +64,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -72,7 +74,6 @@ private:
       width = 106;
       height = 17 * 2 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    ModulationChain* mPressure{ nullptr };
 };

--- a/Source/PressureToModwheel.h
+++ b/Source/PressureToModwheel.h
@@ -48,6 +48,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -56,7 +58,6 @@ private:
       width = 120;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 };
 
 #endif /* defined(__Bespoke__PressureToModwheel__) */

--- a/Source/PressureToVibrato.h
+++ b/Source/PressureToVibrato.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = 138;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    NoteInterval mVibratoInterval{ NoteInterval::kInterval_16n };
    DropdownList* mIntervalSelector{ nullptr };

--- a/Source/PreviousNote.h
+++ b/Source/PreviousNote.h
@@ -46,6 +46,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -54,7 +56,6 @@ private:
       width = 110;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mPitch{ -1 };
    int mVelocity{ 0 };

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -81,6 +81,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    void UpdateSample();
@@ -94,7 +95,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/PulseButton.h
+++ b/Source/PulseButton.h
@@ -48,6 +48,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -56,7 +58,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    ClickButton* mButton{ nullptr };
    float mWidth{ 200 };

--- a/Source/PulseChance.h
+++ b/Source/PulseChance.h
@@ -56,11 +56,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void Reseed();
 

--- a/Source/PulseDelayer.h
+++ b/Source/PulseDelayer.h
@@ -59,6 +59,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    struct PulseInfo
@@ -75,7 +76,6 @@ private:
       width = 108;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mDelay{ .25 };
    FloatSlider* mDelaySlider{ nullptr };

--- a/Source/PulseDisplayer.h
+++ b/Source/PulseDisplayer.h
@@ -49,11 +49,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 150 };
    float mHeight{ 30 };

--- a/Source/PulseFlag.h
+++ b/Source/PulseFlag.h
@@ -52,11 +52,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 150 };
    float mHeight{ 40 };

--- a/Source/PulseGate.h
+++ b/Source/PulseGate.h
@@ -50,6 +50,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -58,7 +60,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    bool mAllow{ true };
    Checkbox* mAllowCheckbox{ nullptr };

--- a/Source/PulseHocket.h
+++ b/Source/PulseHocket.h
@@ -56,6 +56,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return true; }
 
    void Reseed();
    void AdjustHeight();

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -90,11 +90,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    void Step(double time, float velocity, int flags);

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -82,11 +82,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
 
    void Step(double time, float velocity, int flags);

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -69,11 +69,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    float GetOffset();
 

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -58,6 +58,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
    double GetIntervalPos(double time);
    void SyncToAdsr();
 

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -69,12 +69,13 @@ public:
    static void CreateStaticFramebuffer(); //windows was having trouble creating a nanovg context and fbo on the fly
    static IUIControl* sBindToUIControl;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
    void PostRender() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -98,6 +98,8 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void Step(double time, int pulseFlags);
    void SetGridSize(float w, float h);
@@ -106,7 +108,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -70,10 +70,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/RandomNoteGenerator.h
+++ b/Source/RandomNoteGenerator.h
@@ -59,6 +59,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,8 +69,6 @@ private:
       width = 120;
       height = 92;
    }
-   bool Enabled() const override { return mEnabled; }
-
 
    NoteInterval mInterval{ NoteInterval::kInterval_16n };
    DropdownList* mIntervalSelector{ nullptr };

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -76,6 +76,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    float SinSample(float phase); //phase 0-512
@@ -84,7 +85,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& w, float& h) override
    {
       w = 1020;

--- a/Source/Rewriter.h
+++ b/Source/Rewriter.h
@@ -64,6 +64,8 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -72,7 +74,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/RingModulator.h
+++ b/Source/RingModulator.h
@@ -67,6 +67,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -75,7 +77,6 @@ private:
       width = 130;
       height = 68;
    }
-   bool Enabled() const override { return mEnabled; }
 
    ChannelBuffer mDryBuffer;
 

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -52,10 +52,11 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 300;

--- a/Source/SampleCanvas.h
+++ b/Source/SampleCanvas.h
@@ -76,11 +76,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void SetNumMeasures(int numMeasures);
    void UpdateNumColumns();

--- a/Source/SampleCapturer.h
+++ b/Source/SampleCapturer.h
@@ -57,11 +57,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    void MouseReleased() override;

--- a/Source/SampleFinder.h
+++ b/Source/SampleFinder.h
@@ -75,6 +75,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void UpdateSample();
    void DoWrite();
@@ -83,7 +85,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    Sample* mSample{ nullptr };

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -103,6 +103,8 @@ public:
    int GetModuleSaveStateRev() const override { return 2; }
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void UpdateSample(Sample* sample, bool ownsSample);
    float GetPlayPositionForMouse(float mouseX) const;
@@ -127,7 +129,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -83,6 +83,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 2; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void StopRecording();
    float DetectSampleFrequency();
@@ -90,8 +92,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
-
 
    PolyphonyMgr mPolyMgr;
    NoteInputBuffer mNoteInputBuffer;

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -91,11 +91,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 0; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;
 

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -143,6 +143,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    struct ScaleInfo
    {
@@ -158,7 +160,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return true; }
 
    void NotifyListeners();
 

--- a/Source/ScaleDegree.h
+++ b/Source/ScaleDegree.h
@@ -53,6 +53,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct NoteInfo
    {
@@ -71,7 +73,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 200 };
    float mHeight{ 20 };

--- a/Source/ScaleDetect.h
+++ b/Source/ScaleDetect.h
@@ -63,6 +63,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
 
 private:
    bool ScaleSatisfied(int root, std::string type);
@@ -74,7 +75,6 @@ private:
       width = 140;
       height = 36;
    }
-   bool Enabled() const override { return true; }
 
    std::array<bool, 128> mPitchOn{ false };
    ClickButton* mResetButton{ nullptr };

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -126,6 +126,8 @@ public:
 
    static std::string GetBootstrapImportString() { return "import bespoke; import module; import scriptmodule; import random; import math"; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void PlayNote(double time, float pitch, float velocity, float pan, int noteOutputIndex, int lineNum);
    void AdjustUIControl(IUIControl* control, float value, double time, int lineNum);
@@ -149,7 +151,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
@@ -315,10 +316,11 @@ public:
 
    void ButtonClicked(ClickButton* button, double time) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override
@@ -358,9 +360,10 @@ public:
       height = mHeight;
    }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void DrawModule() override;
-   bool Enabled() const override { return true; }
 
    int mWidth{ 600 };
    int mHeight{ 120 };

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -54,10 +54,11 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -89,6 +89,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    void UpdateSample();
    void UpdateDisplaySamples();
@@ -96,7 +98,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/Selector.h
+++ b/Source/Selector.h
@@ -56,10 +56,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    void SyncList();

--- a/Source/SignalClamp.h
+++ b/Source/SignalClamp.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       w = 120;
       h = 40;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mMin{ -1 };
    FloatSlider* mMinSlider{ nullptr };

--- a/Source/SignalGenerator.h
+++ b/Source/SignalGenerator.h
@@ -72,11 +72,12 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    enum FreqMode
    {

--- a/Source/SingleOscillator.h
+++ b/Source/SingleOscillator.h
@@ -76,6 +76,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -85,7 +87,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
    void UpdateOldControlName(std::string& oldName) override;
 
    float mWidth{ 200 };

--- a/Source/SliderSequencer.h
+++ b/Source/SliderSequencer.h
@@ -87,6 +87,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    float MeasurePos(double time);
 
@@ -97,7 +99,6 @@ private:
       width = 320;
       height = 165;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mLastMeasurePos{ 0 };
    std::vector<SliderLine*> mSliderLines;

--- a/Source/SlowLayers.h
+++ b/Source/SlowLayers.h
@@ -70,11 +70,12 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    int LoopLength() const;
 

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -83,6 +83,8 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void SetSnapshot(int idx, double time);
    void Store(int idx);
@@ -95,7 +97,6 @@ private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -71,11 +71,12 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    bool IsResizable() const override { return false; }
    void PostRepatch(PatchCableSource* cable, bool fromUserClick) override;
    bool ShouldSavePatchCableSources() const override { return false; }

--- a/Source/SpectralDisplay.h
+++ b/Source/SpectralDisplay.h
@@ -59,6 +59,8 @@ public:
 
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mWidth{ 400 };
    float mHeight{ 100 };

--- a/Source/Splitter.h
+++ b/Source/Splitter.h
@@ -54,6 +54,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -62,7 +64,6 @@ private:
       w = 80;
       h = 10;
    }
-   bool Enabled() const override { return mEnabled; }
 
    RollingBuffer mVizBuffer2;
    PatchCableSource* mPatchCableSource2{ nullptr };

--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -1112,7 +1112,7 @@ void StepSequencerRow::CreateUIControls()
 
 void StepSequencerRow::OnTimeEvent(double time)
 {
-   if (mSeq->Enabled() == false || mSeq->HasExternalPulseSource())
+   if (mSeq->IsEnabled() == false || mSeq->HasExternalPulseSource())
       return;
 
    float offsetMs = mOffset * TheTransport->MsPerBar();

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -122,7 +122,7 @@ public:
    void Poll() override;
    void PlayStepNote(double time, int note, float val);
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
-   bool Enabled() const override { return mEnabled; }
+   bool IsEnabled() const override { return mEnabled; }
    int GetPadPressure(int row) { return mPadPressures[row]; }
    NoteInterval GetStepInterval() const { return mStepInterval; }
    int GetStepNum(double time);

--- a/Source/StutterControl.cpp
+++ b/Source/StutterControl.cpp
@@ -211,7 +211,7 @@ StutterParams StutterControl::GetStutter(StutterControl::StutterType type)
 void StutterControl::CheckboxUpdated(Checkbox* checkbox, double time)
 {
    if (checkbox == mEnabledCheckbox)
-      mStutterProcessor.SetEnabled(time, Enabled());
+      mStutterProcessor.SetEnabled(time, IsEnabled());
 
    for (int i = 0; i < kNumStutterTypes; ++i)
    {

--- a/Source/StutterControl.h
+++ b/Source/StutterControl.h
@@ -66,6 +66,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    enum StutterType
    {
@@ -94,7 +96,6 @@ private:
 
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
    void UpdateGridLights();
 

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -50,6 +50,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -58,7 +60,6 @@ private:
       width = 90;
       height = 21;
    }
-   bool Enabled() const override { return true; }
 
    std::array<bool, 128> mIsNoteBeingSustained{ false };
    bool mSustain{ false };

--- a/Source/TakeRecorder.h
+++ b/Source/TakeRecorder.h
@@ -59,6 +59,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -67,7 +69,6 @@ private:
       w = 120;
       h = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mStartSeconds{ 0 };
    FloatSlider* mStartSecondsSlider{ nullptr };

--- a/Source/TimelineControl.h
+++ b/Source/TimelineControl.h
@@ -58,10 +58,11 @@ public:
    void SetUpFromSaveData() override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& w, float& h) override;
 
    float GetSliderWidth() { return mWidth - 6; }

--- a/Source/TimerDisplay.h
+++ b/Source/TimerDisplay.h
@@ -45,10 +45,11 @@ public:
 
    void ButtonClicked(ClickButton* button, double time) override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 150;

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -148,11 +148,12 @@ public:
 
    static bool sShowInitialHelpOverlay;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void DrawModuleUnclipped() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -178,6 +178,8 @@ public:
    static bool sDoEventLookahead;
    static double sEventEarlyMs;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    void UpdateListeners(double jumpMs);
    double Swing(double measurePos);
@@ -194,7 +196,6 @@ private:
       width = 140;
       height = 100;
    }
-   bool Enabled() const override { return true; }
 
    float mTempo{ 120 };
    int mTimeSigTop{ 4 };

--- a/Source/TransposeFrom.h
+++ b/Source/TransposeFrom.h
@@ -60,6 +60,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    struct NoteInfo
    {
@@ -76,7 +78,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int GetTransposeAmount() const;
    void OnRootChanged(double time);

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -56,6 +56,8 @@ public:
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -64,7 +66,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mAmount{ 0 };
    FloatSlider* mAmountSlider{ nullptr };

--- a/Source/UnstableModWheel.h
+++ b/Source/UnstableModWheel.h
@@ -60,6 +60,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -68,7 +70,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void FillModulationBuffer(double time, int voiceIdx);
 

--- a/Source/UnstablePitch.h
+++ b/Source/UnstablePitch.h
@@ -82,6 +82,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -90,7 +92,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void FillModulationBuffer(double time, int voiceIdx);
 

--- a/Source/UnstablePressure.h
+++ b/Source/UnstablePressure.h
@@ -60,6 +60,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -68,7 +70,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void FillModulationBuffer(double time, int voiceIdx);
 

--- a/Source/UserPrefsEditor.h
+++ b/Source/UserPrefsEditor.h
@@ -66,10 +66,11 @@ public:
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return true; }
    void GetModuleDimensions(float& width, float& height) override
    {
       width = mWidth;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -105,12 +105,13 @@ public:
    int GetModuleSaveStateRev() const override { return 3; }
    std::vector<IUIControl*> ControlsToIgnoreInSaveState() const override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void PreDrawModule() override;
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
    void LoadVST(juce::PluginDescription desc);
    void LoadVSTFromSaveData(FileStreamIn& in, int rev);
    void GetVSTFileDesc(std::string vstName, juce::PluginDescription& desc);

--- a/Source/ValueSetter.h
+++ b/Source/ValueSetter.h
@@ -64,6 +64,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -72,7 +74,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void Go(double time);
 

--- a/Source/ValueStream.h
+++ b/Source/ValueStream.h
@@ -70,10 +70,11 @@ public:
    //IPatchable
    void PostRepatch(PatchCableSource* cableSource, bool fromUserClick) override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
-   bool Enabled() const override { return mEnabled; }
    void GetModuleDimensions(float& width, float& height) override;
 
    IUIControl* mUIControl{ nullptr };

--- a/Source/VelocityCurve.h
+++ b/Source/VelocityCurve.h
@@ -57,6 +57,8 @@ public:
    void LoadState(FileStreamIn& in, int rev) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -65,7 +67,6 @@ private:
       w = 106;
       h = 105;
    }
-   bool Enabled() const override { return mEnabled; }
 
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/VelocityScaler.h
+++ b/Source/VelocityScaler.h
@@ -53,6 +53,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -61,7 +63,6 @@ private:
       width = 108;
       height = 22;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mScale{ 1 };
    FloatSlider* mScaleSlider{ nullptr };

--- a/Source/VelocitySetter.h
+++ b/Source/VelocitySetter.h
@@ -54,6 +54,7 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule
@@ -63,7 +64,6 @@ private:
       width = 90;
       height = 38;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mVelocity{ 1 };
    FloatSlider* mVelocitySlider{ nullptr };

--- a/Source/VelocityStepSequencer.h
+++ b/Source/VelocityStepSequencer.h
@@ -79,6 +79,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -87,7 +89,6 @@ private:
       width = 160;
       height = 160;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mVels[VSS_MAX_STEPS]{};
    IntSlider* mVelSliders[VSS_MAX_STEPS]{};

--- a/Source/VelocityToCV.h
+++ b/Source/VelocityToCV.h
@@ -65,6 +65,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -73,7 +75,6 @@ private:
       width = 106;
       height = 17 * 3 + 2;
    }
-   bool Enabled() const override { return mEnabled; }
 
    int mVelocity{ 0 };
    bool mPassZero{ false };

--- a/Source/VelocityToChance.h
+++ b/Source/VelocityToChance.h
@@ -57,11 +57,12 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
-   bool Enabled() const override { return mEnabled; }
 
    void Reseed();
 

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -85,6 +85,8 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    bool CanStartVinylControl();
 
@@ -95,7 +97,6 @@ private:
       width = 90;
       height = 20;
    }
-   bool Enabled() const override { return mEnabled; }
 
    bool mUseVinylControl{ false };
    Checkbox* mUseVinylControlCheckbox{ nullptr };

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -69,6 +69,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -77,7 +79,6 @@ private:
       w = 235;
       h = 170;
    }
-   bool Enabled() const override { return mEnabled; }
 
    FFTData mFFTData{ VOCODER_WINDOW_SIZE, FFT_FREQDOMAIN_SIZE };
 

--- a/Source/VocoderCarrierInput.h
+++ b/Source/VocoderCarrierInput.h
@@ -58,6 +58,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return true; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       w = 60;
       h = 0;
    }
-   bool Enabled() const override { return true; }
 
    VocoderBase* mVocoder{ nullptr };
    IAudioReceiver* mVocoderTarget{ nullptr };

--- a/Source/VolcaBeatsControl.h
+++ b/Source/VolcaBeatsControl.h
@@ -58,6 +58,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -66,7 +68,6 @@ private:
       width = 263;
       height = 170;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mClapSpeed{ .5 };
    float mClaveSpeed{ .5 };

--- a/Source/WaveformViewer.h
+++ b/Source/WaveformViewer.h
@@ -66,6 +66,8 @@ public:
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -74,7 +76,6 @@ private:
       w = mWidth;
       h = mHeight;
    }
-   bool Enabled() const override { return mEnabled; }
 
    float mAudioView[BUFFER_VIZ_SIZE][2]{};
    bool mDoubleBufferFlip{ false };

--- a/Source/Waveshaper.h
+++ b/Source/Waveshaper.h
@@ -59,11 +59,12 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override;
-   bool Enabled() const override { return mEnabled; }
 
    float mRescale{ 1 };
    FloatSlider* mRescaleSlider{ nullptr };

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -50,6 +50,8 @@ public:
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
 
+   bool IsEnabled() const override { return mEnabled; }
+
 private:
    //IDrawableModule
    void DrawModule() override;
@@ -58,7 +60,6 @@ private:
       width = 110;
       height = 0;
    }
-   bool Enabled() const override { return mEnabled; }
 };
 
 #endif /* defined(__modularSynth__WhiteKeys__) */

--- a/resource/osc_support.txt
+++ b/resource/osc_support.txt
@@ -68,9 +68,9 @@ Direct module control:
 	(Un-)Minimizing a module:
 		address: /bespoke/module/pulse/<module name>
 		parameters: [f] or [i]
-			If the first paramater is 0 the module will be minimized.
-			If the first paramater is 1 the module will be un-minimized.
-			If the first paramater is -1 the module will toggle its minimized state.
+			If the first parameter is 0 the module will be minimized.
+			If the first parameter is 1 the module will be un-minimized.
+			If the first parameter is -1 the module will toggle its minimized state.
 		Notes:
 			The <module name> should be the URL escaped name of the module.
 		example: /bespoke/module/minimize/notesequencer -1
@@ -78,9 +78,9 @@ Direct module control:
 	Enabling or disabling a module:
 		address: /bespoke/module/enable/<module name>
 		parameters: [f] or [i]
-			If the first paramater is 0 the module will be disabled.
-			If the first paramater is 1 the module will be enabled.
-			If the first paramater is -1 the module will toggle its enabled state.
+			If the first parameter is 0 the module will be disabled.
+			If the first parameter is 1 the module will be enabled.
+			If the first parameter is -1 the module will toggle its enabled state.
 		Notes:
 			The <module name> should be the URL escaped name of the module.
 	example: /bespoke/module/enable/notesequencer -1
@@ -88,9 +88,9 @@ Direct module control:
 	View and zoom to a module:
 		address: /bespoke/module/focus/<module name>
 		parameters: [f] or [i]
-			If the first paramater is greater than 0.1 the zoom will be set to this.
-			If the first paramater is between -0.1 and 0.1 the zoom will be set to view the entire module.
-			If the first paramater is less than -0.1 zoom will be left as it was.
+			If the first parameter is greater than 0.1 the zoom will be set to this.
+			If the first parameter is between -0.1 and 0.1 the zoom will be set to view the entire module.
+			If the first parameter is less than -0.1 zoom will be left as it was.
 			Regardless of the first parameter the view will be moved so that the module is in the center of the screen.
 		Notes:
 			The <module name> should be the URL escaped name of the module.

--- a/resource/osc_support.txt
+++ b/resource/osc_support.txt
@@ -25,7 +25,7 @@ Notes:
 		The second to last parameter is the note number corresponding to the standard midi notes.
 		The last parameter is the velocity of the note.
 		If three parameters are provided the first integer parameter will denote the note "channel".
-	example: /note 60 127
+	example: /bespoke/note 60 127
 
 Location store:
 	address: /bespoke/location/store
@@ -45,4 +45,56 @@ Location recall:
 		There is a limit of 10 location bookmarks (0 to 9).
 	example: /bespoke/location/recall 1
 
+Direct module control:
+	Sending notes directly to a module:
+		address: /bespoke/module/note/<module name>
+		parameters: [f, f] or [i, i]
+			The first parameter is the note number corresponding to the standard midi notes.
+			The second parameter is the velocity of the note.
+		Notes:
+			The <module name> should be the URL escaped name of the module.
+		example: /bespoke/module/note/oscillator2 60 127
+
+	Sending pulses directly to a module:
+		address: /bespoke/module/pulse/<module name>
+		parameters: [f] or [i]
+			The first parameter is the velocity of the pulse.
+		Notes:
+			The <module name> should be the URL escaped name of the module.
+			The velocity for pulses is in the range of 0 and 1.
+		example: /bespoke/module/pulse/notesequencer 1
+		example: /bespoke/module/pulse/pulsesequence .7
+
+	(Un-)Minimizing a module:
+		address: /bespoke/module/pulse/<module name>
+		parameters: [f] or [i]
+			If the first paramater is 0 the module will be minimized.
+			If the first paramater is 1 the module will be un-minimized.
+			If the first paramater is -1 the module will toggle its minimized state.
+		Notes:
+			The <module name> should be the URL escaped name of the module.
+		example: /bespoke/module/minimize/notesequencer -1
+
+	Enabling or disabling a module:
+		address: /bespoke/module/enable/<module name>
+		parameters: [f] or [i]
+			If the first paramater is 0 the module will be disabled.
+			If the first paramater is 1 the module will be enabled.
+			If the first paramater is -1 the module will toggle its enabled state.
+		Notes:
+			The <module name> should be the URL escaped name of the module.
+	example: /bespoke/module/enable/notesequencer -1
+	
+	View and zoom to a module:
+		address: /bespoke/module/focus/<module name>
+		parameters: [f] or [i]
+			If the first paramater is greater than 0.1 the zoom will be set to this.
+			If the first paramater is between -0.1 and 0.1 the zoom will be set to view the entire module.
+			If the first paramater is less than -0.1 zoom will be left as it was.
+			Regardless of the first parameter the view will be moved so that the module is in the center of the screen.
+		Notes:
+			The <module name> should be the URL escaped name of the module.
+	example: /bespoke/module/focus/midicontroller -1
+	
+	
 Any other addresses with parameters of type integer or float will be automapped to CC's in the midicontroller interface.


### PR DESCRIPTION
- Added the ability to send notes and pulses directly to modules through OSC.
- Added the ability to toggle minimize and enabled state of modules through OSC.
- Added a way to move to a module as well as zoom to it through OSC.
- Refactored module's private Enabled() method into a public IsEnabled() method.



I suspect there might be a better way to the the "focusing" on modules but couldn't think of the way. What I have now does work.