### PR TITLE
Fix EnvelopeEditor modulation when minimized.

### DIFF
--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -473,9 +473,6 @@ void EnvelopeEditor::DrawModule()
       ofPopStyle();
    }
 
-   if (Minimized())
-      return;
-
    mMaxSustainSlider->SetShowing(mADSRDisplay != nullptr && mADSRDisplay->GetADSR()->GetHasSustainStage());
 
    mADSRViewLengthSlider->Draw();


### PR DESCRIPTION
This fix is likely not the correct way to resolve this issue however seems to be necessary at this time since sliders calculate their stuff when rendered.

In theory the correct fix is to remove any and all state changing calculations from rendering code but this is likely far more work than I can already see it being.

Resolves: #1175.

Another "solution" would be to prohibit minimizing of the envelope editor :P

(Also looking at this does this mean in situations like this the actual update rate of the final value is rate limited to the frame rate instead of audio rate?)