### PR TITLE
Make file extensions mostly case insensitive on all platforms.

### DIFF
--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -596,9 +596,9 @@ void NoteCanvas::QuantizeNotes()
 void NoteCanvas::LoadMidi()
 {
    using namespace juce;
-   String file_pattern = "*.mid,*.midi";
+   String file_pattern = "*.mid;*.midi";
    if (File::areFileNamesCaseSensitive())
-      file_pattern += file_pattern.toUpperCase();
+      file_pattern += ";" + file_pattern.toUpperCase();
    FileChooser chooser("Load midi", File(ofToDataPath("")), file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())
    {

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -596,7 +596,10 @@ void NoteCanvas::QuantizeNotes()
 void NoteCanvas::LoadMidi()
 {
    using namespace juce;
-   FileChooser chooser("Load midi", File(ofToDataPath("")), "*.mid", true, false, TheSynth->GetFileChooserParent());
+   String file_pattern = "*.mid,*.midi";
+   if (File::areFileNamesCaseSensitive())
+      file_pattern += file_pattern.toUpperCase();
+   FileChooser chooser("Load midi", File(ofToDataPath("")), file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())
    {
       bool wasPlaying = mPlay;

--- a/Source/SampleBrowser.cpp
+++ b/Source/SampleBrowser.cpp
@@ -173,7 +173,7 @@ void SampleBrowser::SetDirectory(String dirPath)
          {
             for (auto& w : wildcards)
             {
-               if (file.getFileName().matchesWildcard(w, !File::areFileNamesCaseSensitive()))
+               if (file.getFileName().matchesWildcard(w, true))
                {
                   include = true;
                   break;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -745,7 +745,7 @@ void SamplePlayer::LoadFile()
 {
    auto file_pattern = TheSynth->GetAudioFormatManager().getWildcardForAllFormats();
    if (File::areFileNamesCaseSensitive())
-      file_pattern += file_pattern.toUpperCase();
+      file_pattern += ";" + file_pattern.toUpperCase();
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
                        file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -743,8 +743,11 @@ void SamplePlayer::OnYoutubeSearchComplete(std::string searchTerm, double search
 
 void SamplePlayer::LoadFile()
 {
+   auto file_pattern = TheSynth->GetAudioFormatManager().getWildcardForAllFormats();
+   if (File::areFileNamesCaseSensitive())
+      file_pattern += file_pattern.toUpperCase();
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetFileChooserParent());
+                       file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -726,7 +726,7 @@ void Scale::ButtonClicked(ClickButton* button, double time)
    {
       std::string prompt = "Load ";
       prompt += (button == mLoadSCLButton) ? "SCL" : "KBM";
-      std::string pat = (button == mLoadSCLButton) ? "*.scl,*.SCL" : "*.kbm,*.KBM";
+      std::string pat = (button == mLoadSCLButton) ? "*.scl;*.SCL" : "*.kbm;*.KBM";
       juce::FileChooser chooser(prompt, juce::File(""), pat, true, false, TheSynth->GetFileChooserParent());
       if (chooser.browseForFileToOpen())
       {

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -726,7 +726,7 @@ void Scale::ButtonClicked(ClickButton* button, double time)
    {
       std::string prompt = "Load ";
       prompt += (button == mLoadSCLButton) ? "SCL" : "KBM";
-      std::string pat = (button == mLoadSCLButton) ? "*.scl" : "*.kbm";
+      std::string pat = (button == mLoadSCLButton) ? "*.scl,*.SCL" : "*.kbm,*.KBM";
       juce::FileChooser chooser(prompt, juce::File(""), pat, true, false, TheSynth->GetFileChooserParent());
       if (chooser.browseForFileToOpen())
       {

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -292,8 +292,11 @@ void SeaOfGrain::UpdateDisplaySamples()
 void SeaOfGrain::LoadFile()
 {
    using namespace juce;
+   auto file_pattern = TheSynth->GetAudioFormatManager().getWildcardForAllFormats();
+   if (File::areFileNamesCaseSensitive())
+      file_pattern += file_pattern.toUpperCase();
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
-                       TheSynth->GetAudioFormatManager().getWildcardForAllFormats(), true, false, TheSynth->GetFileChooserParent());
+                       file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())
    {
       auto file = chooser.getResult();

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -294,7 +294,7 @@ void SeaOfGrain::LoadFile()
    using namespace juce;
    auto file_pattern = TheSynth->GetAudioFormatManager().getWildcardForAllFormats();
    if (File::areFileNamesCaseSensitive())
-      file_pattern += file_pattern.toUpperCase();
+      file_pattern += ";" + file_pattern.toUpperCase();
    FileChooser chooser("Load sample", File(ofToDataPath("samples")),
                        file_pattern, true, false, TheSynth->GetFileChooserParent());
    if (chooser.browseForFileToOpen())


### PR DESCRIPTION
- Make the SampleBrowser case insensitive on all platforms regardless of file system case sensitiveness.
- Also accept full capitalization extensions on case sensitive file systems in file chooser dialog's.
- Added *.midi as valid extension for midi files.

Many sources of sample or midi files have the extensions in full capitalization and thus are currently impossible to load directly into bespoke (with the exception of drag and drop) on systems that have a case sensitive file system.

This PR should fix all of the cases where the extension is full capitalization however it won't fix all cases for when the file extension has mixed capitalization (this would require the `juce::FileChooser` to support this which it does not).

I've only done this for FileChooser's that can accept files from other sources than only Bespoke itself (i.e. I'm not doing it for *.pfb or *.vstp since these are made by Bespoke always lowercase).

I have tested some of this code but I can't truly test it since I do not have a case sensitive file system.

Resolves: #732.