### PR TITLE
Fix the `circlesequencer` not triggering a note when a circle is set to `1`.

### DIFF
--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -310,11 +310,14 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
    info.mCustomDivisor = mLength;
 
    double remainderMs;
-   int oldStep = TheTransport->GetQuantized(NextBufferTime(true) - gBufferSizeMs, &info);
-   int newStep = TheTransport->GetQuantized(NextBufferTime(true), &info, &remainderMs);
-   if (oldStep != newStep && mSteps[newStep] > 0)
+   const int oldStep = TheTransport->GetQuantized(NextBufferTime(true) - gBufferSizeMs, &info);
+   const int newStep = TheTransport->GetQuantized(NextBufferTime(true), &info, &remainderMs);
+   const int oldMeasure = TheTransport->GetMeasure(NextBufferTime(true) - gBufferSizeMs);
+   const int newMeasure = TheTransport->GetMeasure(NextBufferTime(true));
+
+   if ((oldMeasure != newMeasure || oldStep != newStep) && mSteps[newStep] > 0)
    {
-      double time = NextBufferTime(true) - remainderMs;
+      const double time = NextBufferTime(true) - remainderMs;
       mOwner->PlayNoteOutput(time, mPitch, mSteps[newStep] * 127, -1);
       mOwner->PlayNoteOutput(time + TheTransport->GetDuration(kInterval_16n), mPitch, 0, -1);
    }


### PR DESCRIPTION
Resolves: #218.

There are still issues with offsets but I think those are a completely different problem.