### PR TITLE
Fix cables not moving to the correct location when a module that has direct children is minimized

### DIFF
--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -611,6 +611,7 @@ PatchCablePos PatchCable::GetPatchCablePos()
       target->GetPosition(xThat, yThat);
 
       IDrawableModule* targetModuleParent = dynamic_cast<IDrawableModule*>(target->GetParent());
+      IDrawableModule* targetModuleParentParent = dynamic_cast<IDrawableModule*>(targetModuleParent ? targetModuleParent->GetParent() : nullptr);
       ModuleContainer* targetModuleParentContainer = targetModuleParent ? targetModuleParent->GetOwningContainer() : nullptr;
       IDrawableModule* targetModuleParentContainerModule = targetModuleParentContainer ? targetModuleParentContainer->GetOwner() : nullptr;
       if (targetModuleParentContainerModule && targetModuleParentContainerModule->Minimized())
@@ -620,6 +621,13 @@ PatchCablePos PatchCable::GetPatchCablePos()
          targetModuleParent->GetPosition(xThat, yThat);
          targetModuleParent->GetDimensions(wThat, hThat);
          if (targetModuleParent->HasTitleBar() && !mDragging)
+            yThatAdjust = IDrawableModule::TitleBarHeight();
+      }
+      if (targetModuleParentParent && (targetModuleParentParent->Minimized() || target->IsShowing() == false))
+      {
+         targetModuleParentParent->GetPosition(xThat, yThat);
+         targetModuleParentParent->GetDimensions(wThat, hThat);
+         if (targetModuleParentParent->HasTitleBar() && !mDragging)
             yThatAdjust = IDrawableModule::TitleBarHeight();
       }
    }

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -611,7 +611,7 @@ PatchCablePos PatchCable::GetPatchCablePos()
       target->GetPosition(xThat, yThat);
 
       IDrawableModule* targetModuleParent = dynamic_cast<IDrawableModule*>(target->GetParent());
-      IDrawableModule* targetModuleParentParent = dynamic_cast<IDrawableModule*>(targetModuleParent ? targetModuleParent->GetParent() : nullptr);
+      IDrawableModule* targetModuleGrandparent = dynamic_cast<IDrawableModule*>(targetModuleParent ? targetModuleParent->GetParent() : nullptr);
       ModuleContainer* targetModuleParentContainer = targetModuleParent ? targetModuleParent->GetOwningContainer() : nullptr;
       IDrawableModule* targetModuleParentContainerModule = targetModuleParentContainer ? targetModuleParentContainer->GetOwner() : nullptr;
       if (targetModuleParentContainerModule && targetModuleParentContainerModule->Minimized())
@@ -623,11 +623,11 @@ PatchCablePos PatchCable::GetPatchCablePos()
          if (targetModuleParent->HasTitleBar() && !mDragging)
             yThatAdjust = IDrawableModule::TitleBarHeight();
       }
-      if (targetModuleParentParent && (targetModuleParentParent->Minimized() || target->IsShowing() == false))
+      if (targetModuleGrandparent && (targetModuleGrandparent->Minimized() || target->IsShowing() == false))
       {
-         targetModuleParentParent->GetPosition(xThat, yThat);
-         targetModuleParentParent->GetDimensions(wThat, hThat);
-         if (targetModuleParentParent->HasTitleBar() && !mDragging)
+         targetModuleGrandparent->GetPosition(xThat, yThat);
+         targetModuleGrandparent->GetDimensions(wThat, hThat);
+         if (targetModuleGrandparent->HasTitleBar() && !mDragging)
             yThatAdjust = IDrawableModule::TitleBarHeight();
       }
    }


### PR DESCRIPTION
Fix cables not moving to the correct location when a module that has direct children is minimized.

Resolves: #420.

Before:
![image](https://user-images.githubusercontent.com/211381/222832839-e643e769-b9f8-4327-b952-983d573b1fcd.png)
![image](https://user-images.githubusercontent.com/211381/222832896-5aca21cb-a0fb-4d2e-acba-def62a89c520.png)

After:
![image](https://user-images.githubusercontent.com/211381/222833048-2989aefe-f392-46f7-8cc0-482065be3c9d.png)
