### PR TITLE
Allow disabling of output limit.

### DIFF
--- a/Source/OutputChannel.cpp
+++ b/Source/OutputChannel.cpp
@@ -139,8 +139,8 @@ void OutputChannel::DrawModule()
       {
          ofPushStyle();
          ofFill();
-         const float level = mLevelMeters[i].mPeakTracker.GetPeak() / mLimit > 0 ? mLimit : 1;
-         const float slowLevel = mLevelMeters[i].mPeakTrackerSlow.GetPeak() / mLimit > 0 ? mLimit : 1;
+         const float level = mLevelMeters[i].mPeakTracker.GetPeak() / (mLimit > 0 ? mLimit : 1);
+         const float slowLevel = mLevelMeters[i].mPeakTrackerSlow.GetPeak() / (mLimit > 0 ? mLimit : 1);
          ofColor color(0, 255, 0);
          if (j > kNumSegments - 3)
             color.set(255, 0, 0);

--- a/Source/OutputChannel.cpp
+++ b/Source/OutputChannel.cpp
@@ -72,7 +72,7 @@ void OutputChannel::Process(double time)
       {
          const auto channelbuffer = TheSynth->GetOutputBuffer(channel);
          for (int i = 0; i < gBufferSize; ++i)
-            if (mLimit > 0 + std::numeric_limits<float>::epsilon())
+            if (mLimit > std::numeric_limits<float>::epsilon())
                channelbuffer[i] += std::clamp(buffer[i], -mLimit, mLimit);
             else
                channelbuffer[i] += buffer[i];
@@ -90,7 +90,7 @@ void OutputChannel::Process(double time)
       {
          const auto channel1buffer = TheSynth->GetOutputBuffer(channel1);
          for (int i = 0; i < gBufferSize; ++i)
-            if (mLimit > 0 + std::numeric_limits<float>::epsilon())
+            if (mLimit > std::numeric_limits<float>::epsilon())
                channel1buffer[i] += std::clamp(buffer1[i], -mLimit, mLimit);
             else
                channel1buffer[i] += buffer1[i];
@@ -103,7 +103,7 @@ void OutputChannel::Process(double time)
       {
          const auto channel2buffer = TheSynth->GetOutputBuffer(channel2);
          for (int i = 0; i < gBufferSize; ++i)
-            if (mLimit > 0 + std::numeric_limits<float>::epsilon())
+            if (mLimit > std::numeric_limits<float>::epsilon())
                channel2buffer[i] += std::clamp(buffer2[i], -mLimit, mLimit);
             else
                channel2buffer[i] += buffer2[i];

--- a/Source/PeakTracker.cpp
+++ b/Source/PeakTracker.cpp
@@ -27,20 +27,20 @@
 #include "SynthGlobals.h"
 #include "Profiler.h"
 
-void PeakTracker::Process(float* buffer, int bufferSize)
+void PeakTracker::Process(const float* buffer, int bufferSize)
 {
    PROFILER(PeakTracker);
 
    for (int j = 0; j < bufferSize; ++j)
    {
-      float scalar = powf(0.5f, 1.0f / (mDecayTime * gSampleRate));
-      float input = fabsf(buffer[j]);
+      const float scalar = powf(0.5f, 1.0f / (mDecayTime * gSampleRate));
+      const float input = fabsf(buffer[j]);
 
       if (input >= mPeak)
       {
          /* When we hit a peak, ride the peak to the top. */
          mPeak = input;
-         if (mLimit != -1 && mPeak >= mLimit)
+         if (mLimit > 0 + std::numeric_limits<float>::epsilon() && mPeak >= mLimit)
          {
             mPeak = mLimit;
             mHitLimitTime = gTime;

--- a/Source/PeakTracker.cpp
+++ b/Source/PeakTracker.cpp
@@ -40,7 +40,7 @@ void PeakTracker::Process(const float* buffer, int bufferSize)
       {
          /* When we hit a peak, ride the peak to the top. */
          mPeak = input;
-         if (mLimit > 0 + std::numeric_limits<float>::epsilon() && mPeak >= mLimit)
+         if (mLimit > std::numeric_limits<float>::epsilon() && mPeak >= mLimit)
          {
             mPeak = mLimit;
             mHitLimitTime = gTime;
@@ -50,7 +50,7 @@ void PeakTracker::Process(const float* buffer, int bufferSize)
       {
          /* Exponential decay of output when signal is low. */
          mPeak = mPeak * scalar;
-         if (mPeak < FLT_EPSILON)
+         if (mPeak < std::numeric_limits<float>::epsilon())
             mPeak = 0.0;
       }
    }

--- a/Source/PeakTracker.h
+++ b/Source/PeakTracker.h
@@ -31,7 +31,7 @@
 class PeakTracker
 {
 public:
-   void Process(float* buffer, int bufferSize);
+   void Process(const float* buffer, int bufferSize);
    float GetPeak() const { return mPeak; }
    void SetDecayTime(float time) { mDecayTime = time; }
    void SetLimit(float limit) { mLimit = limit; }


### PR DESCRIPTION
Also brought some of the code to modern standard and used the same method all across the plugin (std::clamp and CLAMP where both used).

Also applied an optimization done in 806b123a21a0bf1cf9abce7eec14ab01c56f0c63 to other variables used in the tight loops but I have not actually profiled before and after so have no idea if this is better or not or if the compiler already did this on its own. At least it should now be consistent between single channel output modules and double channel output modules.