### PR TITLE
Fix a bug where LFO and EnvelopeEditor modules would not restore their minimized state.

### DIFF
--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -628,6 +628,9 @@ void EnvelopeEditor::LoadLayout(const ofxJSONElement& moduleInfo)
    {
       SetUpFromSaveData();
       Pin();
+      // Since `mPinned` is set after `IDrawableModule::LoadBasics` we need to manually set minimized
+      // after setting `mPinned` which is used to check if this module has a titlebar.
+      SetMinimized(moduleInfo["start_minimized"].asBool(), false);
    }
 }
 

--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -52,9 +52,9 @@ void FloatSliderLFOControl::CreateUIControls()
    BUTTON(mPinButton, "pin");
    UIBLOCK_NEWLINE();
    UIBLOCK_SHIFTY(40);
-   DROPDOWN(mIntervalSelector, "interval", (int*)(&mLFOSettings.mInterval), 47);
+   DROPDOWN(mIntervalSelector, "interval", reinterpret_cast<int*>(&mLFOSettings.mInterval), 47);
    UIBLOCK_SHIFTRIGHT();
-   DROPDOWN(mOscSelector, "osc", (int*)(&mLFOSettings.mOscType), 47);
+   DROPDOWN(mOscSelector, "osc", reinterpret_cast<int*>(&mLFOSettings.mOscType), 47);
    UIBLOCK_NEWLINE();
    FLOATSLIDER(mOffsetSlider, "offset", &mLFOSettings.mLFOOffset, 0, 1);
    UIBLOCK_SHIFTUP();
@@ -110,9 +110,7 @@ void FloatSliderLFOControl::CreateUIControls()
    UpdateVisibleControls();
 }
 
-FloatSliderLFOControl::~FloatSliderLFOControl()
-{
-}
+FloatSliderLFOControl::~FloatSliderLFOControl() = default;
 
 void FloatSliderLFOControl::DrawModule()
 {
@@ -432,6 +430,9 @@ void FloatSliderLFOControl::SaveLayout(ofxJSONElement& moduleInfo)
 void FloatSliderLFOControl::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    SetUpFromSaveData();
+   // Since `mPinned` is set after `IDrawableModule::LoadBasics` we need to manually set minimized
+   // after setting `mPinned` which is used to check if this module has a titlebar.
+   SetMinimized(moduleInfo["start_minimized"].asBool(), false);
 }
 
 void FloatSliderLFOControl::SetUpFromSaveData()

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -1047,10 +1047,7 @@ void IDrawableModule::LoadBasics(const ofxJSONElement& moduleInfo, std::string t
 
    SetName(name.c_str());
 
-   SetMinimized(start_minimized);
-
-   if (mMinimized)
-      mMinimizeAnimation = 1;
+   SetMinimized(start_minimized, false);
 
    if (draw_lissajous)
       TheSynth->AddLissajousDrawer(this);

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -82,10 +82,13 @@ public:
    bool CheckNeedsDraw() override;
    virtual bool AlwaysOnTop() { return false; }
    void ToggleMinimized();
-   void SetMinimized(bool minimized)
+   void SetMinimized(bool minimized, bool animate = true)
    {
-      if (HasTitleBar())
-         mMinimized = minimized;
+      if (!HasTitleBar())
+         return;
+      mMinimized = minimized;
+      if (!animate)
+         mMinimizeAnimation = minimized ? 1 : 0;
    }
    virtual void KeyPressed(int key, bool isRepeat);
    virtual void KeyReleased(int key);


### PR DESCRIPTION
Fix a bug where LFO and EnvelopeEditor modules would not restore their minimized state. Resolves: #511.