### PR TITLE
Fix `effectchain` module limit.

### DIFF
--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -68,7 +68,8 @@ void EffectChain::Init()
 
 void EffectChain::AddEffect(std::string type, bool onTheFly /*=false*/)
 {
-   assert(mEffects.size() < MAX_EFFECTS_IN_CHAIN - 1);
+   if (mEffects.size() >= MAX_EFFECTS_IN_CHAIN)
+      return;
 
    IAudioEffect* effect = TheSynth->GetEffectFactory()->MakeEffect(type);
    if (effect == nullptr)
@@ -102,11 +103,16 @@ void EffectChain::AddEffect(std::string type, bool onTheFly /*=false*/)
 
    EffectControls controls;
    controls.mMoveLeftButton = new ClickButton(this, "<", 0, 0);
+   controls.mMoveLeftButton->SetCableTargetable(false);
    controls.mMoveRightButton = new ClickButton(this, ">", 0, 0);
+   controls.mMoveRightButton->SetCableTargetable(false);
    controls.mDeleteButton = new ClickButton(this, "x", 0, 0);
+   controls.mDeleteButton->SetCableTargetable(false);
    controls.mDryWetSlider = new FloatSlider(this, ("mix" + ofToString(mEffects.size() - 1)).c_str(), 0, 0, 60, 13, dryWet, 0, 1, 2);
+   controls.mDryWetSlider->SetCableTargetable(false);
    controls.mPush2DisplayEffectButton = new ClickButton(this, ("edit " + name).c_str(), 0, 0);
    controls.mPush2DisplayEffectButton->SetShowing(false);
+   controls.mPush2DisplayEffectButton->SetCableTargetable(false);
    mEffectControls.push_back(controls);
 }
 


### PR DESCRIPTION
- Hard limit the number of EffectChain modules instead of a crashing.
- Made the EffectChain EffectControls untargetable by modulation cables since this crashes when modules are deleted.
