### PR TITLE
Added VU meters to audiometer

### DIFF
--- a/Source/AudioMeter.cpp
+++ b/Source/AudioMeter.cpp
@@ -103,7 +103,7 @@ void AudioMeter::DrawModule()
    int numChannels = mNumChannels;
 
    if (numChannels == 1)
-       mHeight = 32;
+      mHeight = 32;
    else
       mHeight = 42;
 
@@ -113,7 +113,7 @@ void AudioMeter::DrawModule()
    const int kBarHeight = 8;
    const float kSegmentWidth = (mWidth - kPaddingOutside * 2) / kNumSegments;
    const float kOffsetY = 20;
-   
+
    for (int i = 0; i < numChannels; ++i)
    {
       for (int j = 0; j < kNumSegments; ++j)

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -30,6 +30,7 @@
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"
+#include "Checkbox.h"
 #include "PeakTracker.h"
 
 class AudioMeter : public IAudioProcessor, public IDrawableModule, public IFloatSliderListener
@@ -51,6 +52,8 @@ public:
    //IFloatSliderListener
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
+   void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
@@ -59,16 +62,30 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& w, float& h) override
    {
-      w = 120;
-      h = 22;
+      w = mWidth;
+      h = mHeight;
    }
    bool Enabled() const override { return mEnabled; }
 
+   float mWidth{ 120 };
+   float mHeight{ 62 };
    float mLevel{ 0 };
    float mMaxLevel{ 1 };
    FloatSlider* mLevelSlider{ nullptr };
+   bool mVUMode{ false };
+   Checkbox* mVUCheckbox{ nullptr };
    PeakTracker mPeakTracker;
    float* mAnalysisBuffer{ nullptr };
+   float mLimit{ 1 };
+   int mNumChannels{ 1 };
+   
+   struct LevelMeter
+   {
+      PeakTracker mPeakTracker;
+      PeakTracker mPeakTrackerSlow;
+   };
+
+   std::array<LevelMeter, 2> mLevelMeters;
 };
 
 #endif /* defined(__Bespoke__AudioMeter__) */

--- a/Source/AudioMeter.h
+++ b/Source/AudioMeter.h
@@ -53,7 +53,7 @@ public:
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
 
    void CheckboxUpdated(Checkbox* checkbox, double time) override {}
-   
+
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
@@ -78,7 +78,7 @@ private:
    float* mAnalysisBuffer{ nullptr };
    float mLimit{ 1 };
    int mNumChannels{ 1 };
-   
+
    struct LevelMeter
    {
       PeakTracker mPeakTracker;

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1131,8 +1131,9 @@ audiorouter~selector for switching where audio is routed to. connect to targets 
 
 
 
-audiometer~sets a slider to an audio level's volume. useful to map a midi display value to.
+audiometer~monitor audio levels. sets a slider to an audio level's volume. useful to map a midi display value to. optionally displays a VU meter.
 ~level~the input audio level. hook this up to an LED-display midi control to see the value displayed on your controller.
+~vu~turn VU meter on or off
 
 
 


### PR DESCRIPTION
as discussed on Discord: https://discord.com/channels/846834873254805554/854199300540071956/1083425235698724994

Added optional VU meters to  the `audiometer` module, toggleable with a checkbox. One or two VU meters are displayed, depending on whether the input signal is mono or stereo. Without the toggle enabled, the module has the same pixel dimensions as unaltered `audiometer` module.

Meters are mostly just copypasted from the `output` module. I've moved some consts and function calls out of for loops. 

Tested on Windows.