### PR TITLE
Switch to AudioIODeviceCallback::audioDeviceIOCallbackWithContext

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -160,12 +160,14 @@ public:
       // but be careful - it will be called on the audio thread, not the GUI thread.
    }
 
-   void audioDeviceIOCallback(const float** inputChannelData,
-                              int numInputChannels,
-                              float** outputChannelData,
-                              int numOutputChannels,
-                              int numSamples) override
+   void audioDeviceIOCallbackWithContext(const float** inputChannelData,
+                                         int numInputChannels,
+                                         float** outputChannelData,
+                                         int numOutputChannels,
+                                         int numSamples,
+                                         const AudioIODeviceCallbackContext& context) override
    {
+      ignoreUnused(context);
       mSynth.AudioIn(inputChannelData, numSamples, numInputChannels);
       mSynth.AudioOut(outputChannelData, numSamples, numOutputChannels);
    }


### PR DESCRIPTION
In AudioIODeviceCallback::audioDeviceIOCallback has recently been removed[1] in upstream JUCE.

Switch to AudioIODeviceCallback::audioDeviceIOCallbackWithContext, which is the same but with an additional `context` parameter.

[1]: https://github.com/juce-framework/JUCE/commit/c97864d7f34f8d4ea4caa794d818318073e751a2

TODO:

- [x] Run clang-format