### PR TITLE
Rename libs/link to libs/ableton-link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,8 +13,8 @@
 [submodule "libs/json/jsoncpp"]
 	path = libs/json/jsoncpp
 	url = https://github.com/open-source-parsers/jsoncpp.git
-[submodule "libs/link"]
-	path = libs/link
+[submodule "libs/ableton-link"]
+	path = libs/ableton-link
 	url = https://github.com/Ableton/link.git
 [submodule "libs/readerwriterqueue"]
 	path = libs/readerwriterqueue

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(cmake/lib.cmake)
 include(cmake/versiontools.cmake)
-include(../libs/link/AbletonLinkConfig.cmake)
+include(../libs/ableton-link/AbletonLinkConfig.cmake)
 
 juce_add_gui_app(BespokeSynth
     PRODUCT_NAME BespokeSynth


### PR DESCRIPTION
The name "link" is very unspecific, it could refer to numerous things.

The new name "ableton-link" reflects that this is the Ableton Link library.