### PR TITLE
Trying to fix a few race conditions

### DIFF
--- a/Source/LocationZoomer.cpp
+++ b/Source/LocationZoomer.cpp
@@ -46,6 +46,8 @@ void LocationZoomer::Init()
 
 void LocationZoomer::Update()
 {
+   auto g = TheSynth->LockRenderWithGuard();
+
    if (mCurrentProgress < 1)
    {
       mCurrentProgress = ofClamp(mCurrentProgress + ofGetLastFrameTime() * mSpeed, 0, 1);

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -230,6 +230,10 @@ public:
          mRenderLock.unlock();
       }
    }
+   std::lock_guard<std::recursive_mutex> LockRenderWithGuard()
+   {
+      return std::lock_guard<std::recursive_mutex>(mRenderLock);
+   }
    void UpdateFrameRate(float fps) { mFrameRate = fps; }
    float GetFrameRate() const { return mFrameRate; }
    std::recursive_mutex& GetRenderLock() { return mRenderLock; }

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -164,7 +164,11 @@ public:
    ofVec2f& GetDrawOffset() { return mModuleContainer.GetDrawOffsetRef(); }
    void SetDrawOffset(ofVec2f offset) { mModuleContainer.SetDrawOffset(offset); }
    const ofRectangle& GetDrawRect() const { return mDrawRect; }
-   void SetPixelRatio(double ratio) { mPixelRatio = ratio; }
+   void SetPixelRatio(double ratio)
+   {
+      auto g = LockRenderWithGuard();
+      mPixelRatio = ratio;
+   }
    double GetPixelRatio() const { return mPixelRatio; }
    long GetFrameCount() { return mFrameCount; }
    void SetUIScale(float scale) { mUILayerModuleContainer.SetDrawScale(scale); }


### PR DESCRIPTION
It seems to be a common problem in Bespoke that there are race conditions between the render thread and other threads that update various variables.

For this pull request, I used ThreadSanitizer and fixed two race conditions, to get familiar with the process, and gather some feedback from other Bespoke developers.