### PR TITLE
ModularSynth::Get{In,Out}putBuffer: Assert that the channel number is in range

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2063,11 +2063,13 @@ void ModularSynth::AudioIn(const float** input, int bufferSize, int nChannels)
 
 float* ModularSynth::GetInputBuffer(int channel)
 {
+   assert(channel >= 0 && channel < mInputBuffers.size());
    return mInputBuffers[channel];
 }
 
 float* ModularSynth::GetOutputBuffer(int channel)
 {
+   assert(channel >= 0 && channel < mOutputBuffers.size());
    return mOutputBuffers[channel];
 }
 


### PR DESCRIPTION
I have seen a crash where this invariant is violated. I think it's better to check it explicitly than to rely on std::vector behaving predictably beyond this point.