### PR TITLE
massive RAM savings by changing how global record buffer saves

### DIFF
--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -389,8 +389,6 @@ private:
 
    Sample* mHeldSample{ nullptr };
 
-   float* mSaveOutputBuffer[2];
-
    IDrawableModule* mLastClickedModule{ nullptr };
    bool mInitialized{ false };
 


### PR DESCRIPTION
rather than creating a duplicate massive buffer to rearrange the circular buffer into, this now chunks it out during the saving process as a better way of achieving that. saves ~700mb of RAM with the default 30 minute recording buffer.