### PR TITLE
Allow layouts to specify channels for input, like output

### DIFF
--- a/Source/InputChannel.cpp
+++ b/Source/InputChannel.cpp
@@ -113,6 +113,7 @@ void InputChannel::DrawModule()
 
 void InputChannel::LoadLayout(const ofxJSONElement& moduleInfo)
 {
+   mModuleSaveData.LoadEnum<int>("channels", moduleInfo, 0, mChannelSelector);
    mModuleSaveData.LoadString("target", moduleInfo);
 
    SetUpFromSaveData();
@@ -120,5 +121,6 @@ void InputChannel::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void InputChannel::SetUpFromSaveData()
 {
+   mChannelSelectionIndex = mModuleSaveData.GetEnum<int>("channels");
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
 }


### PR DESCRIPTION
The output module can already read its channel selection from layout file, so this mirrors that behavior for the input module.

Now you don't have to set inputs up again when making a new file 😅