### PR TITLE
when doing a "set" from the midicontroller, always force a value update

### DIFF
--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -59,7 +59,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    bool CanBeTargetedBy(PatchCableSource* source) const override { return false; }
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -130,7 +130,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    void KeyPressed(int key, bool isRepeat) override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/CanvasScrollbar.h
+++ b/Source/CanvasScrollbar.h
@@ -50,7 +50,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    void KeyPressed(int key, bool isRepeat) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/CanvasTimeline.h
+++ b/Source/CanvasTimeline.h
@@ -44,7 +44,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    void KeyPressed(int key, bool isRepeat) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/Checkbox.cpp
+++ b/Source/Checkbox.cpp
@@ -171,10 +171,10 @@ float Checkbox::GetValueForMidiCC(float slider) const
    return slider > .5f ? 1 : 0;
 }
 
-void Checkbox::SetValue(float value, double time)
+void Checkbox::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    bool on = value > 0.5f;
-   if (*mVar != on)
+   if (*mVar != on || forceUpdate)
    {
       *mVar = on;
       CalcSliderVal();

--- a/Source/Checkbox.h
+++ b/Source/Checkbox.h
@@ -48,7 +48,7 @@ public:
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return 2; }

--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -213,7 +213,7 @@ void ClickButton::SetFromMidiCC(float slider, double time, bool setViaModulator)
       MouseReleased();
 }
 
-void ClickButton::SetValue(float value, double time)
+void ClickButton::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    if (value > 0)
       DoClick(time);

--- a/Source/ClickButton.h
+++ b/Source/ClickButton.h
@@ -73,7 +73,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override { return GetMidiValue(); }
    float GetMidiValue() const override;
    std::string GetDisplayValue(float val) const override;

--- a/Source/CodeEntry.h
+++ b/Source/CodeEntry.h
@@ -75,7 +75,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;
    bool IsSliderControl() override { return false; }

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -468,17 +468,13 @@ void DropdownList::SetIndex(int i, double time, bool forceUpdate)
    SetValue(mElements[i].mValue, time, forceUpdate);
 }
 
-void DropdownList::SetValue(float value, double time)
+void DropdownList::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
-   SetValue((int)value, time, false);
-}
-
-void DropdownList::SetValue(int value, double time, bool forceUpdate)
-{
-   if (value != *mVar || forceUpdate)
+   int intValue = (int)value;
+   if (intValue != *mVar || forceUpdate)
    {
       int oldVal = *mVar;
-      *mVar = value;
+      *mVar = intValue;
       CalcSliderVal();
       gControlTactileFeedback = 1;
       mOwner->DropdownUpdated(this, oldVal, time);

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -143,7 +143,7 @@ public:
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
@@ -166,7 +166,6 @@ private:
    void OnClicked(float x, float y, bool right) override;
    void CalcSliderVal();
    int FindItemIndex(float val) const;
-   void SetValue(int value, double time, bool forceUpdate);
    void CalculateWidth();
    ofVec2f GetModalListPosition() const;
 

--- a/Source/GridController.h
+++ b/Source/GridController.h
@@ -89,7 +89,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    bool CanBeTargetedBy(PatchCableSource* source) const override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, bool shouldSetValue = true) override;

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -52,7 +52,7 @@ public:
    void RemoveRemoteController() { --mRemoteControlCount; }
    virtual void SetFromMidiCC(float slider, double time, bool setViaModulator) = 0;
    virtual float GetValueForMidiCC(float slider) const { return 0; }
-   virtual void SetValue(float value, double time) = 0;
+   virtual void SetValue(float value, double time, bool forceUpdate = false) = 0;
    virtual void SetValueDirect(float value, double time) { SetValue(value, time); } //override if you need special control here
    virtual float GetValue() const { return 0; }
    virtual float GetMidiValue() const { return 0; }

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -601,7 +601,7 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue, NextBufferTime(false));
+                  uicontrol->SetValue(connection->mValue, NextBufferTime(false), K(forceUpdate));
                uicontrol->StartBeacon();
             }
          }
@@ -612,13 +612,13 @@ void MidiController::MidiReceived(MidiMessageType messageType, int control, floa
                if (connection->mIncrementAmount != 0)
                   uicontrol->Increment(connection->mIncrementAmount);
                else
-                  uicontrol->SetValue(connection->mValue, NextBufferTime(false));
+                  uicontrol->SetValue(connection->mValue, NextBufferTime(false), K(forceUpdate));
                uicontrol->StartBeacon();
             }
          }
          else if (connection->mType == kControlType_Direct)
          {
-            uicontrol->SetValue(value * 127, NextBufferTime(false));
+            uicontrol->SetValue(value * 127, NextBufferTime(false), K(forceUpdate));
             uicontrol->StartBeacon();
          }
 

--- a/Source/RadioButton.cpp
+++ b/Source/RadioButton.cpp
@@ -273,14 +273,19 @@ float RadioButton::GetValueForMidiCC(float slider) const
    return mElements[index].mValue;
 }
 
-void RadioButton::SetValue(float value, double time)
+void RadioButton::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    if (mMultiSelect)
       value = *mVar ^ (1 << (int)value);
-   SetValueDirect(value, time);
+   SetValueDirect(value, time, forceUpdate);
 }
 
 void RadioButton::SetValueDirect(float value, double time)
+{
+   SetValueDirect(value, time, false);
+}
+
+void RadioButton::SetValueDirect(float value, double time, bool forceUpdate)
 {
    int oldVal = *mVar;
 

--- a/Source/RadioButton.h
+++ b/Source/RadioButton.h
@@ -72,7 +72,7 @@ public:
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    void SetValueDirect(float value, double time) override;
    float GetValue() const override;
    float GetMidiValue() const override;
@@ -100,6 +100,7 @@ private:
    void SetIndex(int i, double time);
    void CalcSliderVal();
    void UpdateDimensions();
+   void SetValueDirect(float value, double time, bool forceUpdate);
 
    void OnClicked(float x, float y, bool right) override;
 

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -504,7 +504,7 @@ float FloatSlider::ValToPos(float val, bool ignoreSmooth) const
    return 0;
 }
 
-void FloatSlider::SetValue(float value, double time)
+void FloatSlider::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    if (TheLFOController && TheLFOController->WantsBinding(this))
    {
@@ -531,7 +531,7 @@ void FloatSlider::SetValue(float value, double time)
    else*/
    *var = value;
    DisableLFO();
-   if (oldVal != *var)
+   if (oldVal != *var || forceUpdate)
    {
       mOwner->FloatSliderUpdated(this, oldVal, time);
    }
@@ -1093,11 +1093,11 @@ float IntSlider::GetValueForMidiCC(float slider) const
    return (int)round(ofMap(slider, 0, 1, mMin, mMax));
 }
 
-void IntSlider::SetValue(float value, double time)
+void IntSlider::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    int oldVal = *mVar;
    *mVar = (int)round(ofClamp(value, mMin, mMax));
-   if (oldVal != *mVar)
+   if (oldVal != *mVar || forceUpdate)
    {
       CalcSliderVal();
       gControlTactileFeedback = 1;

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -110,7 +110,7 @@ public:
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override;
    std::string GetDisplayValue(float val) const override;
    float GetMidiValue() const override;
@@ -237,7 +237,7 @@ public:
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override;
    float GetValueForMidiCC(float slider) const override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override;
    float GetMidiValue() const override;
    void GetRange(float& min, float& max) override

--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -569,7 +569,7 @@ void TextEntry::GetRange(float& min, float& max)
    }
 }
 
-void TextEntry::SetValue(float value, double time)
+void TextEntry::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    if (mType == kTextEntry_Int)
    {

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -98,7 +98,7 @@ public:
    float GetValueForMidiCC(float slider) const override;
    float GetMidiValue() const override;
    void GetRange(float& min, float& max) override;
-   void SetValue(float value, double time) override;
+   void SetValue(float value, double time, bool forceUpdate = false) override;
    float GetValue() const override;
    int GetNumValues() override;
    std::string GetDisplayValue(float val) const override;

--- a/Source/UIGrid.h
+++ b/Source/UIGrid.h
@@ -110,7 +110,7 @@ public:
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}
-   void SetValue(float value, double time) override {}
+   void SetValue(float value, double time, bool forceUpdate = false) override {}
    bool IsSliderControl() override { return false; }
    bool IsButtonControl() override { return false; }
 


### PR DESCRIPTION
this fixes an issue where, if I was on snapshot 1 and wanted to restore snapshot 1 by pressing a button mapped to snapshot 1, it wouldn't work because the dropdown was already on "1"