### PR TITLE
collection of improvements discovered while performing with midiwalll

### DIFF
--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -78,8 +78,9 @@ void Looper::CreateUIControls()
    mWriteInputCheckbox = new Checkbox(this, "write", 80, 3, &mWriteInput);
    mSwapButton = new ClickButton(this, "swap", 137, 81);
    mCopyButton = new ClickButton(this, "copy", 140, 65);
-   mDoubleSpeedButton = new ClickButton(this, "2x", 151, 28);
-   mHalveSpeedButton = new ClickButton(this, ".5x", 147, 43);
+   mDoubleSpeedButton = new ClickButton(this, "2x", 153, 19);
+   mHalveSpeedButton = new ClickButton(this, ".5x", 149, 34);
+   mExtendButton = new ClickButton(this, "extend", 127, 49);
    mUndoButton = new ClickButton(this, "undo", -1, -1);
    mLoopPosOffsetSlider = new FloatSlider(this, "offset", -1, -1, 130, 15, &mLoopPosOffset, 0, mLoopLength);
    mWriteOffsetButton = new ClickButton(this, "apply", -1, -1);
@@ -104,6 +105,7 @@ void Looper::CreateUIControls()
    mNumBarsSelector->AddLabel(" 6 ", 6);
    mNumBarsSelector->AddLabel(" 8 ", 8);
    mNumBarsSelector->AddLabel("12 ", 12);
+   mNumBarsSelector->AddLabel("16 ", 16);
 
    mFourTetSlicesDropdown->AddLabel(" 1", 1);
    mFourTetSlicesDropdown->AddLabel(" 2", 2);
@@ -624,6 +626,7 @@ void Looper::DrawModule()
    mDecaySlider->Draw();
    mDoubleSpeedButton->Draw();
    mHalveSpeedButton->Draw();
+   mExtendButton->Draw();
    mUndoButton->Draw();
    mLoopPosOffsetSlider->Draw();
    mWriteOffsetButton->Draw();
@@ -1043,6 +1046,12 @@ void Looper::ButtonClicked(ClickButton* button, double time)
          mSpeed = .5f;
          ResampleForSpeed(GetPlaybackSpeed());
       }
+   }
+   if (button == mExtendButton)
+   {
+      int newLength = mNumBars * 2;
+      if (newLength <= 16)
+         SetNumBars(newLength);
    }
    if (button == mUndoButton)
       mWantUndo = true;

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -184,6 +184,7 @@ private:
    ClickButton* mCommitButton{ nullptr };
    ClickButton* mDoubleSpeedButton{ nullptr };
    ClickButton* mHalveSpeedButton{ nullptr };
+   ClickButton* mExtendButton{ nullptr };
    ChannelBuffer* mUndoBuffer{ nullptr };
    ClickButton* mUndoButton{ nullptr };
    bool mWantUndo{ false };

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -159,7 +159,7 @@ private:
    IntSlider* mNextCommitTargetSlider{ nullptr };
    int mNextCommitTargetIndex{ 0 };
    Checkbox* mAutoAdvanceThroughLoopersCheckbox{ nullptr };
-   bool mAutoAdvanceThroughLoopers{ true };
+   bool mAutoAdvanceThroughLoopers{ false };
 
    bool mFreeRecording{ false };
    Checkbox* mFreeRecordingCheckbox{ nullptr };

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2785,9 +2785,9 @@ void ModularSynth::SaveState(std::string file, bool autosave)
    if (!autosave)
    {
       mCurrentSaveStatePath = file;
-      mLastSaveTime = gTime;
       std::string filename = File(mCurrentSaveStatePath).getFileName().toStdString();
       mMainComponent->getTopLevelComponent()->setName("bespoke synth - " + filename);
+      TheTitleBar->DisplayTemporaryMessage("saved " + filename);
    }
 
    mAudioThreadMutex.Lock("SaveState()");
@@ -3256,6 +3256,8 @@ void ModularSynth::SaveOutput()
 
    mGlobalRecordBuffer->ClearBuffer();
    mRecordingLength = 0;
+
+   TheTitleBar->DisplayTemporaryMessage("wrote " + filename);
 }
 
 const String& ModularSynth::GetTextFromClipboard() const

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -267,7 +267,6 @@ public:
    void LoadStatePopup();
    void ToggleQuickSpawn();
    QuickSpawnMenu* GetQuickSpawn() { return mQuickSpawn; }
-   double GetLastSaveTime() { return mLastSaveTime; }
    std::string GetLastSavePath() { return mCurrentSaveStatePath; }
 
    UserPrefsEditor* GetUserPrefsEditor() { return mUserPrefsEditor; }
@@ -386,7 +385,6 @@ private:
    bool mWantReloadInitialLayout{ false };
    std::string mCurrentSaveStatePath;
    std::string mStartupSaveStateFile;
-   double mLastSaveTime{ -9999 };
 
    Sample* mHeldSample{ nullptr };
 

--- a/Source/NoteQuantizer.h
+++ b/Source/NoteQuantizer.h
@@ -45,6 +45,7 @@ public:
 
    void CreateUIControls() override;
    void Init() override;
+   void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
@@ -56,7 +57,7 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
-   bool IsEnabled() const override { return true; }
+   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule

--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -257,7 +257,7 @@ void Snapshots::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
          Delete(pitch);
       else
          SetSnapshot(pitch, time);
-      
+
       UpdateGridValues();
    }
 }

--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -48,6 +48,10 @@ void Snapshots::CreateUIControls()
    mCurrentSnapshotSelector = new DropdownList(this, "snapshot", 35, 3, &mCurrentSnapshot, 64);
    mRandomizeButton = new ClickButton(this, "random", 78, 20);
    mAddButton = new ClickButton(this, "add", 101, 3);
+   mClearButton = new ClickButton(this, "clear", mAddButton, kAnchor_Right);
+   mStoreCheckbox = new Checkbox(this, "store", mClearButton, kAnchor_Right, &mStoreMode);
+   mDeleteCheckbox = new Checkbox(this, "delete", mStoreCheckbox, kAnchor_Right, &mDeleteMode);
+   mAutoStoreOnSwitchCheckbox = new Checkbox(this, "auto-store on switch", mStoreCheckbox, kAnchor_Below, &mAutoStoreOnSwitch);
    mSnapshotLabelEntry = new TextEntry(this, "snapshot label", -1, -1, 12, &mSnapshotLabel);
 
    {
@@ -120,13 +124,17 @@ void Snapshots::DrawModule()
    mAddButton->Draw();
    mSnapshotLabelEntry->SetPosition(3, mGrid->GetRect(K(local)).getMaxY() + 3);
    mSnapshotLabelEntry->Draw();
+   mClearButton->Draw();
+   mStoreCheckbox->Draw();
+   mDeleteCheckbox->Draw();
+   mAutoStoreOnSwitchCheckbox->Draw();
 
    int hover = mGrid->CurrentHover();
-   bool shiftHeld = GetKeyModifiers() == kModifier_Shift;
-   bool altHeld = GetKeyModifiers() == kModifier_Alt;
-   if (shiftHeld || altHeld)
+   bool storeMode = (GetKeyModifiers() == kModifier_Shift) || mStoreMode;
+   bool deleteMode = (GetKeyModifiers() == kModifier_Alt) || mDeleteMode;
+   if (storeMode || deleteMode)
    {
-      if (hover < mGrid->GetCols() * mGrid->GetRows())
+      if (hover >= 0 && hover < mGrid->GetCols() * mGrid->GetRows())
       {
          ofVec2f pos = mGrid->GetCellPosition(hover % mGrid->GetCols(), hover / mGrid->GetCols()) + mGrid->GetPosition(true);
          float xsize = float(mGrid->GetWidth()) / mGrid->GetCols();
@@ -134,13 +142,13 @@ void Snapshots::DrawModule()
 
          ofPushStyle();
          ofSetColor(0, 0, 0);
-         if (shiftHeld)
+         if (storeMode)
          {
             ofFill();
             ofRect(pos.x + xsize / 2 - 1, pos.y + 3, 2, ysize - 6, 0);
             ofRect(pos.x + 3, pos.y + ysize / 2 - 1, xsize - 6, 2, 0);
          }
-         if (altHeld && !mSnapshotCollection[hover].mSnapshots.empty())
+         else if (deleteMode && !mSnapshotCollection[hover].mSnapshots.empty())
          {
             ofLine(pos.x + 3, pos.y + 3, pos.x + xsize - 3, pos.y + ysize - 3);
             ofLine(pos.x + xsize - 3, pos.y + 3, pos.x + 3, pos.y + ysize - 3);
@@ -169,7 +177,7 @@ void Snapshots::DrawModule()
 void Snapshots::DrawModuleUnclipped()
 {
    int hover = mGrid->CurrentHover();
-   if (hover != -1 && !mSnapshotCollection.empty())
+   if (hover >= 0 && !mSnapshotCollection.empty())
    {
       assert(hover >= 0 && hover < mSnapshotCollection.size());
 
@@ -221,9 +229,9 @@ void Snapshots::OnClicked(float x, float y, bool right)
 
       int idx = cell.mCol + cell.mRow * mGrid->GetCols();
 
-      if (GetKeyModifiers() == kModifier_Shift)
+      if (GetKeyModifiers() == kModifier_Shift || mStoreMode)
          Store(idx);
-      else if (GetKeyModifiers() == kModifier_Alt)
+      else if (GetKeyModifiers() == kModifier_Alt || mDeleteMode)
          Delete(idx);
       else
          SetSnapshot(idx, NextBufferTime(false));
@@ -243,7 +251,13 @@ void Snapshots::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
 {
    if (velocity > 0 && pitch < (int)mSnapshotCollection.size())
    {
-      SetSnapshot(pitch, time);
+      if (mStoreMode)
+         Store(pitch);
+      else if (mDeleteMode)
+         Delete(pitch);
+      else
+         SetSnapshot(pitch, time);
+      
       UpdateGridValues();
    }
 }
@@ -259,7 +273,7 @@ void Snapshots::SetSnapshot(int idx, double time)
    if (idx < 0 || idx >= (int)mSnapshotCollection.size())
       return;
 
-   if (mAutoStoreOnSwitch)
+   if (mAutoStoreOnSwitch && idx != mCurrentSnapshot)
       Store(mCurrentSnapshot);
 
    mCurrentSnapshot = idx;
@@ -489,6 +503,16 @@ void Snapshots::ButtonClicked(ClickButton* button, double time)
          }
       }
    }
+
+   if (button == mClearButton)
+   {
+      for (size_t i = 0; i < mSnapshotCollection.size(); ++i)
+      {
+         if (!mSnapshotCollection[i].mSnapshots.empty())
+            Delete(i);
+      }
+      UpdateGridValues();
+   }
 }
 
 void Snapshots::DropdownUpdated(DropdownList* list, int oldVal, double time)
@@ -497,7 +521,12 @@ void Snapshots::DropdownUpdated(DropdownList* list, int oldVal, double time)
    {
       int newIdx = mCurrentSnapshot;
       mCurrentSnapshot = oldVal;
-      SetSnapshot(newIdx, time);
+      if (mStoreMode)
+         Store(newIdx);
+      else if (mDeleteMode)
+         Delete(newIdx);
+      else
+         SetSnapshot(newIdx, time);
       UpdateGridValues();
    }
 }
@@ -560,7 +589,6 @@ void Snapshots::SetUpFromSaveData()
 {
    SetGridSize(mModuleSaveData.GetFloat("gridwidth"), mModuleSaveData.GetFloat("gridheight"));
    mAllowSetOnAudioThread = mModuleSaveData.GetBool("allow_set_on_audio_thread");
-   mAutoStoreOnSwitch = mModuleSaveData.GetBool("auto_store_on_switch");
 }
 
 void Snapshots::SaveState(FileStreamOut& out)

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -1,3 +1,4 @@
+
 /**
     bespoke synth, a software modular synthesizer
     Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
@@ -157,8 +158,14 @@ private:
    PatchCableSource* mUIControlCable{ nullptr };
    int mQueuedSnapshotIndex{ -1 };
    bool mAllowSetOnAudioThread{ false };
-   bool mAutoStoreOnSwitch{ false };
    TextEntry* mSnapshotLabelEntry{ nullptr };
    std::string mSnapshotLabel;
    int mLoadRev{ -1 };
+   ClickButton* mClearButton;
+   bool mStoreMode{ false };
+   Checkbox* mStoreCheckbox;
+   bool mDeleteMode{ false };
+   Checkbox* mDeleteCheckbox;
+   bool mAutoStoreOnSwitch{ false };
+   Checkbox* mAutoStoreOnSwitchCheckbox;
 };

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -196,7 +196,6 @@ private:
    void UpdateMetaLights();
 
    void DrawRowLabel(const char* label, int row, int x, int y);
-   void SetPreset(int preset);
    int GetNumSteps(NoteInterval interval, int numMeasures) const;
    Vec2i ControllerToGrid(const Vec2i& controller);
    int GetNumControllerChunks(); //how many vertical chunks of the sequence are there to fit multi-rowed on the controller?
@@ -215,11 +214,9 @@ private:
       {
          mCol = col;
          mRow = row;
-         mTime = gTime;
       }
       int mCol{ 0 };
       int mRow{ 0 };
-      double mTime{ 0 };
    };
 
    enum class NoteInputMode
@@ -232,8 +229,7 @@ private:
    float mStrength{ 1 };
    FloatSlider* mStrengthSlider{ nullptr };
    int mGridYOff{ 0 };
-   DropdownList* mPresetDropdown{ nullptr };
-   int mPreset{ -1 };
+   ClickButton* mClearButton{ nullptr };
    int mColorOffset{ 3 };
    DropdownList* mGridYOffDropdown{ nullptr };
    std::array<StepSequencerRow*, NUM_STEPSEQ_ROWS> mRows{};

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -439,17 +439,16 @@ void TitleBar::DrawModuleUnclipped()
       return;
    }
 
-   float saveCooldown = 1 - ofClamp((gTime - TheSynth->GetLastSaveTime()) / 1000, 0, 1);
-   if (saveCooldown > 0)
+   float displayMessageCooldown = 1 - ofClamp((gTime - mDisplayMessageTime) / 1000, 0, 1);
+   if (displayMessageCooldown > 0)
    {
       ofPushStyle();
-      ofSetColor(255, 255, 255, saveCooldown * 255);
+      ofSetColor(255, 255, 255, displayMessageCooldown * 255);
       float titleBarWidth, titleBarHeight;
       TheTitleBar->GetDimensions(titleBarWidth, titleBarHeight);
       float x = 100;
       float y = 40 + titleBarHeight;
-      std::string filename = juce::File(TheSynth->GetLastSavePath()).getFileName().toStdString();
-      gFontBold.DrawString("saved " + filename, 50, x, y);
+      gFontBold.DrawString(mDisplayMessage, 50, x, y);
       ofPopStyle();
    }
 
@@ -512,6 +511,12 @@ void TitleBar::DrawModuleUnclipped()
          ofPopStyle();
       }
    }
+}
+
+void TitleBar::DisplayTemporaryMessage(std::string message)
+{
+   mDisplayMessage = message;
+   mDisplayMessageTime = gTime;
 }
 
 bool TitleBar::HiddenByZoom() const

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -135,6 +135,7 @@ public:
    void ListLayouts();
    void ManagePlugins();
    const std::vector<SpawnList*>& GetSpawnLists() const { return mSpawnLists.GetDropdowns(); }
+   void DisplayTemporaryMessage(std::string message);
 
    bool IsSaveable() override { return false; }
 
@@ -184,6 +185,9 @@ private:
    std::unique_ptr<PluginListWindow> mPluginListWindow;
 
    NewPatchConfirmPopup mNewPatchConfirmPopup;
+
+   std::string mDisplayMessage;
+   double mDisplayMessageTime;
 };
 
 extern TitleBar* TheTitleBar;

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -60,6 +60,10 @@ snapshots~save and restore sets of values. connect the grey circle to modules to
 ~snapshot~jump to a snapshot
 ~random~randomize connected controls
 ~add~snapshot the currently connected controls to the next available snapshot slot
+~clear~clear all snapshots
+~store~when clicking/selecting a snapshot, store into that slot (alternately: hold the shift key)
+~delete~when clicking/selecting a snapshot, delete that slot (alternately: hold the alt/option key)
+~auto-store on switch~when switching to a new slot, automatically store state in the current slot
 
 
 
@@ -641,7 +645,7 @@ fouronthefloor~sends note 0 every beat, to trigger a kick drum
 drumsequencer~step sequencer intended for drums. hold shift when dragging on the grid to adjust step velocity.
 ~vel~velocity to use when setting a step
 ~measures~length of the sequence in measures
-~preset~select a pattern preset
+~clear~clear sequence
 ~yoff~vertical offset for grid controller's view of the pattern
 ~offsets~show "offsets" sliders
 ~repeat~repeat input notes at this rate
@@ -871,6 +875,7 @@ looper~loop input audio. use with a "looperrecorder" for full functionality.
 ~copy~take the contents of this looper and copy it onto another. click this button on the copy source, then on the copy target.
 ~2x~make loop play at double speed
 ~.5x~make loop play at half speed
+~extend~make loop twice as long
 ~undo~undo last loop commit
 ~offset~amount to offset looper's playhead from transport position
 ~apply~shift the contents of the looper so the current offset is the start of the buffer


### PR DESCRIPTION
- give feedback when "write audio" completes
- add interface to allow better control over storing/deleting snapshots via midicontroller
- add "extend" button to looper
- make looperrecorder not auto-advance through loopers by default
- get rid of drumsequencer's presets, and replace it with just a "clear" button
- change up how grid controllers edit drumsequencer, to make it more responsive
- make it possible to enable/disable the note quantizer effect