### PR TITLE
fix issue where opening a plugin with a modal popup will endlessly spam the popup

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -587,6 +587,7 @@ void VSTPlugin::Poll()
 
    if (mWantOpenVstWindow)
    {
+      mWantOpenVstWindow = false;
       if (mPlugin != nullptr)
       {
          if (mWindow == nullptr)
@@ -596,7 +597,6 @@ void VSTPlugin::Poll()
          //if (mWindow->GetNSViewComponent())
          //   mWindowOverlay = new NSWindowOverlay(mWindow->GetNSViewComponent()->getView());
       }
-      mWantOpenVstWindow = false;
    }
 }
 void VSTPlugin::audioProcessorChanged(juce::AudioProcessor* processor, const ChangeDetails& details)


### PR DESCRIPTION
this happened with valhalla plugins that needed their license file specified, for example