### PR TITLE
a whole bunch of improvements to push2 integration

### DIFF
--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -516,6 +516,52 @@ void DrumPlayer::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
    }
 }
 
+bool DrumPlayer::OnPush2Control(MidiMessageType type, int controlIndex, float midiValue)
+{
+   if (type == kMidiMessage_Note)
+   {
+      if (controlIndex >= 36 && controlIndex <= 99)
+      {
+         int gridIndex = controlIndex - 36;
+         int x = gridIndex % 8;
+         int y = gridIndex / 8;
+
+         if (x < 4 && y < 4)
+            OnGridButton(x, 3 - y, midiValue / 127.0f, nullptr);
+
+         return true;
+      }
+   }
+
+   return false;
+}
+
+void DrumPlayer::UpdatePush2Leds(Push2Control* push2)
+{
+   for (int x = 0; x < 8; ++x)
+   {
+      for (int y = 0; y < 8; ++y)
+      {
+         int pushColor;
+
+         if (x < 4 && y < 4)
+         {
+            int index = x + y * 4;
+            if (mDrumHits[index].GetPlayProgress(gTime) < 1)
+               pushColor = 2;
+            else
+               pushColor = 1;
+         }
+         else
+         {
+            pushColor = 0;
+         }
+
+         push2->SetLed(kMidiMessage_Note, x + y * 8 + 36, pushColor);
+      }
+   }
+}
+
 void DrumPlayer::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    x -= 5;

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -44,12 +44,13 @@
 #include "PatchCableSource.h"
 #include "RollingBuffer.h"
 #include "GridController.h"
+#include "Push2Control.h"
 
 #define NUM_DRUM_HITS 16
 
 class SamplePlayer;
 
-class DrumPlayer : public IAudioSource, public INoteReceiver, public IDrawableModule, public IFloatSliderListener, public IDropdownListener, public IButtonListener, public IIntSliderListener, public ITextEntryListener, public IGridControllerListener, public ITimeListener
+class DrumPlayer : public IAudioSource, public INoteReceiver, public IDrawableModule, public IFloatSliderListener, public IDropdownListener, public IButtonListener, public IIntSliderListener, public ITextEntryListener, public IGridControllerListener, public ITimeListener, public IPush2GridController
 {
 public:
    DrumPlayer();
@@ -88,6 +89,10 @@ public:
 
    //ITimeListener
    void OnTimeEvent(double time) override;
+
+   //IPush2GridController
+   bool OnPush2Control(MidiMessageType type, int controlIndex, float midiValue) override;
+   void UpdatePush2Leds(Push2Control* push2) override;
 
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;

--- a/Source/FloatSliderLFOControl.cpp
+++ b/Source/FloatSliderLFOControl.cpp
@@ -195,6 +195,38 @@ void FloatSliderLFOControl::DrawModule()
             ofMap(GetLFOValue(0, mLFO.TransformPhase(currentPhase)), GetTargetMax(), GetTargetMin(), 0, height) + y, 2);
 }
 
+bool FloatSliderLFOControl::DrawToPush2Screen()
+{
+   FloatSlider* slider = GetOwner();
+   if (slider)
+   {
+      ofRectangle rect(30, -12, 100, 11);
+      ofSetColor(100, 100, 100);
+      ofRect(rect);
+
+      float screenPos = rect.x + 1 + (rect.width - 2) * slider->ValToPos(slider->GetValue(), true);
+      float lfomax = ofClamp(GetMax(), slider->GetMin(), slider->GetMax());
+      float screenPosMax = rect.x + 1 + (rect.width - 2) * slider->ValToPos(lfomax, true);
+      float lfomin = ofClamp(GetMin(), slider->GetMin(), slider->GetMax());
+      float screenPosMin = rect.x + 1 + (rect.width - 2) * slider->ValToPos(lfomin, true);
+
+      ofPushStyle();
+      ofSetColor(0, 200, 0);
+      ofFill();
+      if (fabs(screenPos - screenPosMin) > 1)
+         ofRect(screenPosMin, rect.y, screenPos - screenPosMin, rect.height, 1); //lfo bar
+      ofPopStyle();
+
+      ofPushStyle();
+      ofSetColor(0, 255, 0);
+      ofSetLineWidth(2);
+      ofLine(screenPosMin, rect.y + 1, screenPosMin, rect.getMaxY() - 1); //min bar
+      ofLine(screenPosMax, rect.y + 1, screenPosMax, rect.getMaxY() - 1); //max bar
+      ofPopStyle();
+   }
+   return false;
+}
+
 void FloatSliderLFOControl::SetLFOEnabled(bool enabled)
 {
    if (enabled && !mEnabled && !TheSynth->IsLoadingState()) //if turning on

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -85,6 +85,7 @@ public:
    bool InLowResMode() const { return mLFOSettings.mLowResMode; }
    bool HasSpecialDelete() const override { return true; }
    void DoSpecialDelete() override;
+   bool DrawToPush2Screen() override;
 
    //IModulator
    float Value(int samplesIn = 0) override;

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -185,11 +185,12 @@ public:
    virtual bool HasDebugDraw() const { return false; }
    virtual bool HasPush2OverrideControls() const { return false; }
    virtual void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const {}
+   virtual bool DrawToPush2Screen() { return false; }
 
    //IPatchable
    PatchCableSource* GetPatchCableSource(int index = 0) override
    {
-      if (index == 0)
+      if (index == 0 && (mMainPatchCableSource != nullptr || mPatchCableSources.empty()))
          return mMainPatchCableSource;
       else
          return mPatchCableSources[index];

--- a/Source/MidiDevice.h
+++ b/Source/MidiDevice.h
@@ -113,6 +113,9 @@ public:
 
    static void SendMidiMessage(MidiDeviceListener* listener, const char* deviceName, const juce::MidiMessage& message);
 
+   static constexpr float kPitchBendCenter{ 8192.0f };
+   static constexpr float kPitchBendMax{ 16320.0f };
+
 private:
    void handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message) override;
 

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -470,9 +470,26 @@ void ModularSynth::ZoomView(float zoomAmount, bool fromMouse)
    mHideTooltipsUntilMouseMove = true;
 }
 
+void ModularSynth::SetZoomLevel(float zoomLevel)
+{
+   float oldDrawScale = gDrawScale;
+   gDrawScale = zoomLevel;
+   float zoomAmount = (gDrawScale - oldDrawScale) / oldDrawScale;
+   ofVec2f zoomCenter = ofVec2f(ofGetWidth() / gDrawScale * .5f, ofGetHeight() / gDrawScale * .5f);
+   GetDrawOffset() -= zoomCenter * zoomAmount;
+   mZoomer.CancelMovement();
+   mHideTooltipsUntilMouseMove = true;
+}
+
 void ModularSynth::PanView(float x, float y)
 {
    GetDrawOffset() += ofVec2f(x, y) / gDrawScale;
+   mHideTooltipsUntilMouseMove = true;
+}
+
+void ModularSynth::PanTo(float x, float y)
+{
+   SetDrawOffset(ofVec2f(ofGetWidth() / gDrawScale / 2 - x, ofGetHeight() / gDrawScale / 2 - y));
    mHideTooltipsUntilMouseMove = true;
 }
 

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -176,7 +176,9 @@ public:
    bool MouseMovedSignificantlySincePressed() const { return mMouseMovedSignificantlySincePressed; }
 
    void ZoomView(float zoomAmount, bool fromMouse);
+   void SetZoomLevel(float zoomLevel);
    void PanView(float x, float y);
+   void PanTo(float x, float y);
    void SetRawSpaceMouseTwist(float twist, bool isUsing)
    {
       mSpaceMouseInfo.mTwist = twist;

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -41,12 +41,13 @@
 #include "IPulseReceiver.h"
 #include "GridController.h"
 #include "IDrivableSequencer.h"
+#include "Push2Control.h"
 
 #define NSS_MAX_STEPS 32
 
 class PatchCableSource;
 
-class NoteStepSequencer : public IDrawableModule, public ITimeListener, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public MidiDeviceListener, public UIGridListener, public IAudioPoller, public IScaleListener, public INoteReceiver, public IPulseReceiver, public IGridControllerListener, public IDrivableSequencer
+class NoteStepSequencer : public IDrawableModule, public ITimeListener, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public MidiDeviceListener, public UIGridListener, public IAudioPoller, public IScaleListener, public INoteReceiver, public IPulseReceiver, public IGridControllerListener, public IDrivableSequencer, public IPush2GridController
 {
 public:
    NoteStepSequencer();
@@ -59,7 +60,7 @@ public:
    void CreateUIControls() override;
 
    void Init() override;
-   void SetEnabled(bool enabled) override { mEnabled = enabled; }
+   void SetEnabled(bool enabled) override;
 
    void SetMidiController(std::string name);
 
@@ -79,6 +80,10 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
+
+   //IPush2GridController
+   bool OnPush2Control(MidiMessageType type, int controlIndex, float midiValue) override;
+   void UpdatePush2Leds(Push2Control* push2) override;
 
    //IAudioPoller
    void OnTransportAdvanced(float amount) override;
@@ -147,6 +152,7 @@ private:
    void RandomizeLengths();
    void Step(double time, float velocity, int pulseFlags);
    void SendNoteToCable(int index, double time, int pitch, int velocity);
+   void GetPush2Layout(int& sequenceRows, int& pitchCols, int& pitchRows);
 
    enum NoteMode
    {
@@ -224,4 +230,13 @@ private:
    int mGridControlOffsetY{ 0 };
    IntSlider* mGridControlOffsetXSlider{ nullptr };
    IntSlider* mGridControlOffsetYSlider{ nullptr };
+   int mPush2HeldStep{ -1 };
+   bool mPush2HeldStepWasEdited{ false };
+   double mPush2ButtonPressTime{ -1 };
+   int mQueuedPush2Tone{ -1 };
+   int mQueuedPush2Vel{ 127 };
+   float mQueuedPush2Length{ 1 };
+   bool mGridSyncQueued{ false };
+   bool mPush2VelocityHeld{ false };
+   bool mPush2LengthHeld{ false };
 };

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -38,10 +38,11 @@
 #include "UIGrid.h"
 #include "Scale.h"
 #include "GridController.h"
+#include "Push2Control.h"
 
 class PatchCableSource;
 
-class NoteTable : public IDrawableModule, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public UIGridListener, public IScaleListener, public INoteReceiver, public IGridControllerListener
+class NoteTable : public IDrawableModule, public INoteSource, public IButtonListener, public IDropdownListener, public IIntSliderListener, public IFloatSliderListener, public UIGridListener, public INoteReceiver, public IGridControllerListener, public IPush2GridController
 {
 public:
    NoteTable();
@@ -70,9 +71,6 @@ public:
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
 
-   //IScaleListener
-   void OnScaleChanged() override;
-
    //UIGridListener
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
 
@@ -83,6 +81,10 @@ public:
    //IGridControllerListener
    void OnControllerPageSelected() override;
    void OnGridButton(int x, int y, float velocity, IGridController* grid) override;
+
+   //IPush2GridController
+   bool OnPush2Control(MidiMessageType type, int controlIndex, float midiValue) override;
+   void UpdatePush2Leds(Push2Control* push2) override;
 
    void ButtonClicked(ClickButton* button, double time) override;
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
@@ -107,11 +109,10 @@ private:
    void UpdateGridControllerLights(bool force);
 
    void PlayColumn(double time, int column, int velocity, int voiceIdx, ModulationParameters modulation);
-   void SetUpColumnControls();
-   void SyncGridToSeq();
    float ExtraWidth() const;
    float ExtraHeight() const;
    void RandomizePitches(bool fifths);
+   void GetPush2Layout(int& sequenceRows, int& pitchCols, int& pitchRows);
 
    enum NoteMode
    {
@@ -128,9 +129,8 @@ private:
    DropdownList* mNoteModeSelector{ nullptr };
    int mLength{ 8 };
    IntSlider* mLengthSlider{ nullptr };
-   bool mSetLength{ false };
    int mNoteRange{ 15 };
-   bool mShowColumnControls{ false };
+   bool mShowColumnCables{ false };
    int mRowOffset{ 0 };
 
    ClickButton* mRandomizePitchButton{ nullptr };
@@ -141,15 +141,16 @@ private:
 
    static constexpr int kMaxLength = 32;
 
-   int mTones[kMaxLength]{};
-   std::array<double, kMaxLength> mLastColumnPlayTime{ -1 };
-   std::array<int, kMaxLength> mLastColumnNoteOnPitch{ -1 };
-   std::array<DropdownList*, kMaxLength> mToneDropdowns{ nullptr };
+   std::array<double, kMaxLength> mLastColumnPlayTime{};
+   std::array<bool[127], kMaxLength> mLastColumnNoteOnPitches{};
    std::array<AdditionalNoteCable*, kMaxLength> mColumnCables{ nullptr };
+   std::array<double, 127> mPitchPlayTimes{};
 
    GridControlTarget* mGridControlTarget{ nullptr };
    int mGridControlOffsetX{ 0 };
    int mGridControlOffsetY{ 0 };
    IntSlider* mGridControlOffsetXSlider{ nullptr };
    IntSlider* mGridControlOffsetYSlider{ nullptr };
+
+   int mPush2HeldStep{ -1 };
 };

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -139,8 +139,12 @@ void Push2Control::Exit()
       SetLed(kMidiMessage_Note, i, 0);
       SetLed(kMidiMessage_Control, i, 0);
    }
-   bzero(mPixels, GetNumDisplayPixels());
-   ThePushBridge.Flip(mPixels);
+
+   if (mPixels != nullptr)
+   {
+      memset(mPixels, 0, sizeof(unsigned char) * GetNumDisplayPixels());
+      ThePushBridge.Flip(mPixels);
+   }
 
    mDevice.DisconnectInput();
    mDevice.DisconnectOutput();

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -44,6 +44,7 @@ using namespace juce::gl;
 #include "DropdownList.h"
 #include "FloatSliderLFOControl.h"
 #include "UserPrefsEditor.h"
+#include "Snapshots.h"
 #include "push2/JuceToPush2DisplayBridge.h"
 #include "push2/Push2-Bitmap.h"
 
@@ -64,26 +65,51 @@ namespace
 {
    const int kTapTempoButton = 3;
    const int kMetronomeButton = 9;
-   const int kNewButton = 87;
-   const int kDeleteButton = 118;
-   const int kAutomateButton = 89;
-   const int kCircleButton = 86;
-   const int kAddDeviceButton = 52;
-   const int kAboveScreenButtonRow = 102;
    const int kBelowScreenButtonRow = 20;
-   const int kUpButton = 46;
-   const int kDownButton = 47;
+   const int kMasterButton = 28;
+   const int kStopClipButton = 29;
+   const int kSetupButton = 30;
+   const int kLayoutButton = 31;
+   const int kConvertButton = 35;
+   const int kQuantizeButtonSection = 36;
    const int kLeftButton = 44;
    const int kRightButton = 45;
+   const int kUpButton = 46;
+   const int kDownButton = 47;
+   const int kSelectButton = 48;
+   const int kShiftButton = 49;
    const int kNoteButton = 50;
    const int kSessionButton = 51;
+   const int kAddDeviceButton = 52;
+   const int kAddTrackButton = 53;
+   const int kOctaveDownButton = 54;
+   const int kOctaveUpButton = 55;
+   const int kRepeatButton = 56;
+   const int kAccentButton = 57;
+   const int kScaleButton = 58;
+   const int kUserButton = 59;
+   const int kMuteButton = 60;
+   const int kSoloButton = 61;
    const int kPageLeftButton = 62;
    const int kPageRightButton = 63;
-   const int kMasterButton = 28;
-   const int kQuantizeButtonSection = 36;
+   const int kCornerKnob = 79;
+   const int kPlayButton = 85;
+   const int kCircleButton = 86;
+   const int kNewButton = 87;
+   const int kDuplicateButton = 88;
+   const int kAutomateButton = 89;
+   const int kFixedLengthButton = 90;
+   const int kAboveScreenButtonRow = 102;
+   const int kDeviceButton = 110;
+   const int kBrowseButton = 111;
+   const int kMixButton = 112;
+   const int kClipButton = 113;
+   const int kQuantizeButton = 116;
+   const int kDoubleLoopButton = 117;
+   const int kDeleteButton = 118;
+   const int kUndoButton = 119;
+
    const int kNumQuantizeButtons = 8;
-   const int kSetupButton = 30;
-   const int kUserButton = 59;
 }
 #include "leathers/pop"
 
@@ -104,11 +130,20 @@ Push2Control::Push2Control()
 
 Push2Control::~Push2Control()
 {
+}
+
+void Push2Control::Exit()
+{
    for (int i = 0; i < 128; ++i)
    {
       SetLed(kMidiMessage_Note, i, 0);
       SetLed(kMidiMessage_Control, i, 0);
    }
+   bzero(mPixels, GetNumDisplayPixels());
+   ThePushBridge.Flip(mPixels);
+
+   mDevice.DisconnectInput();
+   mDevice.DisconnectOutput();
 }
 
 void Push2Control::CreateUIControls()
@@ -158,13 +193,13 @@ void Push2Control::DrawModuleUnclipped()
       ofPushStyle();
       ofVec2f pos = GetPosition();
       ofTranslate(-pos.x, -pos.y);
-      DrawDisplayModuleRect(mDisplayModule->GetRect());
+      DrawDisplayModuleRect(mDisplayModule->GetRect(), 3);
       ofPopMatrix();
       ofPopStyle();
    }
 }
 
-void Push2Control::DrawDisplayModuleRect(ofRectangle rect)
+void Push2Control::DrawDisplayModuleRect(ofRectangle rect, float thickness)
 {
    if (mDisplayModule->HasTitleBar())
    {
@@ -172,7 +207,7 @@ void Push2Control::DrawDisplayModuleRect(ofRectangle rect)
       rect.height += IDrawableModule::TitleBarHeight();
    }
    ofSetColor(255, 255, 255, ofMap(sin(gTime / 1000 * PI * 2), -1, 1, 60, 100));
-   ofSetLineWidth(3);
+   ofSetLineWidth(thickness);
    ofNoFill();
    ofRect(rect.x - 3, rect.y - 3, rect.width + 6, rect.height + 6);
 }
@@ -294,10 +329,7 @@ bool Push2Control::Initialize()
       ofLog() << "push 2 connected";
    }
 
-   const auto width = ableton::Push2DisplayBitmap::kWidth;
-   const auto height = ableton::Push2DisplayBitmap::kHeight;
-
-   mPixels = new unsigned char[3 * (width * kPixelRatio) * (height * kPixelRatio)];
+   mPixels = new unsigned char[GetNumDisplayPixels()];
 
    mFontHandle = nvgCreateFont(sVG, ofToResourcePath("frabk.ttf").c_str(), ofToResourcePath("frabk.ttf").c_str());
    mFontHandleBold = nvgCreateFont(sVG, ofToResourcePath("frabk_m.ttf").c_str(), ofToResourcePath("frabk_m.ttf").c_str());
@@ -313,11 +345,19 @@ bool Push2Control::Initialize()
       {
          mDevice.ConnectOutput(i);
          mDevice.ConnectInput(devices[i].c_str());
+
+         std::string touchStripConfig = { 0x00, 0x21, 0x1D, 0x01, 0x01, 0x17, 0x03 };
+         mDevice.SendSysEx(touchStripConfig);
          break;
       }
    }
 
    return true;
+}
+
+int Push2Control::GetNumDisplayPixels() const
+{
+   return 3 * (ableton::Push2DisplayBitmap::kWidth * kPixelRatio) * (ableton::Push2DisplayBitmap::kHeight * kPixelRatio);
 }
 
 void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float t, float pxRatio)
@@ -355,10 +395,10 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
 
    SetModuleGridLights();
 
-   mModuleColumnOffsetSmoothed = ofLerp(mModuleColumnOffsetSmoothed, mModuleColumnOffset, .3f);
+   mModuleViewOffsetSmoothed = ofLerp(mModuleViewOffsetSmoothed, mModuleViewOffset, .3f);
    mModuleListOffsetSmoothed = ofLerp(mModuleListOffsetSmoothed, round(mModuleListOffset), .3f);
 
-   if (mScreenDisplayMode == ScreenDisplayMode::kNormal)
+   if (mScreenDisplayMode == ScreenDisplayMode::kNormal || mScreenDisplayMode == ScreenDisplayMode::kMap)
    {
       DrawLowerModuleSelector();
       DrawDisplayModuleControls();
@@ -378,6 +418,10 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
          stateInfo = "tap a button in the column below this button to bookmark the \"" + std::string(mDisplayModule->Name()) + "\" module...";
       else if (mInMidiControllerBindMode)
          stateInfo = "MIDI bind mode: hold a knob or button, then move/press a MIDI control to bind to that module control";
+      else if (mAddTrackHeld && mDisplayModule != nullptr && mDisplayModuleSnapshots == nullptr)
+         stateInfo = "press one of the 4 buttons to the right of this screen to create a snapshot";
+      else if (mAddTrackHeld && mDisplayModule != nullptr && mDisplayModuleSnapshots != nullptr)
+         stateInfo = "press one of the 4 buttons to the right of this screen to store a snapshot";
 
       if (stateInfo != "")
       {
@@ -419,7 +463,7 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
          ofSetColor(IDrawableModule::GetColor(kModuleCategory_Other));
          ofNoFill();
 
-         ofTranslate(-kColumnSpacing * mModuleColumnOffsetSmoothed, 0);
+         ofTranslate(-kColumnSpacing * mModuleViewOffsetSmoothed, 0);
 
          nvgFontSize(sVG, 16);
          DrawControls(mButtonControls, false, 60);
@@ -433,10 +477,10 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
          ofFill();
          ofSetColor(IDrawableModule::GetColor(GetModuleTypeForSpawnList(list)));
          ofRect(mSelectedGridSpawnListIndex * boxWidth, -5, boxWidth, 12);
-         for (int i = 0; i < list->GetNumValues(); ++i)
+         for (int i = mModuleViewOffset * 8; i < list->GetNumValues(); ++i)
          {
             int x = (i % 8) * boxWidth;
-            int y = (i / 8) * boxHeight + 10;
+            int y = (i / 8) * boxHeight + 10 - mModuleViewOffsetSmoothed * boxHeight;
             ofPushMatrix();
             ofClipWindow(x, y, boxWidth, boxHeight, false);
             ofSetColor(GetSpawnGridColor(i, GetModuleTypeForSpawnList(list)));
@@ -451,28 +495,97 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
 
       for (int i = 0; i < 8; ++i)
       {
-         if (i < (int)mSpawnModuleControls.size())
-            SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, GetPadColorForType(GetModuleTypeForSpawnList(mSpawnModuleControls[i])));
+         if (mSelectedGridSpawnListIndex != -1 && i != mSelectedGridSpawnListIndex)
+            SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, 0);
+         else if (i < (int)mSpawnModuleControls.size())
+            SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, GetPadColorForType(GetModuleTypeForSpawnList(mSpawnModuleControls[i]), true));
          else
             SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, 0);
          SetLed(kMidiMessage_Control, i + kBelowScreenButtonRow, 0);
       }
    }
 
+   if (mScreenDisplayMode == ScreenDisplayMode::kMap)
+   {
+      ofPushStyle();
+      ofPushMatrix();
+
+      ofPushStyle();
+      ofFill();
+      ofSetColor(0, 0, 0, 150);
+      ofRect(0, 0, ableton::Push2DisplayBitmap::kWidth * kPixelRatio, ableton::Push2DisplayBitmap::kHeight * kPixelRatio);
+      ofPopStyle();
+
+      float screenScale = .2f;
+      ofScale(screenScale * gDrawScale, screenScale * gDrawScale, screenScale * gDrawScale);
+      ofTranslate(TheSynth->GetDrawOffset().x, TheSynth->GetDrawOffset().y);
+      ofTranslate(1500 / gDrawScale, -100 / gDrawScale); //center on display
+
+      TheSynth->GetRootContainer()->Draw();
+      TheSynth->GetRootContainer()->DrawPatchCables(false);
+      TheSynth->GetRootContainer()->DrawUnclipped();
+
+      if (mDisplayModule != nullptr && !mDisplayModule->IsDeleted() &&
+          mDisplayModule->GetOwningContainer() != nullptr && mDisplayModule->IsShowing())
+         DrawDisplayModuleRect(mDisplayModule->GetRect(), 6);
+
+      ofPopMatrix();
+      ofPopStyle();
+
+      /*for (int i = 0; i < 8; ++i)
+      {
+         SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, 0);
+         SetLed(kMidiMessage_Control, i + kBelowScreenButtonRow, 0);
+      }*/
+   }
+
    bool isHoveringOverNewModule = (gHoveredModule != mDisplayModule && gHoveredModule != nullptr);
+   if (mDisplayModule != nullptr)
+      SetLed(kMidiMessage_Control, kPlayButton, mDisplayModule->IsEnabled() ? 126 : 127);
+   else
+      SetLed(kMidiMessage_Control, kPlayButton, 0);
    SetLed(kMidiMessage_Control, kTapTempoButton, isHoveringOverNewModule ? 127 : 0, isHoveringOverNewModule ? 32 : 0);
+   SetLed(kMidiMessage_Control, kMetronomeButton, mDisplayModule == this ? 127 : 8);
    SetLed(kMidiMessage_Control, kNewButton, 127, mNewButtonHeld ? 0 : -1);
    SetLed(kMidiMessage_Control, kDeleteButton, 127, mDeleteButtonHeld ? 0 : -1);
    SetLed(kMidiMessage_Control, kAutomateButton, 126, mModulationButtonHeld ? 0 : -1);
    SetLed(kMidiMessage_Control, kMasterButton, 127, mAddModuleBookmarkButtonHeld ? 0 : -1);
-   SetLed(kMidiMessage_Control, kCircleButton, 8, mAllowRepatch ? 11 : -1);
+   SetLed(kMidiMessage_Control, kCircleButton, 8, mAllowRepatch ? 127 : -1);
    SetLed(kMidiMessage_Control, kAddDeviceButton, 127, mScreenDisplayMode == ScreenDisplayMode::kAddModule ? 0 : -1);
-   SetLed(kMidiMessage_Control, kUpButton, 127);
-   SetLed(kMidiMessage_Control, kDownButton, 127);
-   SetLed(kMidiMessage_Control, kLeftButton, 127);
-   SetLed(kMidiMessage_Control, kRightButton, 127);
-   SetLed(kMidiMessage_Control, kPageLeftButton, mModuleHistoryPosition > 0 ? 127 : 0);
-   SetLed(kMidiMessage_Control, kPageRightButton, mModuleHistoryPosition < mModuleHistory.size() - 1 ? 127 : 0);
+   SetLed(kMidiMessage_Control, kAddTrackButton, mDisplayModule != nullptr ? 127 : 0, mAddTrackHeld ? 0 : -1);
+   SetLed(kMidiMessage_Control, kUserButton, 127, mScreenDisplayMode == ScreenDisplayMode::kMap ? 0 : -1);
+   if (mDisplayModuleSnapshots != nullptr)
+   {
+      SetLed(kMidiMessage_Control, kDeviceButton, mDisplayModuleSnapshots->HasSnapshot(0) ? 127 : 8, mDisplayModuleSnapshots->GetCurrentSnapshot() == 0 ? 0 : -1);
+      SetLed(kMidiMessage_Control, kMixButton, mDisplayModuleSnapshots->HasSnapshot(1) ? 127 : 8, mDisplayModuleSnapshots->GetCurrentSnapshot() == 1 ? 0 : -1);
+      SetLed(kMidiMessage_Control, kBrowseButton, mDisplayModuleSnapshots->HasSnapshot(2) ? 127 : 8, mDisplayModuleSnapshots->GetCurrentSnapshot() == 2 ? 0 : -1);
+      SetLed(kMidiMessage_Control, kClipButton, mDisplayModuleSnapshots->HasSnapshot(3) ? 127 : 8, mDisplayModuleSnapshots->GetCurrentSnapshot() == 3 ? 0 : -1);
+   }
+   else
+   {
+      SetLed(kMidiMessage_Control, kDeviceButton, 0, mAddTrackHeld && mDisplayModule != nullptr ? 8 : -1);
+      SetLed(kMidiMessage_Control, kMixButton, 0, mAddTrackHeld && mDisplayModule != nullptr ? 8 : -1);
+      SetLed(kMidiMessage_Control, kBrowseButton, 0, mAddTrackHeld && mDisplayModule != nullptr ? 8 : -1);
+      SetLed(kMidiMessage_Control, kClipButton, 0, mAddTrackHeld && mDisplayModule != nullptr ? 8 : -1);
+   }
+   SetLed(kMidiMessage_Control, kUpButton, mShiftHeld ? 0 : 127, 127);
+   SetLed(kMidiMessage_Control, kDownButton, mShiftHeld ? 0 : 127, 127);
+   SetLed(kMidiMessage_Control, kLeftButton, mShiftHeld ? 0 : 127, 127);
+   SetLed(kMidiMessage_Control, kRightButton, mShiftHeld ? 0 : 127, 127);
+   if (mHeldKnobIndex == -1)
+   {
+      SetLed(kMidiMessage_Control, kPageLeftButton, mModuleHistoryPosition > 0 ? 127 : 0);
+      SetLed(kMidiMessage_Control, kPageRightButton, mModuleHistoryPosition < mModuleHistory.size() - 1 ? 127 : 0);
+      SetLed(kMidiMessage_Control, kOctaveUpButton, 0);
+      SetLed(kMidiMessage_Control, kOctaveDownButton, 0);
+   }
+   else
+   {
+      SetLed(kMidiMessage_Control, kPageLeftButton, 32, 127);
+      SetLed(kMidiMessage_Control, kPageRightButton, 32, 127);
+      SetLed(kMidiMessage_Control, kOctaveUpButton, 32, 127);
+      SetLed(kMidiMessage_Control, kOctaveDownButton, 32, 127);
+   }
    SetLed(kMidiMessage_Control, kSetupButton, mInMidiControllerBindMode ? 127 : 32, mInMidiControllerBindMode ? 0 : 32);
    if (mGridControlModule != nullptr)
    {
@@ -488,9 +601,11 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
    {
       int color = 0;
       if (mBookmarkSlots[i] != nullptr && !mBookmarkSlots[i]->IsDeleted())
-         color = GetPadColorForType(mBookmarkSlots[i]->GetModuleCategory());
-      SetLed(kMidiMessage_Control, kQuantizeButtonSection + i, color);
+         color = GetPadColorForType(mBookmarkSlots[i]->GetModuleCategory(), mBookmarkSlots[i]->IsEnabled());
+      SetLed(kMidiMessage_Control, kQuantizeButtonSection + i, color, mDisplayModule == mBookmarkSlots[i] ? 0 : -1);
    }
+   SetLed(kMidiMessage_Control, kShiftButton, 127, mShiftHeld ? 0 : -1);
+   SetLed(kMidiMessage_Control, kSelectButton, mDisplayModule != nullptr ? 127 : 0);
 
    //test led colors
    //SetLed(kMidiMessage_Note, 92, (int)mModuleListOffset);
@@ -526,33 +641,7 @@ int Push2Control::GetSpawnGridPadColor(int index, ModuleCategory moduleType) con
    if ((index / 4) % 4 == 0 || (index / 4) % 4 == 3)
       bright = true;
 
-   int color;
-   switch (moduleType)
-   {
-      case kModuleCategory_Instrument:
-         color = bright ? 26 : 116;
-         break;
-      case kModuleCategory_Note:
-         color = bright ? 8 : 80;
-         break;
-      case kModuleCategory_Synth:
-         color = bright ? 11 : 86;
-         break;
-      case kModuleCategory_Audio:
-         color = bright ? 18 : 96;
-         break;
-      case kModuleCategory_Modulator:
-         color = bright ? 22 : 112;
-         break;
-      case kModuleCategory_Pulse:
-         color = bright ? 9 : 82;
-         break;
-      default:
-         color = bright ? 118 : 124;
-         break;
-   }
-
-   return color;
+   return GetPadColorForType(moduleType, bright);
 }
 
 void Push2Control::SetModuleGridLights()
@@ -615,8 +704,9 @@ void Push2Control::SetModuleGridLights()
          int gridX = i % 8;
          int gridY = i / 8;
          int gridIndex = gridX + (7 - gridY) * 8 + 36;
-         if (i < list->GetNumValues())
-            SetLed(kMidiMessage_Note, gridIndex, GetSpawnGridPadColor(i, GetModuleTypeForSpawnList(list)));
+         int moduleIndex = i + mModuleViewOffset * 8;
+         if (moduleIndex < list->GetNumValues())
+            SetLed(kMidiMessage_Note, gridIndex, GetSpawnGridPadColor(moduleIndex, GetModuleTypeForSpawnList(list)));
          else
             SetLed(kMidiMessage_Note, gridIndex, 0);
       }
@@ -634,10 +724,14 @@ void Push2Control::SetModuleGridLights()
          int gridIndex = gridX + (7 - gridY) * 8;
          int padNumber = 36 + i;
          if (mModuleGrid[gridIndex] != nullptr)
-            SetLed(kMidiMessage_Note, padNumber, GetPadColorForType(mModuleGrid[gridIndex]->GetModuleCategory()), mModuleGrid[gridIndex] == mDisplayModule ? 122 : -1);
+            SetLed(kMidiMessage_Note, padNumber, GetPadColorForType(mModuleGrid[gridIndex]->GetModuleCategory(), mModuleGrid[gridIndex]->IsEnabled()), mModuleGrid[gridIndex] == mDisplayModule ? 0 : -1);
          else
             SetLed(kMidiMessage_Note, padNumber, 0);
       }
+
+      //all touchstrip LEDs off
+      std::string touchStripLights = { 0x00, 0x21, 0x1D, 0x01, 0x01, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+      GetDevice()->SendSysEx(touchStripLights);
    }
 }
 
@@ -660,7 +754,7 @@ void Push2Control::DrawDisplayModuleControls()
       float x;
       float y;
       mDisplayModule->GetPosition(x, y, true);
-      mDisplayModule->SetPosition(5 - kColumnSpacing * mModuleColumnOffsetSmoothed, 15);
+      mDisplayModule->SetPosition(5 - kColumnSpacing * mModuleViewOffsetSmoothed, 15);
       float titleBarHeight;
       float highlight;
       mDisplayModule->DrawFrame(kColumnSpacing * MAX(1, MAX(mSliderControls.size(), mButtonControls.size())) - 14, 80, false, titleBarHeight, highlight);
@@ -670,14 +764,18 @@ void Push2Control::DrawDisplayModuleControls()
       ofNoFill();
 
       nvgFontSize(sVG, 16);
-      DrawControls(mButtonControls, false, 60);
-      DrawControls(mSliderControls, true, 20);
+      bool screenDrawingHandled = mDisplayModule->DrawToPush2Screen();
+      if (!screenDrawingHandled)
+      {
+         DrawControls(mButtonControls, false, 60);
+         DrawControls(mSliderControls, true, 20);
+      }
 
       int topRowLedColors[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
       for (int i = 0; i < mButtonControls.size(); ++i)
       {
-         if (i - mModuleColumnOffset >= 0 && i - mModuleColumnOffset < 8)
-            topRowLedColors[i - mModuleColumnOffset] = GetPadColorForType(mButtonControls[i]->GetModuleParent()->GetModuleCategory());
+         if (i - mModuleViewOffset >= 0 && i - mModuleViewOffset < 8)
+            topRowLedColors[i - mModuleViewOffset] = GetPadColorForType(mButtonControls[i]->GetModuleParent()->GetModuleCategory(), true);
       }
       for (int i = 0; i < 8; ++i)
          SetLed(kMidiMessage_Control, i + kAboveScreenButtonRow, topRowLedColors[i]);
@@ -711,11 +809,11 @@ void Push2Control::DrawLowerModuleSelector()
       float highlight;
       mModules[i]->DrawFrame(kColumnSpacing - 14, 80, true, titleBarHeight, highlight);
       if (mModules[i] == mDisplayModule)
-         DrawDisplayModuleRect(ofRectangle(0, 0, kColumnSpacing - 14, 80));
+         DrawDisplayModuleRect(ofRectangle(0, 0, kColumnSpacing - 14, 80), 3);
       mModules[i]->SetPosition(x, y);
 
       if (i - round(mModuleListOffset) >= 0 && i - round(mModuleListOffset) < 8)
-         bottomRowLedColors[i - (int)round(mModuleListOffset)] = GetPadColorForType(mModules[i]->GetModuleCategory());
+         bottomRowLedColors[i - (int)round(mModuleListOffset)] = GetPadColorForType(mModules[i]->GetModuleCategory(), true);
 
       ofPopMatrix();
       ofPopStyle();
@@ -725,31 +823,31 @@ void Push2Control::DrawLowerModuleSelector()
       SetLed(kMidiMessage_Control, i + kBelowScreenButtonRow, bottomRowLedColors[i]);
 }
 
-int Push2Control::GetPadColorForType(ModuleCategory type)
+int Push2Control::GetPadColorForType(ModuleCategory type, bool enabled) const
 {
    int color;
    switch (type)
    {
       case kModuleCategory_Instrument:
-         color = 26;
+         color = enabled ? 26 : 116;
          break;
       case kModuleCategory_Note:
-         color = 8;
+         color = enabled ? 8 : 80;
          break;
       case kModuleCategory_Synth:
-         color = 11;
+         color = enabled ? 11 : 86;
          break;
       case kModuleCategory_Audio:
-         color = 18;
+         color = enabled ? 18 : 96;
          break;
       case kModuleCategory_Modulator:
-         color = 22;
+         color = enabled ? 22 : 110;
          break;
       case kModuleCategory_Pulse:
-         color = 9;
+         color = enabled ? 9 : 82;
          break;
       default:
-         color = 118;
+         color = enabled ? 118 : 119;
          break;
    }
    return color;
@@ -783,14 +881,17 @@ void Push2Control::DrawControls(std::vector<IUIControl*> controls, bool sliders,
 {
    for (int i = (int)controls.size() - 1; i >= 0; --i)
    {
-      if (i - mModuleColumnOffset < -1 || i - mModuleColumnOffset > 8)
+      if (i - mModuleViewOffset < -1 || i - mModuleViewOffset > 8)
          continue;
 
       float x;
       float y;
       controls[i]->GetPosition(x, y, true);
       controls[i]->SetPosition(kColumnSpacing * i + 3, yPos);
+      ofPushMatrix();
+      ofClipWindow(kColumnSpacing * i, yPos, kColumnSpacing, 100, true);
       controls[i]->Render();
+      ofPopMatrix();
       controls[i]->SetPosition(x, y);
 
       ofPushStyle();
@@ -807,7 +908,7 @@ void Push2Control::DrawControls(std::vector<IUIControl*> controls, bool sliders,
       else
          DrawTextBold(controls[i]->Name(), kColumnSpacing * i + 3, yPos - 5, 16);
 
-      int pushControlIndex = i - mModuleColumnOffset;
+      int pushControlIndex = i - mModuleViewOffset;
       if (sliders && pushControlIndex >= 0 && pushControlIndex < 8 && mNoteHeldState[pushControlIndex])
       {
          DropdownList* dropdown = dynamic_cast<DropdownList*>(mSliderControls[i]);
@@ -850,10 +951,21 @@ void Push2Control::Poll()
 {
    if (mPendingSpawnPitch != -1)
    {
-      int gridIndex = mPendingSpawnPitch - 36;
-      int gridX = gridIndex % 8;
-      int gridY = gridIndex / 8;
-      ofVec2f newModulePos = ofVec2f(ofMap(gridX, 0, 7, mModuleGridRect.getMinX(), mModuleGridRect.getMaxX()), ofMap(gridY, 7, 0, mModuleGridRect.getMinY(), mModuleGridRect.getMaxY()));
+      int padNum = mPendingSpawnPitch - 36;
+      int gridX = padNum % 8;
+      int gridY = padNum / 8;
+      int gridIndex = gridX + (7 - gridY) * 8;
+      IDrawableModule* existingModule = mModuleGrid[gridIndex];
+      ofVec2f newModulePos;
+      if (existingModule != nullptr)
+      {
+         ofRectangle existingModuleRect = existingModule->GetRect();
+         newModulePos = ofVec2f(existingModuleRect.getMinX(), existingModuleRect.getMaxY() + 40);
+      }
+      else
+      {
+         newModulePos = ofVec2f(ofMap(gridX, 0, 7, mModuleGridRect.getMinX(), mModuleGridRect.getMaxX()), ofMap(gridY, 7, 0, mModuleGridRect.getMinY(), mModuleGridRect.getMaxY()));
+      }
 
       for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
       {
@@ -865,6 +977,22 @@ void Push2Control::Poll()
             mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
             mScreenDisplayMode = ScreenDisplayMode::kNormal;
             SetDisplayModule(module, true);
+
+            if (existingModule != nullptr && existingModule->GetPatchCableSource() != nullptr)
+            {
+               IClickable* insertTarget = existingModule->GetPatchCableSource()->GetTarget();
+
+               existingModule->GetPatchCableSource()->FindValidTargets();
+               if (existingModule->GetPatchCableSource()->IsValidTarget(module))
+                  existingModule->SetTarget(module);
+
+               if (module->GetPatchCableSource())
+               {
+                  module->GetPatchCableSource()->FindValidTargets();
+                  if (insertTarget != nullptr && module->GetPatchCableSource()->IsValidTarget(insertTarget))
+                     module->SetTarget(insertTarget);
+               }
+            }
             break;
          }
       }
@@ -916,9 +1044,22 @@ void Push2Control::SetDisplayModule(IDrawableModule* module, bool addToHistory)
       mDisplayModuleCanControlGrid = true;
    else
       mDisplayModuleCanControlGrid = false;
-   mModuleColumnOffset = 0;
-   mModuleColumnOffsetSmoothed = 0;
+   mModuleViewOffset = 0;
+   mModuleViewOffsetSmoothed = 0;
    UpdateControlList();
+
+   mDisplayModuleSnapshots = nullptr;
+   std::vector<IDrawableModule*> modules;
+   TheSynth->GetAllModules(modules);
+   for (auto* searchModule : modules)
+   {
+      Snapshots* snapshotsModule = dynamic_cast<Snapshots*>(searchModule);
+      if (snapshotsModule != nullptr)
+      {
+         if (snapshotsModule->IsTargetingModule(module))
+            mDisplayModuleSnapshots = snapshotsModule;
+      }
+   }
 
    if (module != nullptr && addToHistory)
    {
@@ -1031,9 +1172,9 @@ void Push2Control::OnMidiNote(MidiNote& note)
 
    if (note.mPitch >= 0 && note.mPitch <= 7) //main encoders
    {
-      if (mScreenDisplayMode == ScreenDisplayMode::kNormal)
+      if (mScreenDisplayMode == ScreenDisplayMode::kNormal || mScreenDisplayMode == ScreenDisplayMode::kMap)
       {
-         int controlIndex = note.mPitch + mModuleColumnOffset;
+         int controlIndex = note.mPitch + mModuleViewOffset;
          if (controlIndex < mSliderControls.size())
          {
             if (note.mVelocity > 0)
@@ -1064,6 +1205,19 @@ void Push2Control::OnMidiNote(MidiNote& note)
                {
                   sBindToUIControl = mSliderControls[controlIndex];
                }
+
+               if (mHeldModule && mAllowRepatch)
+               {
+                  PatchCableSource* cable = mHeldModule->GetPatchCableSource();
+                  if (mShiftHeld && mHeldModule->GetPatchCableSources().size() >= 2)
+                     cable = mHeldModule->GetPatchCableSources()[1];
+                  if (cable != nullptr)
+                  {
+                     cable->FindValidTargets();
+                     if (cable->IsValidTarget(mSliderControls[controlIndex]))
+                        cable->SetTarget(mSliderControls[controlIndex]);
+                  }
+               }
             }
             else
             {
@@ -1084,6 +1238,11 @@ void Push2Control::OnMidiNote(MidiNote& note)
             }
          }
       }
+
+      if (note.mVelocity > 0)
+         mHeldKnobIndex = note.mPitch;
+      else
+         mHeldKnobIndex = -1;
    }
    else if (note.mPitch >= 36 && note.mPitch <= 99 && mGridControlModule == nullptr) //pads
    {
@@ -1092,10 +1251,10 @@ void Push2Control::OnMidiNote(MidiNote& note)
          if (note.mVelocity > 0)
          {
             auto* list = mSpawnLists.GetDropdowns()[mSelectedGridSpawnListIndex]->GetList();
-            int gridIndex = note.mPitch - 36;
-            int gridX = gridIndex % 8;
-            int gridY = gridIndex / 8;
-            gridIndex = gridX + (7 - gridY) * 8;
+            int padNum = note.mPitch - 36;
+            int gridX = padNum % 8;
+            int gridY = padNum / 8;
+            int gridIndex = gridX + (7 - gridY) * 8 + mModuleViewOffset * 8;
             if (gridIndex < list->GetNumValues())
             {
                list->SetValueDirect(gridIndex, gTime);
@@ -1110,24 +1269,30 @@ void Push2Control::OnMidiNote(MidiNote& note)
       }
       else if (mGridControlModule == nullptr)
       {
+         int padNum = note.mPitch - 36;
+         int gridX = padNum % 8;
+         int gridY = padNum / 8;
+         int gridIndex = gridX + (7 - gridY) * 8;
+         if (mModuleGrid[gridIndex] != nullptr)
+         {
+            if ((!mAllowRepatch && note.mVelocity > 0) || (mAllowRepatch && note.mVelocity == 0))
+               SetDisplayModule(mModuleGrid[gridIndex], true);
+         }
+
          if (note.mVelocity > 0)
          {
-            int gridIndex = note.mPitch - 36;
-            int gridX = gridIndex % 8;
-            int gridY = gridIndex / 8;
-            gridIndex = gridX + (7 - gridY) * 8;
-            if (mModuleGrid[gridIndex] != nullptr)
-               SetDisplayModule(mModuleGrid[gridIndex], true);
-
             if (mHeldModule != nullptr)
             {
-               if (mAllowRepatch && mHeldModule->GetPatchCableSource() != nullptr)
+               PatchCableSource* cable = mHeldModule->GetPatchCableSource();
+               if (mShiftHeld && mHeldModule->GetPatchCableSources().size() >= 2)
+                  cable = mHeldModule->GetPatchCableSources()[1];
+               if (mAllowRepatch && cable != nullptr)
                {
-                  mHeldModule->GetPatchCableSource()->FindValidTargets();
-                  if (mHeldModule->GetPatchCableSource()->IsValidTarget(mModuleGrid[gridIndex]))
-                     mHeldModule->SetTarget(mModuleGrid[gridIndex]);
+                  cable->FindValidTargets();
+                  if (cable->IsValidTarget(mModuleGrid[gridIndex]))
+                     cable->SetTarget(mModuleGrid[gridIndex]);
                   else
-                     mHeldModule->GetPatchCableSource()->ClearPatchCables();
+                     cable->ClearPatchCables();
                }
             }
             else
@@ -1160,20 +1325,37 @@ void Push2Control::OnMidiControl(MidiControl& control)
 
    if (control.mControl >= 71 && control.mControl <= 78) //main encoders
    {
-      int controlIndex = control.mControl - 71 + mModuleColumnOffset;
+      int controlIndex = control.mControl - 71 + mModuleViewOffset;
       if (controlIndex < mSliderControls.size())
       {
          float currentNormalized = mSliderControls[controlIndex]->GetMidiValue();
          float increment = control.mValue < 64 ? control.mValue : control.mValue - 128;
-         increment *= .005f;
-         mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment, NextBufferTime(false), false);
+         increment *= mShiftHeld ? .0005f : .005f;
+
+         FloatSlider* floatSlider = dynamic_cast<FloatSlider*>(mSliderControls[controlIndex]);
+         if (floatSlider && floatSlider->GetModulator() && floatSlider->GetModulator()->Active() && floatSlider->GetModulator()->CanAdjustRange())
+         {
+            IModulator* modulator = floatSlider->GetModulator();
+            float min = floatSlider->GetMin();
+            float max = floatSlider->GetMax();
+            float modMin = ofMap(modulator->GetMin(), min, max, 0, 1);
+            float modMax = ofMap(modulator->GetMax(), min, max, 0, 1);
+
+            modulator->GetMin() = ofMap(modMin - increment, 0, 1, min, max, K(clamp));
+            modulator->GetMax() = ofMap(modMax + increment, 0, 1, min, max, K(clamp));
+         }
+         else
+         {
+            mSliderControls[controlIndex]->SetFromMidiCC(currentNormalized + increment, NextBufferTime(false), false);
+         }
       }
    }
    else if (control.mControl >= kAboveScreenButtonRow && control.mControl < kAboveScreenButtonRow + 8) //buttons below encoders
    {
-      int controlIndex = control.mControl - kAboveScreenButtonRow + mModuleColumnOffset;
-      if (mScreenDisplayMode == ScreenDisplayMode::kNormal)
+      int controlIndex = control.mControl - kAboveScreenButtonRow;
+      if (mScreenDisplayMode == ScreenDisplayMode::kNormal || mScreenDisplayMode == ScreenDisplayMode::kMap)
       {
+         controlIndex += mModuleViewOffset;
          if (controlIndex < mButtonControls.size())
          {
             if (control.mValue > 0)
@@ -1218,13 +1400,19 @@ void Push2Control::OnMidiControl(MidiControl& control)
 
             for (int i = 0; i < mSpawnLists.GetDropdowns().size(); ++i)
                mSpawnLists.GetDropdowns()[i]->GetList()->SetValue(-1, gTime);
+
+            mModuleViewOffset = 0;
+            mModuleViewOffsetSmoothed = 0;
          }
       }
    }
    else if (control.mControl == 14) //leftmost clicky encoder
    {
       int increment = control.mValue < 64 ? control.mValue : control.mValue - 128;
-      mModuleColumnOffset = (int)ofClamp(mModuleColumnOffset + increment, 0, MAX(0, (int)MAX(mSliderControls.size(), mButtonControls.size()) - 8));
+      if (mScreenDisplayMode == ScreenDisplayMode::kAddModule)
+         mModuleViewOffset = std::max(0, mModuleViewOffset + increment);
+      else
+         mModuleViewOffset = (int)ofClamp(mModuleViewOffset + increment, 0, MAX(0, (int)MAX(mSliderControls.size(), mButtonControls.size()) - 8));
    }
    else if (control.mControl == 15) //encoder next to above encoder
    {
@@ -1274,6 +1462,10 @@ void Push2Control::OnMidiControl(MidiControl& control)
       if (gHoveredModule != nullptr && gHoveredModule != mDisplayModule)
          SetDisplayModule(gHoveredModule, true);
    }
+   else if (control.mControl == kMetronomeButton)
+   {
+      SetDisplayModule(this, true);
+   }
    else if (control.mControl == kAddDeviceButton)
    {
       if (control.mValue > 0)
@@ -1291,11 +1483,59 @@ void Push2Control::OnMidiControl(MidiControl& control)
             mSelectedGridSpawnListIndex = -1;
          }
 
-         mModuleColumnOffset = 0;
-         mModuleColumnOffsetSmoothed = 0;
+         mModuleViewOffset = 0;
+         mModuleViewOffsetSmoothed = 0;
          mModuleListOffset = 0;
          mModuleListOffsetSmoothed = 0;
          UpdateControlList();
+      }
+   }
+   else if (control.mControl == kUserButton)
+   {
+      if (control.mValue > 0)
+      {
+         if (mScreenDisplayMode == ScreenDisplayMode::kMap)
+         {
+            mScreenDisplayMode = ScreenDisplayMode::kNormal;
+         }
+         else
+         {
+            mScreenDisplayMode = ScreenDisplayMode::kMap;
+         }
+      }
+   }
+   else if (control.mControl == kDeviceButton || control.mControl == kMixButton || control.mControl == kBrowseButton || control.mControl == kClipButton)
+   {
+      if (control.mValue > 0)
+      {
+         int index = 0;
+         if (control.mControl == kDeviceButton)
+            index = 0;
+         if (control.mControl == kMixButton)
+            index = 1;
+         if (control.mControl == kBrowseButton)
+            index = 2;
+         if (control.mControl == kClipButton)
+            index = 3;
+
+         if (mAddTrackHeld)
+         {
+            if (mDisplayModuleSnapshots == nullptr)
+            {
+               ModuleFactory::Spawnable spawnable;
+               spawnable.mLabel = "snapshots";
+               mDisplayModuleSnapshots = dynamic_cast<Snapshots*>(TheSynth->SpawnModuleOnTheFly(spawnable, mDisplayModule->GetRect().getMaxX() + 40, mDisplayModule->GetPosition().y));
+               mDisplayModuleSnapshots->AddSnapshotTarget(mDisplayModule);
+            }
+
+            if (mDisplayModuleSnapshots != nullptr)
+               mDisplayModuleSnapshots->StoreSnapshot(index);
+         }
+         else
+         {
+            if (mDisplayModuleSnapshots != nullptr)
+               mDisplayModuleSnapshots->SetSnapshot(index, gTime);
+         }
       }
    }
    else if (control.mControl == kUpButton || control.mControl == kDownButton || control.mControl == kLeftButton || control.mControl == kRightButton)
@@ -1312,7 +1552,11 @@ void Push2Control::OnMidiControl(MidiControl& control)
          if (control.mControl == kRightButton)
             direction.x += 1;
 
-         if (mDisplayModule)
+         if (mShiftHeld)
+         {
+            TheSynth->PanView(direction.x * -50, direction.y * -50);
+         }
+         else if (mDisplayModule)
          {
             ofVec2f pos = mDisplayModule->GetPosition();
             pos += direction * 50;
@@ -1320,21 +1564,42 @@ void Push2Control::OnMidiControl(MidiControl& control)
          }
       }
    }
-   else if (control.mControl == kPageLeftButton || control.mControl == kPageRightButton)
+   else if (control.mControl == kPageLeftButton ||
+            control.mControl == kPageRightButton ||
+            control.mControl == kOctaveUpButton ||
+            control.mControl == kOctaveDownButton)
    {
       if (control.mValue > 0)
       {
-         int direction = 0;
-         if (control.mControl == kPageLeftButton)
-            direction -= 1;
-         if (control.mControl == kPageRightButton)
-            direction += 1;
-
-         int newHistoryPos = mModuleHistoryPosition + direction;
-         if (newHistoryPos >= 0 && newHistoryPos < mModuleHistory.size())
+         if (mHeldKnobIndex == -1)
          {
-            mModuleHistoryPosition = newHistoryPos;
-            SetDisplayModule(mModuleHistory[mModuleHistoryPosition], false);
+            int direction = 0;
+            if (control.mControl == kPageLeftButton)
+               direction -= 1;
+            if (control.mControl == kPageRightButton)
+               direction += 1;
+
+            int newHistoryPos = mModuleHistoryPosition + direction;
+            if (newHistoryPos >= 0 && newHistoryPos < mModuleHistory.size())
+            {
+               mModuleHistoryPosition = newHistoryPos;
+               SetDisplayModule(mModuleHistory[mModuleHistoryPosition], false);
+            }
+         }
+         else
+         {
+            int controlIndex = mHeldKnobIndex + mModuleViewOffset;
+            if (controlIndex < mSliderControls.size() && (mScreenDisplayMode == ScreenDisplayMode::kNormal || mScreenDisplayMode == ScreenDisplayMode::kMap))
+            {
+               if (control.mControl == kPageRightButton)
+                  mSliderControls[controlIndex]->Increment(1);
+               if (control.mControl == kPageLeftButton)
+                  mSliderControls[controlIndex]->Increment(-1);
+               if (control.mControl == kOctaveUpButton)
+                  mSliderControls[controlIndex]->Double();
+               if (control.mControl == kOctaveDownButton)
+                  mSliderControls[controlIndex]->Halve();
+            }
          }
       }
    }
@@ -1374,6 +1639,27 @@ void Push2Control::OnMidiControl(MidiControl& control)
             SwitchToBookmarkedModule(i);
       }
    }
+   else if (control.mControl == kShiftButton)
+   {
+      mShiftHeld = control.mValue > 0;
+   }
+   else if (control.mControl == kAddTrackButton)
+   {
+      mAddTrackHeld = control.mValue > 0;
+   }
+   else if (control.mControl == kSelectButton)
+   {
+      if (control.mValue > 0 && mDisplayModule != nullptr)
+      {
+         ofRectangle rect = mDisplayModule->GetRect();
+         TheSynth->PanTo(rect.getCenter().x, rect.getCenter().y);
+      }
+   }
+   else if (control.mControl == kPlayButton)
+   {
+      if (control.mValue > 0 && mDisplayModule != nullptr)
+         mDisplayModule->SetEnabled(!mDisplayModule->IsEnabled());
+   }
    else
    {
       ofLog() << "control " << control.mControl << " " << control.mValue;
@@ -1389,7 +1675,10 @@ void Push2Control::OnMidiPitchBend(MidiPitchBend& pitchBend)
          return;
    }
 
-   ofLog() << "pitchbend " << pitchBend.mChannel << " " << pitchBend.mValue;
+   float value = pitchBend.mValue / MidiDevice::kPitchBendMax;
+   TheSynth->SetZoomLevel(pow(2, value * 2 - 1) + .1f);
+
+   //ofLog() << "pitchbend " << pitchBend.mChannel << " " << pitchBend.mValue;
 }
 
 bool Push2Control::IsIgnorableModule(IDrawableModule* module)

--- a/Source/Scale.cpp
+++ b/Source/Scale.cpp
@@ -467,6 +467,33 @@ void Scale::Poll()
       SetRandomRootAndScale();
       mWantSetRandomRootAndScale = false;
    }
+
+   if (mQueuedButtonPress)
+   {
+      ClickButton* button = mQueuedButtonPress;
+      mQueuedButtonPress = nullptr;
+      if (button == mLoadSCLButton || button == mLoadKBMButton)
+      {
+         std::string prompt = "Load ";
+         prompt += (button == mLoadSCLButton) ? "SCL" : "KBM";
+         std::string pat = (button == mLoadSCLButton) ? "*.scl;*.SCL" : "*.kbm;*.KBM";
+         juce::FileChooser chooser(prompt, juce::File(""), pat, true, false, TheSynth->GetFileChooserParent());
+         if (chooser.browseForFileToOpen())
+         {
+            auto file = chooser.getResult();
+            std::cout << file.getFullPathName().toStdString() << std::endl;
+            if (button == mLoadSCLButton)
+            {
+               mSclContents = file.loadFileAsString().toStdString();
+            }
+            else
+            {
+               mKbmContents = file.loadFileAsString().toStdString();
+            }
+            UpdateTuningTable();
+         }
+      }
+   }
 }
 
 float Scale::RationalizeNumber(float input)
@@ -722,27 +749,7 @@ void Scale::TextEntryComplete(TextEntry* entry)
 
 void Scale::ButtonClicked(ClickButton* button, double time)
 {
-   if (button == mLoadSCLButton || button == mLoadKBMButton)
-   {
-      std::string prompt = "Load ";
-      prompt += (button == mLoadSCLButton) ? "SCL" : "KBM";
-      std::string pat = (button == mLoadSCLButton) ? "*.scl;*.SCL" : "*.kbm;*.KBM";
-      juce::FileChooser chooser(prompt, juce::File(""), pat, true, false, TheSynth->GetFileChooserParent());
-      if (chooser.browseForFileToOpen())
-      {
-         auto file = chooser.getResult();
-         std::cout << file.getFullPathName().toStdString() << std::endl;
-         if (button == mLoadSCLButton)
-         {
-            mSclContents = file.loadFileAsString().toStdString();
-         }
-         else
-         {
-            mKbmContents = file.loadFileAsString().toStdString();
-         }
-         UpdateTuningTable();
-      }
-   }
+   mQueuedButtonPress = button;
 }
 
 void Scale::LoadLayout(const ofxJSONElement& moduleInfo)

--- a/Source/Scale.h
+++ b/Source/Scale.h
@@ -189,6 +189,7 @@ private:
 
    ClickButton* mLoadSCLButton{ nullptr };
    ClickButton* mLoadKBMButton{ nullptr };
+   ClickButton* mQueuedButtonPress{ nullptr };
 
    std::vector<ScaleInfo> mScales;
    int mNumSeptatonicScales{ 0 };

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -72,6 +72,18 @@ void SingleOscillator::CreateUIControls()
    IDrawableModule::CreateUIControls();
 
    float width, height;
+
+   UIBLOCK(3 + kGap + kColumnWidth, 3, kColumnWidth);
+   UICONTROL_CUSTOM(mADSRDisplay, new ADSRDisplay(UICONTROL_BASICS("env"), kColumnWidth, 36, &mVoiceParams.mAdsr));
+   FLOATSLIDER(mVolSlider, "vol", &mVoiceParams.mVol, 0, 1);
+   FLOATSLIDER_DIGITS(mDetuneSlider, "detune", &mVoiceParams.mDetune, -.05f, .05f, 3);
+   INTSLIDER(mUnisonSlider, "unison", &mVoiceParams.mUnison, 1, SingleOscillatorVoice::kMaxUnison);
+   FLOATSLIDER(mUnisonWidthSlider, "width", &mVoiceParams.mUnisonWidth, 0, 1);
+   CHECKBOX(mLiteCPUModeCheckbox, "lite cpu", &mVoiceParams.mLiteCPUMode);
+   ENDUIBLOCK(width, height);
+   mWidth = MAX(width, mWidth);
+   mHeight = MAX(height, mHeight);
+
    UIBLOCK(3, 42, kColumnWidth);
    DROPDOWN(mOscSelector, "osc", (int*)(&mVoiceParams.mOscType), kColumnWidth / 2);
    UIBLOCK_SHIFTRIGHT();
@@ -87,15 +99,6 @@ void SingleOscillator::CreateUIControls()
    FLOATSLIDER(mSyncFreqSlider, "syncf", &mVoiceParams.mSyncFreq, 10, 999.9f);
    UIBLOCK_NEWLINE();
    UIBLOCK_POPSLIDERWIDTH();
-   ENDUIBLOCK(mWidth, mHeight);
-
-   UIBLOCK(3 + kGap + kColumnWidth, 3, kColumnWidth);
-   UICONTROL_CUSTOM(mADSRDisplay, new ADSRDisplay(UICONTROL_BASICS("env"), kColumnWidth, 36, &mVoiceParams.mAdsr));
-   FLOATSLIDER(mVolSlider, "vol", &mVoiceParams.mVol, 0, 1);
-   FLOATSLIDER_DIGITS(mDetuneSlider, "detune", &mVoiceParams.mDetune, -.05f, .05f, 3);
-   INTSLIDER(mUnisonSlider, "unison", &mVoiceParams.mUnison, 1, SingleOscillatorVoice::kMaxUnison);
-   FLOATSLIDER(mUnisonWidthSlider, "width", &mVoiceParams.mUnisonWidth, 0, 1);
-   CHECKBOX(mLiteCPUModeCheckbox, "lite cpu", &mVoiceParams.mLiteCPUMode);
    ENDUIBLOCK(width, height);
    mWidth = MAX(width, mWidth);
    mHeight = MAX(height, mHeight);

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -57,6 +57,14 @@ public:
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
 
+   bool HasSnapshot(int index) const;
+   int GetCurrentSnapshot() const { return mCurrentSnapshot; }
+   bool IsTargetingModule(IDrawableModule* module) const;
+   void AddSnapshotTarget(IDrawableModule* target);
+   void SetSnapshot(int idx, double time);
+   void StoreSnapshot(int idx);
+   void DeleteSnapshot(int idx);
+
    void OnTransportAdvanced(float amount) override;
 
    //INoteReceiver
@@ -87,9 +95,6 @@ public:
    bool IsEnabled() const override { return true; }
 
 private:
-   void SetSnapshot(int idx, double time);
-   void Store(int idx);
-   void Delete(int idx);
    void UpdateGridValues();
    void SetGridSize(float w, float h);
    bool IsConnectedToPath(std::string path) const;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -988,7 +988,7 @@ void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal, double time)
             mPlugin->setCurrentProgramStateInformation(vstProgramState, vstProgramStateSize);
          }
 
-         if (rev >= 2)
+         if (rev >= 2 && mModuleSaveData.GetBool("preset_file_sets_params"))
          {
             int numParamsShowing = input->readInt();
             for (auto& param : mParameterSliders)
@@ -1161,6 +1161,8 @@ void VSTPlugin::LoadLayout(const ofxJSONElement& moduleInfo)
    mModuleSaveData.LoadBool("usevoiceaschannel", moduleInfo, false);
    mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 1, 96, K(isTextField));
    mModuleSaveData.LoadInt("modwheelcc(1or74)", moduleInfo, 1, 0, 127, K(isTextField));
+
+   mModuleSaveData.LoadBool("preset_file_sets_params", moduleInfo, true);
 
    if (!moduleInfo["vst"].isNull())
       mOldVstPath = moduleInfo["vst"].asString();


### PR DESCRIPTION
push2control features:
- added notesequencer editing/performance interface
- added drumplayer interface
- added notetable interface
- improved drumsequencer interface
- improved LFO editing
- added canvas panning and zooming
- added drawing canvas on push2 display
- added ability to save/recall snapshots of current module
- made push2control clean up appropriately when deleted
- added ability to scroll module spawner grid
- added dedicated module enable/disable button
- added controls to increment/decrement/double/halve touched slider
- update grid lights to show module enabled/disabled state
- added ability to auto-patch spawned modules
- added ability to hold shift to fine-tune knob

other features:
- added polyphony to notetable
- fixed crash when clicking scale's "load SCL" or "load KBM" buttons via a midi controller
- added option to keep VST preset from resetting exposed param sliders