### PR TITLE
Allow the scrollwheel to adjust the Q slider while hovering over a dot in the `eq` module.

### DIFF
--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -394,6 +394,25 @@ bool EQModule::MouseMoved(float x, float y)
    return false;
 }
 
+bool EQModule::MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll)
+{
+   if (mHoveredFilterHandleIndex != -1)
+   {
+      float add = scrollY;
+      if (GetKeyModifiers() & kModifier_Command)
+      {
+         add /= 10;
+      }
+      else if (GetKeyModifiers() & kModifier_Shift)
+      {
+         add *= 10;
+      }
+      auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;
+      qSlider->SetValue(ofClamp(qSlider->GetValue() + add, qSlider->GetMin(), qSlider->GetMax()), NextBufferTime(false));
+   }
+   return false;
+}
+
 void EQModule::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (auto& filter : mFilters)

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -399,7 +399,7 @@ bool EQModule::MouseScrolled(float x, float y, float scrollX, float scrollY, boo
    if (mHoveredFilterHandleIndex != -1)
    {
       auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;
-      float add = (2 * scrollY) / MAX(qSlider->GetMax() / qSlider->GetValue(), 0.1);
+      float add = (2 * scrollY) / MAX(qSlider->GetModulatorMax() / qSlider->GetValue(), 0.1);
       if (GetKeyModifiers() & kModifier_Command)
       {
          add *= 4;

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -413,6 +413,30 @@ bool EQModule::MouseScrolled(float x, float y, float scrollX, float scrollY, boo
    return false;
 }
 
+void EQModule::KeyPressed(int key, bool isRepeat)
+{
+   if (mHoveredFilterHandleIndex != -1)
+   {
+      auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;
+      if (key == '\\')
+      {
+         qSlider->ResetToOriginal();
+      }
+      else if (key == '[')
+      {
+         qSlider->Halve();
+      }
+      else if (key == ']')
+      {
+         qSlider->Double();
+      }
+      else if ((toupper(key) == 'C' || toupper(key) == 'X') && GetKeyModifiers() == kModifier_Command)
+      {
+         TheSynth->CopyTextToClipboard(ofToString(qSlider->GetValue()));
+      }
+   }
+}
+
 void EQModule::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)
 {
    for (auto& filter : mFilters)

--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -398,16 +398,16 @@ bool EQModule::MouseScrolled(float x, float y, float scrollX, float scrollY, boo
 {
    if (mHoveredFilterHandleIndex != -1)
    {
-      float add = scrollY;
+      auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;
+      float add = (2 * scrollY) / MAX(qSlider->GetMax() / qSlider->GetValue(), 0.1);
       if (GetKeyModifiers() & kModifier_Command)
       {
-         add /= 10;
+         add *= 4;
       }
       else if (GetKeyModifiers() & kModifier_Shift)
       {
-         add *= 10;
+         add /= 10;
       }
-      auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;
       qSlider->SetValue(ofClamp(qSlider->GetValue() + add, qSlider->GetMin(), qSlider->GetMax()), NextBufferTime(false));
    }
    return false;

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -71,6 +71,7 @@ private:
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
    bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
+   void KeyPressed(int key, bool isRepeat) override;
    void MouseReleased() override;
 
    static const int kNumFFTBins = 1024 * 8;

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -70,6 +70,7 @@ private:
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
+   bool MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll) override;
    void MouseReleased() override;
 
    static const int kNumFFTBins = 1024 * 8;


### PR DESCRIPTION
You can also adjust the increment by holding shift or control/command for faster and slower respectively.