### PR TITLE
push2 features and other fixes

### DIFF
--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -49,10 +49,10 @@ ADSRDisplay::ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y,
    if (floatListener)
    {
       int sliderHeight = h / 4;
-      mASlider = new FloatSlider(floatListener, (std::string(name) + "A").c_str(), x, y, w, sliderHeight, &(mAdsr->GetA()), 0, 1000);
-      mDSlider = new FloatSlider(floatListener, (std::string(name) + "D").c_str(), x, y + sliderHeight, w, sliderHeight, &(mAdsr->GetD()), 0, 1000);
+      mASlider = new FloatSlider(floatListener, (std::string(name) + "A").c_str(), x, y, w, sliderHeight, &(mAdsr->GetA()), 0.001f, 1000);
+      mDSlider = new FloatSlider(floatListener, (std::string(name) + "D").c_str(), x, y + sliderHeight, w, sliderHeight, &(mAdsr->GetD()), 0.001f, 1000);
       mSSlider = new FloatSlider(floatListener, (std::string(name) + "S").c_str(), x, y + sliderHeight * 2, w, sliderHeight, &(mAdsr->GetS()), 0, 1);
-      mRSlider = new FloatSlider(floatListener, (std::string(name) + "R").c_str(), x, y + sliderHeight * 3, w, sliderHeight, &(mAdsr->GetR()), 0, 1000);
+      mRSlider = new FloatSlider(floatListener, (std::string(name) + "R").c_str(), x, y + sliderHeight * 3, w, sliderHeight, &(mAdsr->GetR()), 0.001f, 1000);
 
       mASlider->SetMode(FloatSlider::kSquare);
       mDSlider->SetMode(FloatSlider::kSquare);

--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -61,6 +61,10 @@ public:
       IUIControl::SetShowing(showing);
       UpdateSliderVisibility();
    }
+   FloatSlider* GetASlider() { return mASlider; }
+   FloatSlider* GetDSlider() { return mDSlider; }
+   FloatSlider* GetSSlider() { return mSSlider; }
+   FloatSlider* GetRSlider() { return mRSlider; }
 
    //IUIControl
    void SetFromMidiCC(float slider, double time, bool setViaModulator) override {}

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -558,6 +558,10 @@ void Canvas::KeyPressed(int key, bool isRepeat)
       if (key == OF_KEY_UP || key == OF_KEY_DOWN)
       {
          int direction = (key == OF_KEY_UP) ? -1 : 1;
+
+         if (GetKeyModifiers() == kModifier_Shift)
+            direction *= 12; //octave
+
          for (auto* element : mElements)
          {
             if (element->GetHighlighted())

--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -84,7 +84,7 @@ void CanvasElement::DrawElement(bool clamp, bool wrapped, ofVec2f offset)
    DrawContents(clamp, wrapped, offset);
    ofPopStyle();
 
-   if (mHighlighted)
+   if (mHighlighted && mCanvas == gHoveredUIControl)
    {
       ofPushStyle();
       ofNoFill();

--- a/Source/ClipLauncher.cpp
+++ b/Source/ClipLauncher.cpp
@@ -190,7 +190,7 @@ void ClipLauncher::CheckboxUpdated(Checkbox* checkbox, double time)
 
             int bufferSize;
             mSamples[i].mSample->Create(mLooper->GetLoopBuffer(bufferSize));
-            mSamples[i].mNumBars = mLooper->NumBars();
+            mSamples[i].mNumBars = mLooper->GetNumBars();
             mLooper->Clear();
 
             if (mSamples[i].mPlay)

--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -531,7 +531,23 @@ bool DrumPlayer::OnPush2Control(Push2Control* push2, MidiMessageType type, int c
          int y = gridIndex / 8;
 
          if (x < 4 && y < 4)
+         {
             OnGridButton(x, 3 - y, midiValue / 127.0f, nullptr);
+         }
+         else if (x < 4 && midiValue > 0)
+         {
+            int index = x + (y - 4) * 4;
+            if (index == mPush2SelectedHitIdx)
+            {
+               mPush2SelectedHitIdx = -1;
+            }
+            else
+            {
+               mPush2SelectedHitIdx = index;
+               mSelectedHitIdx = index;
+               UpdateVisibleControls();
+            }
+         }
 
          return true;
       }
@@ -546,7 +562,8 @@ void DrumPlayer::UpdatePush2Leds(Push2Control* push2)
    {
       for (int y = 0; y < 8; ++y)
       {
-         int pushColor;
+         int pushColor = 0;
+         int pushColorBlink = -1;
 
          if (x < 4 && y < 4)
          {
@@ -558,13 +575,50 @@ void DrumPlayer::UpdatePush2Leds(Push2Control* push2)
             else
                pushColor = 1;
          }
-         else
+         else if (x < 4)
          {
-            pushColor = 0;
+            int index = x + (y - 4) * 4;
+            if (index == mPush2SelectedHitIdx)
+            {
+               pushColor = 126;
+               pushColorBlink = 86;
+            }
+            else
+            {
+               pushColor = 86;
+            }
          }
 
-         push2->SetLed(kMidiMessage_Note, x + y * 8 + 36, pushColor);
+         push2->SetLed(kMidiMessage_Note, x + y * 8 + 36, pushColor, pushColorBlink);
       }
+   }
+}
+
+void DrumPlayer::GetPush2OverrideControls(std::vector<IUIControl*>& controls) const
+{
+   if (mPush2SelectedHitIdx != -1)
+   {
+      int i = mPush2SelectedHitIdx;
+      controls.push_back(mDrumHits[i].mVolSlider);
+      controls.push_back(mDrumHits[i].mSpeedSlider);
+      if (mDrumHits[i].mUseEnvelope)
+      {
+         controls.push_back(mDrumHits[i].mEnvelopeDisplay);
+         controls.push_back(mDrumHits[i].mEnvelopeDisplay->GetASlider());
+         controls.push_back(mDrumHits[i].mEnvelopeDisplay->GetDSlider());
+         controls.push_back(mDrumHits[i].mEnvelopeDisplay->GetSSlider());
+         controls.push_back(mDrumHits[i].mEnvelopeDisplay->GetRSlider());
+      }
+      controls.push_back(mDrumHits[i].mTestButton);
+      controls.push_back(mDrumHits[i].mPrevButton);
+      controls.push_back(mDrumHits[i].mNextButton);
+      controls.push_back(mDrumHits[i].mRandomButton);
+      controls.push_back(mDrumHits[i].mUseEnvelopeCheckbox);
+      controls.push_back(mDrumHits[i].mPanSlider);
+      controls.push_back(mDrumHits[i].mWidenSlider);
+      controls.push_back(mDrumHits[i].mLinkIdSlider);
+      controls.push_back(mDrumHits[i].mHitCategoryDropdown);
+      controls.push_back(mDrumHits[i].mStartOffsetSlider);
    }
 }
 

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -93,6 +93,8 @@ public:
    //IPush2GridController
    bool OnPush2Control(Push2Control* push2, MidiMessageType type, int controlIndex, float midiValue) override;
    void UpdatePush2Leds(Push2Control* push2) override;
+   bool HasPush2OverrideControls() const override { return mPush2SelectedHitIdx != -1; }
+   void GetPush2OverrideControls(std::vector<IUIControl*>& controls) const override;
 
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
    void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
@@ -174,6 +176,7 @@ private:
    DropdownList* mQuantizeIntervalSelector{ nullptr };
    bool mFullVelocity{ false };
    Checkbox* mFullVelocityCheckbox{ nullptr };
+   int mPush2SelectedHitIdx{ -1 };
 
    void LoadSampleLock();
    void LoadSampleUnlock();

--- a/Source/LoopStorer.cpp
+++ b/Source/LoopStorer.cpp
@@ -91,7 +91,7 @@ void LoopStorer::Poll()
       mSwapMutex.lock();
       int loopLength;
       mSamples[mCurrentBufferIdx]->mBuffer = mLooper->GetLoopBuffer(loopLength);
-      mSamples[mCurrentBufferIdx]->mNumBars = mLooper->NumBars();
+      mSamples[mCurrentBufferIdx]->mNumBars = mLooper->GetNumBars();
       mSamples[mCurrentBufferIdx]->mBufferLength = loopLength;
       mSwapMutex.unlock();
    }
@@ -293,7 +293,7 @@ void LoopStorer::LoadState(FileStreamIn& in, int rev)
 
       int loopLength;
       mSamples[mCurrentBufferIdx]->mBuffer = mLooper->GetLoopBuffer(loopLength);
-      mSamples[mCurrentBufferIdx]->mNumBars = mLooper->NumBars();
+      mSamples[mCurrentBufferIdx]->mNumBars = mLooper->GetNumBars();
       mSamples[mCurrentBufferIdx]->mBufferLength = loopLength;
    }
 
@@ -344,7 +344,7 @@ void LoopStorer::SampleData::Init(LoopStorer* storer, int index)
       if (looper)
       {
          mBuffer = looper->GetLoopBuffer(mBufferLength);
-         mNumBars = looper->NumBars();
+         mNumBars = looper->GetNumBars();
       }
       mIsCurrentBuffer = true;
    }

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -65,7 +65,7 @@ public:
    void Commit(RollingBuffer* commitBuffer = nullptr);
    void Fill(ChannelBuffer* buffer, int length);
    void ResampleForSpeed(float speed);
-   int NumBars() const { return mNumBars; }
+   int GetNumBars() const { return mNumBars; }
    int GetRecorderNumBars() const;
    void SetNumBars(int numBars);
    void RecalcLoopLength() { UpdateNumBars(mNumBars); }
@@ -98,6 +98,7 @@ public:
 
    //IDrawableModule
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
+   bool DrawToPush2Screen() override;
 
    void MergeIn(Looper* otherLooper);
    void SwapBuffers(Looper* otherLooper);
@@ -150,11 +151,6 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
-
-   static const int BUFFER_X = 3;
-   static const int BUFFER_Y = 3;
-   static const int BUFFER_W = 170;
-   static const int BUFFER_H = 93;
 
    ChannelBuffer* mBuffer{ nullptr };
    ChannelBuffer mWorkBuffer;

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -187,7 +187,7 @@ void LooperRecorder::Process(double time)
 
    if (loop)
    {
-      int delaySamps = TheTransport->GetDuration(kInterval_1n) * NumBars() / gInvSampleRateMs;
+      int delaySamps = TheTransport->GetDuration(kInterval_1n) * GetNumBars() / gInvSampleRateMs;
       delaySamps = MIN(delaySamps, MAX_BUFFER_SIZE - 1);
       for (int i = 0; i < bufferSize; ++i)
       {

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -56,7 +56,7 @@ public:
 
    void Init() override;
    void SetNumBars(int numBars) { mNumBars = numBars; }
-   int NumBars() { return mNumBars; }
+   int GetNumBars() const { return mNumBars; }
    void Commit(Looper* looper);
    void RequestMerge(Looper* looper);
    void RequestSwap(Looper* looper);

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -134,39 +134,6 @@ void NoteCanvas::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mo
 void NoteCanvas::KeyPressed(int key, bool isRepeat)
 {
    IDrawableModule::KeyPressed(key, isRepeat);
-
-   if (TheSynth->GetLastClickedModule() == this)
-   {
-      if (key == OF_KEY_UP || key == OF_KEY_DOWN || key == OF_KEY_RIGHT || key == OF_KEY_LEFT)
-      {
-         int directionUpDown = 0;
-         int directionLeftRight = 0;
-         if (key == OF_KEY_UP)
-            directionUpDown = -1;
-         if (key == OF_KEY_DOWN)
-            directionUpDown = 1;
-         if (key == OF_KEY_LEFT)
-            directionLeftRight = -1;
-         if (key == OF_KEY_RIGHT)
-            directionLeftRight = 1;
-
-         if (GetKeyModifiers() == kModifier_Shift)
-            directionUpDown *= 12; //octave
-
-         for (auto element : mCanvas->GetElements())
-         {
-            if (element->GetHighlighted())
-            {
-               element->mRow = ofClamp(element->mRow + directionUpDown, 0, 127);
-               element->mCol = ofClamp(element->mCol + directionLeftRight, 0, mCanvas->GetNumCols() - 1);
-            }
-         }
-      }
-      else
-      {
-         mCanvas->KeyPressed(key, isRepeat);
-      }
-   }
 }
 
 bool NoteCanvas::FreeRecordParityMatched()

--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -108,6 +108,22 @@ void NoteLooper::DrawModule()
    mCanvas->Draw();
 }
 
+bool NoteLooper::DrawToPush2Screen()
+{
+   ofRectangle rect = mCanvas->GetRect(true);
+
+   mCanvas->SetPosition(125, 3);
+   mCanvas->SetDimensions(600, 40);
+
+   mCanvas->SetCursorPos(GetCurPos(gTime));
+   mCanvas->Draw();
+
+   mCanvas->SetPosition(rect.x, rect.y);
+   mCanvas->SetDimensions(rect.width, rect.height);
+
+   return false;
+}
+
 void NoteLooper::Resize(float w, float h)
 {
    mWidth = MAX(w, 370);

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -53,6 +53,10 @@ public:
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    bool IsResizable() const override { return true; }
    void Resize(float w, float h) override;
+   bool DrawToPush2Screen() override;
+
+   int GetNumMeasures() const { return mNumMeasures; }
+   void SetNumMeasures(int numMeasures);
 
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
@@ -81,7 +85,6 @@ public:
 private:
    double GetCurPos(double time) const;
    NoteCanvasElement* AddNote(double measurePos, int pitch, int velocity, double length, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters());
-   void SetNumMeasures(int numMeasures);
    int GetNewVoice(int voiceIdx);
 
    //IDrawableModule

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -140,6 +140,7 @@ private:
    std::vector<IUIControl*> mSliderControls;
    std::vector<IUIControl*> mButtonControls;
    std::vector<IUIControl*> mDisplayedControls;
+   bool mDisplayModuleIsShowingOverrideControls{ false };
    int mModuleViewOffset{ 0 };
    float mModuleViewOffsetSmoothed{ 0 };
 
@@ -166,6 +167,10 @@ private:
    bool mShiftHeld{ false };
    bool mAddTrackHeld{ false };
    int mHeldKnobIndex{ -1 };
+   double mLastResetTime{ -1 };
+   int mHeldModulePatchCableIndex{ 0 };
+   std::string mTextPopup;
+   double mTextPopupTime{ -1 };
 
    struct Routing
    {

--- a/Source/Rewriter.cpp
+++ b/Source/Rewriter.cpp
@@ -124,9 +124,9 @@ void Rewriter::DrawModule()
 
    if (mConnectedLooper)
    {
-      int loopSamples = abs(int(TheTransport->MsPerBar() / 1000 * gSampleRate)) * mConnectedLooper->NumBars();
+      int loopSamples = abs(int(TheTransport->MsPerBar() / 1000 * gSampleRate)) * mConnectedLooper->GetNumBars();
       ofRectangle rect(3, mHeight - kBufferHeight - 3, mWidth - 6, kBufferHeight);
-      float playhead = fmod(TheTransport->GetMeasureTime(gTime), mConnectedLooper->NumBars()) / mConnectedLooper->NumBars();
+      float playhead = fmod(TheTransport->GetMeasureTime(gTime), mConnectedLooper->GetNumBars()) / mConnectedLooper->GetNumBars();
       //mRecordBuffer.Draw(rect.x, rect.y, rect.width, rect.height, loopSamples, L(channel,0), loopSamples * playhead);
       //mRecordBuffer.Draw(rect.x, rect.y, rect.width * playhead, rect.height, loopSamples * playhead, L(channel, 0));
 


### PR DESCRIPTION
-add ability to quickly spawn connected looper or notelooper from push2
-add notelooper push2 interface
-add drumplayer slot editing on push2
-change push2 interface to select output cable
-allow module insertion into chain via push2 by holding shift while patching
-after resetting parameter via push2, add cooldown to not accept change for the next second, to avoid accidentally changing the value you were trying to reset
-remove 0 from ADSR sliders to avoid the ability to cause NaNs
-fix notecanvas arrows causing notes to double-move