### PR TITLE
Clean up data when removing a mapping in the macroslider. Resolves: #1323.

### DIFF
--- a/Source/MacroSlider.cpp
+++ b/Source/MacroSlider.cpp
@@ -116,6 +116,11 @@ MacroSlider::Mapping::Mapping(MacroSlider* owner, int index)
 
 MacroSlider::Mapping::~Mapping()
 {
+   mOwner->GetOwningContainer()->DeleteCablesForControl(mMinSlider);
+   mOwner->GetOwningContainer()->DeleteCablesForControl(mMaxSlider);
+   mOwner->RemoveUIControl(mMinSlider);
+   mOwner->RemoveUIControl(mMaxSlider);
+   mTargetCable->ClearPatchCables();
    mOwner->RemovePatchCableSource(mTargetCable);
 }
 

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -393,6 +393,30 @@ void ModuleContainer::DeleteModule(IDrawableModule* module, bool fail /*= true*/
    TheSynth->OnModuleDeleted(module);
 }
 
+void ModuleContainer::DeleteCablesForControl(const IUIControl* control)
+{
+   // Remove all cables that targetted control on this module
+   std::vector<IDrawableModule*> modules;
+   TheSynth->GetAllModules(modules);
+   std::vector<PatchCable*> cablesToDestroy;
+   for (const auto module_iter : modules)
+   {
+      for (const auto source : module_iter->GetPatchCableSources())
+      {
+         for (const auto cable : source->GetPatchCables())
+         {
+            if (cable->GetTarget() == control)
+            {
+               cablesToDestroy.push_back(cable);
+               break;
+            }
+         }
+      }
+   }
+   for (const auto cable : cablesToDestroy)
+      cable->Destroy(false);
+}
+
 IDrawableModule* ModuleContainer::FindModule(std::string name, bool fail)
 {
    /*string ownerPath = "";

--- a/Source/ModuleContainer.h
+++ b/Source/ModuleContainer.h
@@ -65,6 +65,7 @@ public:
    void AddModule(IDrawableModule* module);
    void TakeModule(IDrawableModule* module);
    void DeleteModule(IDrawableModule* module, bool fail = true);
+   static void DeleteCablesForControl(const IUIControl* control);
    IDrawableModule* FindModule(std::string name, bool fail = true);
    IUIControl* FindUIControl(std::string path);
    bool IsHigherThan(IDrawableModule* checkFor, IDrawableModule* checkAgainst) const;


### PR DESCRIPTION
Clean up data when removing a mapping in the macroslider. Resolves: #1323.