### PR TITLE
Add a setting that allows changing the behavior of pasting onto UI controls.

### DIFF
--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -29,6 +29,7 @@
 #include "SynthGlobals.h"
 #include "IDrawableModule.h"
 #include "FileStream.h"
+#include "UserPrefs.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -426,7 +427,10 @@ void TextEntry::OnKeyPressed(int key, bool isRepeat)
 
       std::string newString = mString;
       strcpy(mString, (newString.substr(0, mCaretPosition) + clipboard.toStdString() + newString.substr(mCaretPosition)).c_str());
-      MoveCaret(mCaretPosition + clipboard.length());
+      if (UserPrefs.immediate_paste.Get())
+         AcceptEntry(true);
+      else
+         MoveCaret(mCaretPosition + clipboard.length());
    }
    else if ((toupper(key) == 'C' || toupper(key) == 'X') && GetKeyModifiers() == kModifier_Command)
    {

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -310,6 +310,7 @@ public:
    UserPrefBool autosave{ "autosave", false, UserPrefCategory::General };
    UserPrefBool show_tooltips_on_load{ "show_tooltips_on_load", true, UserPrefCategory::General };
    UserPrefBool show_minimap{ "show_minimap", false, UserPrefCategory::General };
+   UserPrefBool immediate_paste{ "immediate_paste", false, UserPrefCategory::General };
    UserPrefTextEntryFloat record_buffer_length_minutes{ "record_buffer_length_minutes", 30, 1, 120, 5, UserPrefCategory::General };
 #if !BESPOKE_LINUX
    UserPrefBool vst_always_on_top{ "vst_always_on_top", true, UserPrefCategory::General };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1962,7 +1962,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~autosave~should autosave be enabled on startup
 ~show_tooltips_on_load~should tooltips be enabled on startup
 ~show_minimap~should the minimap be displayed (requires restart)
-~immediate_paste~When this is enabled pasting values on UI controls will apply immediately instead of requiring you to press enter
+~immediate_paste~when enabled, pasting values on UI controls will apply immediately instead of requiring you to press enter
 ~record_buffer_length_minutes~length of always-on recording buffer for "write audio" button in the title bar (requires restart)
 ~vst_always_on_top~should plugin windows always stay on top of bespoke when opened
 ~max_output_channels~number of output channels to allocate (requires restart)

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1962,6 +1962,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~autosave~should autosave be enabled on startup
 ~show_tooltips_on_load~should tooltips be enabled on startup
 ~show_minimap~should the minimap be displayed (requires restart)
+~immediate_paste~When this is enabled pasting values on UI controls will apply immediately instead of requiring you to press enter
 ~record_buffer_length_minutes~length of always-on recording buffer for "write audio" button in the title bar (requires restart)
 ~vst_always_on_top~should plugin windows always stay on top of bespoke when opened
 ~max_output_channels~number of output channels to allocate (requires restart)


### PR DESCRIPTION
Add a setting that allows changing the behavior of pasting onto UI controls.

I left it default off to preserve the existing behavior as default but I find the immediate paste mode far more natural.