### PR TITLE
fix crash on load caused by effectchains with deleted prior effects of the same type

### DIFF
--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -66,7 +66,7 @@ void EffectChain::Init()
    mInitialized = true;
 }
 
-void EffectChain::AddEffect(std::string type, bool onTheFly /*=false*/)
+void EffectChain::AddEffect(std::string type, std::string desiredName, bool onTheFly)
 {
    if (mEffects.size() >= MAX_EFFECTS_IN_CHAIN)
       return;
@@ -78,7 +78,7 @@ void EffectChain::AddEffect(std::string type, bool onTheFly /*=false*/)
    std::vector<std::string> otherEffectNames;
    for (auto* e : mEffects)
       otherEffectNames.push_back(e->Name());
-   std::string name = GetUniqueName(type, otherEffectNames);
+   std::string name = GetUniqueName(desiredName, otherEffectNames);
    effect->SetName(name.c_str());
    effect->SetTypeName(type, kModuleCategory_Processor);
    effect->SetParent(this);
@@ -473,7 +473,7 @@ void EffectChain::ButtonClicked(ClickButton* button, double time)
    {
       if (mSpawnIndex >= 0 && mSpawnIndex < (int)mEffectTypesToSpawn.size())
       {
-         AddEffect(mEffectTypesToSpawn[mSpawnIndex], K(onTheFly));
+         AddEffect(mEffectTypesToSpawn[mSpawnIndex], mEffectTypesToSpawn[mSpawnIndex], K(onTheFly));
          mSpawnIndex = -1;
       }
    }
@@ -512,7 +512,7 @@ void EffectChain::DropdownUpdated(DropdownList* list, int oldVal, double time)
    {
       if (TheSynth->GetTopModalFocusItem() == mEffectSpawnList->GetModalDropdown())
       {
-         AddEffect(mEffectTypesToSpawn[mSpawnIndex], K(onTheFly));
+         AddEffect(mEffectTypesToSpawn[mSpawnIndex], mEffectTypesToSpawn[mSpawnIndex], K(onTheFly));
          mSpawnIndex = -1;
       }
    }
@@ -544,7 +544,7 @@ void EffectChain::LoadBasics(const ofxJSONElement& moduleInfo, std::string typeN
       try
       {
          std::string type = effects[i]["type"].asString();
-         AddEffect(type);
+         AddEffect(type, effects[i]["name"].asString(), !K(onTheFly));
       }
       catch (Json::LogicError& e)
       {

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -54,7 +54,7 @@ public:
 
    void Init() override;
    void Poll() override;
-   void AddEffect(std::string type, bool onTheFly = false);
+   void AddEffect(std::string type, std::string desiredName, bool onTheFly);
    void SetWideCount(int count) { mNumFXWide = count; }
 
    //IAudioSource

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -415,7 +415,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button, double time)
             EffectChain* effectChain = dynamic_cast<EffectChain*>(topLevelModule);
             std::vector<std::string> effects = TheSynth->GetEffectFactory()->GetSpawnableEffects();
             for (std::string effect : effects)
-               effectChain->AddEffect(effect);
+               effectChain->AddEffect(effect, effect, !K(onTheFly));
          }
 
          std::vector<IDrawableModule*> toDump;

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -704,14 +704,15 @@ IUIControl* IDrawableModule::FindUIControl(const char* name, bool fail /*=true*/
    return nullptr;
 }
 
-IDrawableModule* IDrawableModule::FindChild(const char* name) const
+IDrawableModule* IDrawableModule::FindChild(const char* name, bool fail) const
 {
    for (int i = 0; i < mChildren.size(); ++i)
    {
       if (strcmp(mChildren[i]->Name(), name) == 0)
          return mChildren[i];
    }
-   throw UnknownModuleException(name);
+   if (fail)
+      throw UnknownModuleException(name);
    return nullptr;
 }
 
@@ -1277,7 +1278,7 @@ void IDrawableModule::LoadState(FileStreamIn& in, int rev)
          std::string childName;
          in >> childName;
          //ofLog() << "Loading " << childName;
-         IDrawableModule* child = FindChild(childName.c_str());
+         IDrawableModule* child = FindChild(childName.c_str(), true);
          LoadStateValidate(child);
          child->LoadState(in, child->LoadModuleSaveStateRev(in));
       }

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -102,7 +102,7 @@ public:
    virtual void OnUIControlRequested(const char* name) {}
    void AddChild(IDrawableModule* child);
    void RemoveChild(IDrawableModule* child);
-   IDrawableModule* FindChild(const char* name) const;
+   IDrawableModule* FindChild(const char* name, bool fail) const;
    void GetDimensions(float& width, float& height) override;
    virtual void GetModuleDimensions(float& width, float& height)
    {

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -3180,7 +3180,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(ModuleFactory::Spawnable spaw
    {
       EffectChain* effectChain = dynamic_cast<EffectChain*>(module);
       if (effectChain != nullptr)
-         effectChain->AddEffect(spawnable.mLabel, K(onTheFly));
+         effectChain->AddEffect(spawnable.mLabel, spawnable.mLabel, K(onTheFly));
    }
 
    if (spawnable.mSpawnMethod == ModuleFactory::SpawnMethod::Prefab)

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -448,7 +448,7 @@ IDrawableModule* ModuleContainer::FindModule(std::string name, bool fail)
          IDrawableModule* child = nullptr;
          try
          {
-            child = mModules[i]->FindChild(tokens[1].c_str());
+            child = mModules[i]->FindChild(tokens[1].c_str(), fail);
          }
          catch (UnknownModuleException& e)
          {


### PR DESCRIPTION
when adding effects to an effect chain, numbers are automatically appended to avoid collisions (like, if you spawn a granulator in an effectchain, it will be called "granulator", and if you spawn another, it will be called "granulator2"). the effect names were not being loaded in properly, so if you deleted the first granulator, you'd just be left with "granulator2", but on load it would automatically name it "granulator", and all references to "granulator2" would be busted, causing a crash on load. fixes #1354