### PR TITLE
fix issue where BSK files with effectchains saved prior to the 207c4ba8b8968437dcaa12a4736d766ed7ae1714 (2022/11/25) build would not load

### DIFF
--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -544,7 +544,12 @@ void EffectChain::LoadBasics(const ofxJSONElement& moduleInfo, std::string typeN
       try
       {
          std::string type = effects[i]["type"].asString();
-         AddEffect(type, effects[i]["name"].asString(), !K(onTheFly));
+         std::string name;
+         if (effects[i]["name"].isNull()) //old version before name was saved
+            name = type;
+         else
+            name = effects[i]["name"].asString();
+         AddEffect(type, name, !K(onTheFly));
       }
       catch (Json::LogicError& e)
       {


### PR DESCRIPTION
this includes a lot of the included bespoke example patches