### PR TITLE
Allow to devendor abletonlink on systems that provide it system-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(BESPOKE_DEVENDORED_SYSTEM_JUCE "Use system libraries when using system in
 option(BESPOKE_SYSTEM_PYBIND11 "Use a system installation of pybind11" OFF)
 option(BESPOKE_SYSTEM_JSONCPP "Use system-wide installation of jsoncpp" OFF)
 option(BESPOKE_SYSTEM_TUNING_LIBRARY "Use system installation of tuning-library" OFF)
+option(BESPOKE_SYSTEM_ABLETONLINK "Use system installation of abletonlink" OFF)
 option(BESPOKE_USE_ASAN "Build with ASAN" OFF)
 
 # Global CMake options

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,6 +1,10 @@
 include(cmake/lib.cmake)
 include(cmake/versiontools.cmake)
-include(../libs/ableton-link/AbletonLinkConfig.cmake)
+if(BESPOKE_SYSTEM_ABLETONLINK)
+    find_package(AbletonLink NAMES AbletonLink ableton-link link REQUIRED)
+else()
+    include(../libs/ableton-link/AbletonLinkConfig.cmake)
+endif()
 
 juce_add_gui_app(BespokeSynth
     PRODUCT_NAME BespokeSynth


### PR DESCRIPTION
Most Linux distributions package abletonlink and therefore do not want to rely on a vendored version of the library.
Add the `BESPOKE_SYSTEM_ABLETONLINK` cmake option to allow using a system-wide installed abletonlink.