### PR TITLE
Add a `module.set_targets(targetPathList)` function to Python scripting

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -576,11 +576,19 @@ void IDrawableModule::RemovePatchCableSource(PatchCableSource* source)
 
 void IDrawableModule::ClearAllPatchCableSources()
 {
-   if (mMainPatchCableSource != nullptr)
-      mMainPatchCableSource->Clear();
-   else if (!mPatchCableSources.empty())
-      for (auto source : mPatchCableSources)
-         RemovePatchCableSource(source);
+   if (IModulator* modulator = dynamic_cast<IModulator*>(this))
+   {
+      modulator->ClearAllPatchCableSources();
+      return;
+   }
+   else
+   {
+      if (mMainPatchCableSource != nullptr)
+         mMainPatchCableSource->Clear();
+      else if (!mPatchCableSources.empty())
+         for (auto source : mPatchCableSources)
+            RemovePatchCableSource(source);
+   }
 }
 
 void IDrawableModule::Exit()

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -536,6 +536,7 @@ void IDrawableModule::SetTarget(IClickable* target)
       mPatchCableSources[0]->SetTarget(target);
 }
 
+
 void IDrawableModule::SetUpPatchCables(std::string targets)
 {
    assert(mMainPatchCableSource != nullptr);
@@ -564,6 +565,15 @@ void IDrawableModule::RemovePatchCableSource(PatchCableSource* source)
 {
    RemoveFromVector(source, mPatchCableSources);
    delete source;
+}
+
+void IDrawableModule::ClearAllPatchCableSources()
+{
+   if (mMainPatchCableSource != nullptr)
+      mMainPatchCableSource->Clear();
+   else if (!mPatchCableSources.empty())
+      for (auto source : mPatchCableSources)
+         RemovePatchCableSource(source);
 }
 
 void IDrawableModule::Exit()

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -539,19 +539,26 @@ void IDrawableModule::SetTarget(IClickable* target)
 
 void IDrawableModule::SetUpPatchCables(std::string targets)
 {
-   assert(mMainPatchCableSource != nullptr);
-   std::vector<std::string> targetVec = ofSplitString(targets, ",");
-   if (targetVec.empty() || targets == "")
+   if (IModulator* modulator = dynamic_cast<IModulator*>(this))
    {
-      mMainPatchCableSource->Clear();
+      modulator->SetUpPatchCables(targets);
    }
    else
    {
-      for (int i = 0; i < targetVec.size(); ++i)
+      assert(mMainPatchCableSource != nullptr);
+      std::vector<std::string> targetVec = ofSplitString(targets, ",");
+      if (targetVec.empty() || targets == "")
       {
-         IClickable* target = dynamic_cast<IClickable*>(TheSynth->FindModule(targetVec[i]));
-         if (target)
-            mMainPatchCableSource->AddPatchCable(target);
+         mMainPatchCableSource->Clear();
+      }
+      else
+      {
+         for (int i = 0; i < targetVec.size(); ++i)
+         {
+            IClickable* target = dynamic_cast<IClickable*>(TheSynth->FindModule(targetVec[i]));
+            if (target)
+               mMainPatchCableSource->AddPatchCable(target);
+         }
       }
    }
 }

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -141,6 +141,7 @@ public:
    void SetUpPatchCables(std::string targets);
    void AddPatchCableSource(PatchCableSource* source);
    void RemovePatchCableSource(PatchCableSource* source);
+   void ClearAllPatchCableSources();
    bool TestClick(float x, float y, bool right, bool testOnly = false) override;
    std::string GetTypeName() const { return mTypeName; }
    ModuleCategory GetModuleCategory() const { return mModuleCategory; }

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -126,6 +126,13 @@ void IModulator::SetUpPatchCables(std::string targets)
    OnModulatorRepatch();
 }
 
+void IModulator::ClearAllPatchCableSources()
+{
+   assert(mTargetCable != nullptr);
+   mTargetCable->Clear();
+   OnModulatorRepatch();
+}
+
 void IModulator::Poll()
 {
    if (Active())

--- a/Source/IModulator.cpp
+++ b/Source/IModulator.cpp
@@ -106,6 +106,26 @@ void IModulator::OnModulatorRepatch()
    TheSynth->AddExtraPoller(this);
 }
 
+void IModulator::SetUpPatchCables(std::string targets)
+{
+   assert(mTargetCable != nullptr);
+   std::vector<std::string> targetVec = ofSplitString(targets, ",");
+   if (targetVec.empty() || targets == "")
+   {
+      mTargetCable->Clear();
+   }
+   else
+   {
+      for (int i = 0; i < targetVec.size(); ++i)
+      {
+         IClickable* target = dynamic_cast<IClickable*>(TheSynth->FindUIControl(targetVec[i]));
+         if (target)
+            mTargetCable->AddPatchCable(target);
+      }
+   }
+   OnModulatorRepatch();
+}
+
 void IModulator::Poll()
 {
    if (Active())

--- a/Source/IModulator.h
+++ b/Source/IModulator.h
@@ -43,6 +43,7 @@ public:
    virtual bool InitializeWithZeroRange() const { return false; }
    float& GetMin() { return mTargets[0].mSliderTarget ? mTargets[0].mSliderTarget->GetModulatorMin() : mDummyMin; }
    float& GetMax() { return mTargets[0].mSliderTarget ? mTargets[0].mSliderTarget->GetModulatorMax() : mDummyMax; }
+   void SetUpPatchCables(std::string targets);
    void OnModulatorRepatch();
    void Poll() override;
    float GetRecentChange() const;

--- a/Source/IModulator.h
+++ b/Source/IModulator.h
@@ -44,6 +44,7 @@ public:
    float& GetMin() { return mTargets[0].mSliderTarget ? mTargets[0].mSliderTarget->GetModulatorMin() : mDummyMin; }
    float& GetMax() { return mTargets[0].mSliderTarget ? mTargets[0].mSliderTarget->GetModulatorMax() : mDummyMax; }
    void SetUpPatchCables(std::string targets);
+   void ClearAllPatchCableSources();
    void OnModulatorRepatch();
    void Poll() override;
    float GetRecentChange() const;

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -729,6 +729,11 @@ PYBIND11_EMBEDDED_MODULE(module, m)
             target = TheSynth->FindUIControl(targetPath);
          module.SetTarget(target);
       })
+      .def("set_targets", [](IDrawableModule& module, std::string targetList)
+      {
+         module.ClearAllPatchCableSources();
+         module.SetUpPatchCables(targetList);
+      })
       .def("get_target", [](IDrawableModule& module)
       {
          auto* cable = module.GetPatchCableSource();

--- a/resource/python_stubs/module/__init__.pyi
+++ b/resource/python_stubs/module/__init__.pyi
@@ -28,6 +28,9 @@ class module:
    def set_target(this, targetPath):
       pass
 
+   def set_targets(this, targetPath):
+      pass
+
    def get_target(this, ):
       pass
 

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -209,6 +209,7 @@ import module
       m.get_height()
       m.set_target(target)
       m.set_target(targetPath)
+      m.set_targets(targetPathList)
       m.get_target()
       m.get_targets()
       m.set_name(name)

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -210,6 +210,7 @@ import module
       m.set_target(target)
       m.set_target(targetPath)
       m.set_targets(targetPathList)
+         example: m.set_targets("oscillator,oscillator1,oscillator2")
       m.get_target()
       m.get_targets()
       m.set_name(name)


### PR DESCRIPTION
Adds a new Python scripting capabilty, allowing users to set multiple targets for a given module. Targets are selected using comma separated target paths.

Example:
```python
import module

gate = module.create("notegate", 300, 300)

osc0 = module.create("oscillator", 300, 500)
osc0.set_name("osc0")

osc1 = module.create("oscillator", 600, 500)
osc1.set_name("osc1")

gate.set_targets("osc0,osc1")
```

Attached are some test `.bsk` files, simply run the scripts in each file and the results should be clear. Most notably among these is the `audio routing.bsk` file which shows this change "allows" a module with an audio output to route to multiple modules but only the last to be connected functions. Further details can be found in the comments of that file. If it is deemed necessary, additional development could potentially handle this by creating a new `audiorouter` instance and routing through that.

Big-ups to Noxy for holding my hand through developing this addition.

[set_targets.zip](https://github.com/BespokeSynth/BespokeSynth/files/12234354/set_targets.zip)