### PR TITLE
Bypass rework

### DIFF
--- a/Source/Amplifier.cpp
+++ b/Source/Amplifier.cpp
@@ -46,27 +46,30 @@ void Amplifier::Process(double time)
 {
    PROFILER(Amplifier);
 
-   if (!mEnabled)
+   IAudioReceiver* target = GetTarget();
+
+   if (target == nullptr)
       return;
 
    SyncBuffers();
    int bufferSize = GetBuffer()->BufferSize();
 
-   IAudioReceiver* target = GetTarget();
-   if (target)
+   ChannelBuffer* out = target->GetBuffer();
+   for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
    {
-      ChannelBuffer* out = target->GetBuffer();
-      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      auto getBufferChannelCh = GetBuffer()->GetChannel(ch);
+      if (mEnabled)
       {
-         auto getBufferChannelCh = GetBuffer()->GetChannel(ch);
          for (int i = 0; i < bufferSize; ++i)
          {
             ComputeSliders(i);
             gWorkBuffer[i] = getBufferChannelCh[i] * mGain;
          }
          Add(out->GetChannel(ch), gWorkBuffer, GetBuffer()->BufferSize());
-         GetVizBuffer()->WriteChunk(gWorkBuffer, GetBuffer()->BufferSize(), ch);
       }
+      else
+         Add(out->GetChannel(ch), getBufferChannelCh, GetBuffer()->BufferSize());
+      GetVizBuffer()->WriteChunk(gWorkBuffer, GetBuffer()->BufferSize(), ch);
    }
 
    GetBuffer()->Reset();

--- a/Source/Amplifier.cpp
+++ b/Source/Amplifier.cpp
@@ -66,10 +66,13 @@ void Amplifier::Process(double time)
             gWorkBuffer[i] = getBufferChannelCh[i] * mGain;
          }
          Add(out->GetChannel(ch), gWorkBuffer, GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(gWorkBuffer, GetBuffer()->BufferSize(), ch);
       }
       else
+      {
          Add(out->GetChannel(ch), getBufferChannelCh, GetBuffer()->BufferSize());
-      GetVizBuffer()->WriteChunk(gWorkBuffer, GetBuffer()->BufferSize(), ch);
+         GetVizBuffer()->WriteChunk(getBufferChannelCh, GetBuffer()->BufferSize(), ch);
+      }
    }
 
    GetBuffer()->Reset();

--- a/Source/BandVocoder.cpp
+++ b/Source/BandVocoder.cpp
@@ -90,11 +90,25 @@ void BandVocoder::Process(double time)
    PROFILER(BandVocoder);
 
    IAudioReceiver* target = GetTarget();
-   if (target == nullptr || !mEnabled)
+
+   if (target == nullptr)
       return;
 
-   ComputeSliders(0);
    SyncBuffers();
+
+   if (!mEnabled)
+   {
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+      return;
+   }
+
+   ComputeSliders(0);
 
    float inputPreampSq = mInputPreamp * mInputPreamp;
    float carrierPreampSq = mCarrierPreamp * mCarrierPreamp;

--- a/Source/DCOffset.cpp
+++ b/Source/DCOffset.cpp
@@ -48,26 +48,24 @@ void DCOffset::Process(double time)
 {
    PROFILER(DCOffset);
 
-   if (!mEnabled)
-      return;
-
-   ComputeSliders(0);
-   SyncBuffers();
-
    IAudioReceiver* target = GetTarget();
    if (target)
    {
+      ComputeSliders(0);
+      SyncBuffers();
+
       int bufferSize = GetBuffer()->BufferSize();
 
       ChannelBuffer* out = target->GetBuffer();
       for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
       {
          float* buffer = GetBuffer()->GetChannel(ch);
-         for (int i = 0; i < bufferSize; ++i)
-         {
-            ComputeSliders(i);
-            buffer[i] += mOffset;
-         }
+         if (mEnabled)
+            for (int i = 0; i < bufferSize; ++i)
+            {
+               ComputeSliders(i);
+               buffer[i] += mOffset;
+            }
          Add(out->GetChannel(ch), buffer, bufferSize);
          GetVizBuffer()->WriteChunk(buffer, bufferSize, ch);
       }

--- a/Source/FMSynth.cpp
+++ b/Source/FMSynth.cpp
@@ -270,6 +270,8 @@ void FMSynth::SetUpFromSaveData()
    int voiceLimit = mModuleSaveData.GetInt("voicelimit");
    if (voiceLimit > 0)
       mPolyMgr.SetVoiceLimit(voiceLimit);
+   else
+      mPolyMgr.SetVoiceLimit(kNumVoices);
 
    bool mono = mModuleSaveData.GetBool("mono");
    mWriteBuffer.SetNumActiveChannels(mono ? 1 : 2);

--- a/Source/FeedbackModule.cpp
+++ b/Source/FeedbackModule.cpp
@@ -67,8 +67,6 @@ void FeedbackModule::Process(double time)
 {
    PROFILER(FeedbackModule);
 
-   if (!mEnabled)
-      return;
 
    ComputeSliders(0);
    SyncBuffers();
@@ -76,15 +74,16 @@ void FeedbackModule::Process(double time)
    int bufferSize = GetBuffer()->BufferSize();
    IAudioReceiver* target = GetTarget();
 
-   for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+   if (target)
    {
-      if (target)
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
          Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), bufferSize);
-
-      GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), bufferSize, ch);
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), bufferSize, ch);
+      }
    }
 
-   if (mFeedbackTarget)
+   if (mFeedbackTarget && mEnabled)
    {
       mFeedbackTarget->GetBuffer()->SetNumActiveChannels(GetBuffer()->NumActiveChannels());
       mFeedbackVizBuffer.SetNumChannels(GetBuffer()->NumActiveChannels());

--- a/Source/Inverter.cpp
+++ b/Source/Inverter.cpp
@@ -47,9 +47,6 @@ void Inverter::Process(double time)
 {
    PROFILER(Inverter);
 
-   if (!mEnabled)
-      return;
-
    ComputeSliders(0);
    SyncBuffers();
 
@@ -60,7 +57,8 @@ void Inverter::Process(double time)
       ChannelBuffer* out = target->GetBuffer();
       for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
       {
-         Mult(GetBuffer()->GetChannel(ch), -1, out->BufferSize());
+         if (mEnabled)
+            Mult(GetBuffer()->GetChannel(ch), -1, out->BufferSize());
          Add(out->GetChannel(ch), GetBuffer()->GetChannel(ch), out->BufferSize());
          GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
       }

--- a/Source/KarplusStrong.cpp
+++ b/Source/KarplusStrong.cpp
@@ -226,6 +226,8 @@ void KarplusStrong::SetUpFromSaveData()
    int voiceLimit = mModuleSaveData.GetInt("voicelimit");
    if (voiceLimit > 0)
       mPolyMgr.SetVoiceLimit(voiceLimit);
+   else
+      mPolyMgr.SetVoiceLimit(kNumVoices);
 
    bool mono = mModuleSaveData.GetBool("mono");
    mWriteBuffer.SetNumActiveChannels(mono ? 1 : 2);

--- a/Source/Lissajous.cpp
+++ b/Source/Lissajous.cpp
@@ -49,9 +49,6 @@ void Lissajous::Process(double time)
 {
    PROFILER(Lissajous);
 
-   if (!mEnabled)
-      return;
-
    SyncBuffers();
 
    int bufferSize = GetBuffer()->BufferSize();
@@ -65,16 +62,19 @@ void Lissajous::Process(double time)
       }
    }
 
-   mOnlyHasOneChannel = (GetBuffer()->NumActiveChannels() == 1);
-   int secondChannel = mOnlyHasOneChannel ? 0 : 1;
+   if (mEnabled)
+   {
+      mOnlyHasOneChannel = (GetBuffer()->NumActiveChannels() == 1);
+      int secondChannel = mOnlyHasOneChannel ? 0 : 1;
 
-   for (int i = 0; i < bufferSize; ++i)
-      mLissajousPoints[(mOffset + i) % NUM_LISSAJOUS_POINTS].set(GetBuffer()->GetChannel(0)[i], GetBuffer()->GetChannel(secondChannel)[i]);
+      for (int i = 0; i < bufferSize; ++i)
+         mLissajousPoints[(mOffset + i) % NUM_LISSAJOUS_POINTS].set(GetBuffer()->GetChannel(0)[i], GetBuffer()->GetChannel(secondChannel)[i]);
+
+      mOffset += bufferSize;
+      mOffset %= NUM_LISSAJOUS_POINTS;
+   }
 
    GetBuffer()->Reset();
-
-   mOffset += bufferSize;
-   mOffset %= NUM_LISSAJOUS_POINTS;
 }
 
 void Lissajous::DrawModule()
@@ -83,6 +83,9 @@ void Lissajous::DrawModule()
       return;
 
    mScaleSlider->Draw();
+
+   if (!mEnabled)
+      return;
 
    ofPushStyle();
    ofPushMatrix();

--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -209,8 +209,23 @@ void Looper::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (target == nullptr)
       return;
+
+   if (!mEnabled)
+   {
+      SyncBuffers();
+
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+
+      return;
+   }
 
    ComputeSliders(0);
    int numChannels = MAX(GetBuffer()->NumActiveChannels(), mBuffer->NumActiveChannels());
@@ -334,8 +349,6 @@ void Looper::Process(double time)
          output[ch] = mSwitchAndRamp.Process(ch, output[ch] * volSq);
 
          mWorkBuffer.GetChannel(ch)[i] = output[ch] * mMuteRamp.Value(time);
-
-         GetVizBuffer()->Write(mWorkBuffer.GetChannel(ch)[i] + GetBuffer()->GetChannel(ch)[i], ch);
       }
 
       time += gInvSampleRateMs;
@@ -355,6 +368,7 @@ void Looper::Process(double time)
       if (mPassthrough || mWriteInput)
          Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), bufferSize);
       Add(target->GetBuffer()->GetChannel(ch), mWorkBuffer.GetChannel(ch), bufferSize);
+      GetVizBuffer()->WriteChunk(target->GetBuffer()->GetChannel(ch), bufferSize, ch);
    }
 
    GetBuffer()->Reset();

--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -133,11 +133,25 @@ void LooperRecorder::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (target == nullptr)
       return;
 
-   ComputeSliders(0);
    SyncBuffers();
+
+   if (!mEnabled)
+   {
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+
+      return;
+   }
+
+   ComputeSliders(0);
    mWriteBuffer.SetNumActiveChannels(GetBuffer()->NumActiveChannels());
    mRecordBuffer.SetNumChannels(GetBuffer()->NumActiveChannels());
 

--- a/Source/ModulationVisualizer.cpp
+++ b/Source/ModulationVisualizer.cpp
@@ -39,7 +39,7 @@ void ModulationVisualizer::DrawModule()
       return;
 
    int y = 15;
-   DrawTextNormal("global:" + mGlobalModulation.GetInfoString(), 3, y);
+   DrawTextNormal("global: " + mGlobalModulation.GetInfoString(), 3, y);
    y += 15;
 
    for (int i = 0; i < kNumVoices; ++i)
@@ -89,5 +89,12 @@ std::string ModulationVisualizer::VizVoice::GetInfoString()
       info += "mod:" + ofToString(mModulators.modWheel->GetValue(0), 2) + "  ";
    if (mModulators.pressure)
       info += "pressure:" + ofToString(mModulators.pressure->GetValue(0), 2) + "  ";
+   info += "pan:" + ofToString(mModulators.pan, 2) + "  ";
    return info;
+}
+
+void ModulationVisualizer::Resize(float w, float h)
+{
+   mWidth = w;
+   mHeight = h;
 }

--- a/Source/ModulationVisualizer.h
+++ b/Source/ModulationVisualizer.h
@@ -40,13 +40,14 @@ public:
    static bool AcceptsNotes() { return true; }
    static bool AcceptsPulses() { return false; }
 
-   void SetEnabled(bool enabled) override { mEnabled = enabled; }
-
    //INoteReceiver
    void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
+
+   bool IsResizable() const override { return true; }
+   void Resize(float w, float h) override;
 
    bool IsEnabled() const override { return mEnabled; }
 
@@ -55,8 +56,8 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override
    {
-      width = 300;
-      height = 100;
+      width = mWidth;
+      height = mHeight;
    }
 
    struct VizVoice
@@ -66,6 +67,8 @@ private:
       ModulationParameters mModulators;
    };
 
+   float mWidth{ 350 };
+   float mHeight{ 100 };
    VizVoice mGlobalModulation;
    std::vector<VizVoice> mVoices;
 };

--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -77,10 +77,23 @@ void MultitapDelay::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (target == nullptr)
       return;
 
    SyncBuffers();
+
+   if (!mEnabled)
+   {
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+      return;
+   }
+
    mWriteBuffer.SetNumActiveChannels(GetBuffer()->NumActiveChannels());
    mDelayBuffer.SetNumChannels(GetBuffer()->NumActiveChannels());
    for (int t = 0; t < mNumTaps; ++t)

--- a/Source/NoteDisplayer.cpp
+++ b/Source/NoteDisplayer.cpp
@@ -45,13 +45,17 @@ void NoteDisplayer::DrawModule()
 
 void NoteDisplayer::DrawNoteName(int pitch, float y) const
 {
-   DrawTextNormal(NoteName(pitch) + ofToString(pitch / 12 - 2) + " (" + ofToString(pitch) + ")" + " vel:" + ofToString(mVelocities[pitch]), 4, y);
+   DrawTextNormal(NoteName(pitch) + ofToString(pitch / 12 - 2) + " (" + ofToString(pitch) + ")" +
+                  " vel:" + ofToString(mVelocities[pitch]) +
+                  " voiceId:" + ofToString(mVoiceIds[pitch]),
+                  4, y);
 }
 
 void NoteDisplayer::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
 {
    PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
    mVelocities[pitch] = velocity;
+   mVoiceIds[pitch] = voiceIdx;
 }
 
 void NoteDisplayer::LoadLayout(const ofxJSONElement& moduleInfo)

--- a/Source/NoteDisplayer.h
+++ b/Source/NoteDisplayer.h
@@ -60,9 +60,10 @@ private:
 
    void DrawNoteName(int pitch, float y) const;
 
-   float mWidth{ 110 };
+   float mWidth{ 160 };
    float mHeight{ 60 };
    int mVelocities[128]{};
+   int mVoiceIds[128]{};
 };
 
 #endif /* defined(__Bespoke__NoteDisplayer__) */

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -337,6 +337,8 @@ void NoteTable::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
 {
    if ((mEnabled || velocity == 0) && pitch < kMaxLength)
       PlayColumn(time, pitch, velocity, voiceIdx, modulation);
+   if (!mEnabled)
+      PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
 void NoteTable::PlayColumn(double time, int column, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -337,8 +337,6 @@ void NoteTable::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
 {
    if ((mEnabled || velocity == 0) && pitch < kMaxLength)
       PlayColumn(time, pitch, velocity, voiceIdx, modulation);
-   if (!mEnabled)
-      PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
 }
 
 void NoteTable::PlayColumn(double time, int column, int velocity, int voiceIdx, ModulationParameters modulation)

--- a/Source/Panner.cpp
+++ b/Source/Panner.cpp
@@ -52,8 +52,22 @@ void Panner::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (target == nullptr)
       return;
+
+   if (!mEnabled)
+   {
+      SyncBuffers();
+
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+      return;
+   }
 
    SyncBuffers(2);
    mWidenerBuffer.SetNumChannels(2);

--- a/Source/PulseChance.cpp
+++ b/Source/PulseChance.cpp
@@ -102,6 +102,12 @@ void PulseChance::OnPulse(double time, float velocity, int flags)
 {
    ComputeSliders(0);
 
+   if (!mEnabled)
+   {
+      DispatchPulse(GetPatchCableSource(), time, velocity, flags);
+      return;
+   }
+
    if (flags & kPulseFlag_Reset)
       mRandomIndex = 0;
 

--- a/Source/PulseDelayer.cpp
+++ b/Source/PulseDelayer.cpp
@@ -103,7 +103,10 @@ void PulseDelayer::OnTransportAdvanced(float amount)
 void PulseDelayer::OnPulse(double time, float velocity, int flags)
 {
    if (!mEnabled)
+   {
+      DispatchPulse(GetPatchCableSource(), time, velocity, flags);
       return;
+   }
 
    if (velocity > 0)
       mLastPulseTime = time;

--- a/Source/PulseFlag.cpp
+++ b/Source/PulseFlag.cpp
@@ -69,10 +69,13 @@ void PulseFlag::OnPulse(double time, float velocity, int flags)
 {
    ComputeSliders(0);
 
-   if (mReplaceFlags)
-      flags = 0;
+   if (mEnabled)
+   {
+      if (mReplaceFlags)
+         flags = 0;
 
-   flags |= mFlagValue;
+      flags |= mFlagValue;
+   }
 
    DispatchPulse(GetPatchCableSource(), time, velocity, flags);
 }

--- a/Source/RingModulator.cpp
+++ b/Source/RingModulator.cpp
@@ -72,7 +72,7 @@ void RingModulator::Process(double time)
 
       for (int i = 0; i < bufferSize; ++i)
       {
-         ComputeSliders(0);
+         ComputeSliders(i);
 
          for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
             GetBuffer()->GetChannel(ch)[i] *= mModOsc.Audio(time, mPhase);

--- a/Source/SamplerGrid.cpp
+++ b/Source/SamplerGrid.cpp
@@ -80,11 +80,25 @@ void SamplerGrid::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (target == nullptr)
       return;
 
-   ComputeSliders(0);
    SyncBuffers();
+
+   if (!mEnabled)
+   {
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+
+      return;
+   }
+
+   ComputeSliders(0);
 
    int bufferSize = GetBuffer()->BufferSize();
 

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -108,8 +108,22 @@ void SeaOfGrain::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr || (mSample == nullptr && !mHasRecordedInput) || mLoading)
+   if (target == nullptr || (mSample == nullptr && !mHasRecordedInput) || mLoading)
       return;
+
+   if (!mEnabled)
+   {
+      SyncBuffers();
+
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+      return;
+   }
 
    ComputeSliders(0);
    int numChannels = 2;

--- a/Source/SignalClamp.cpp
+++ b/Source/SignalClamp.cpp
@@ -49,30 +49,28 @@ void SignalClamp::Process(double time)
 {
    PROFILER(SignalClamp);
 
-   if (!mEnabled)
+   IAudioReceiver* target = GetTarget();
+
+   if (target == nullptr)
       return;
 
    ComputeSliders(0);
    SyncBuffers();
 
-   IAudioReceiver* target = GetTarget();
+   int bufferSize = GetBuffer()->BufferSize();
 
-   if (target)
+   ChannelBuffer* out = target->GetBuffer();
+   for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
    {
-      int bufferSize = GetBuffer()->BufferSize();
-
-      ChannelBuffer* out = target->GetBuffer();
-      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
-      {
-         float* buffer = GetBuffer()->GetChannel(ch);
+      float* buffer = GetBuffer()->GetChannel(ch);
+      if (mEnabled)
          for (int i = 0; i < bufferSize; ++i)
          {
             ComputeSliders(i);
             buffer[i] = ofClamp(buffer[i], mMin, mMax);
          }
-         Add(out->GetChannel(ch), buffer, bufferSize);
-         GetVizBuffer()->WriteChunk(buffer, bufferSize, ch);
-      }
+      Add(out->GetChannel(ch), buffer, bufferSize);
+      GetVizBuffer()->WriteChunk(buffer, bufferSize, ch);
    }
 
    GetBuffer()->Reset();

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -340,6 +340,8 @@ void SingleOscillator::SetUpFromSaveData()
    int voiceLimit = mModuleSaveData.GetInt("voicelimit");
    if (voiceLimit > 0)
       mPolyMgr.SetVoiceLimit(voiceLimit);
+   else
+      mPolyMgr.SetVoiceLimit(kNumVoices);
 
    bool mono = mModuleSaveData.GetBool("mono");
    mWriteBuffer.SetNumActiveChannels(mono ? 1 : 2);

--- a/Source/Splitter.cpp
+++ b/Source/Splitter.cpp
@@ -60,9 +60,6 @@ void Splitter::Process(double time)
 {
    PROFILER(Splitter);
 
-   if (!mEnabled)
-      return;
-
    IAudioReceiver* target0 = GetTarget(0);
    if (target0)
    {

--- a/Source/Splitter.h
+++ b/Source/Splitter.h
@@ -48,13 +48,10 @@ public:
 
    //IAudioSource
    void Process(double time) override;
-   void SetEnabled(bool enabled) override { mEnabled = enabled; }
    int GetNumTargets() override { return 2; }
 
    virtual void LoadLayout(const ofxJSONElement& moduleInfo) override;
    virtual void SetUpFromSaveData() override;
-
-   bool IsEnabled() const override { return mEnabled; }
 
 private:
    //IDrawableModule

--- a/Source/Vocoder.cpp
+++ b/Source/Vocoder.cpp
@@ -77,11 +77,24 @@ void Vocoder::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (target == nullptr || !mEnabled)
+   if (target == nullptr)
       return;
 
-   ComputeSliders(0);
    SyncBuffers();
+
+   if (!mEnabled)
+   {
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
+         Add(target->GetBuffer()->GetChannel(ch), GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+         GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
+      }
+
+      GetBuffer()->Reset();
+      return;
+   }
+
+   ComputeSliders(0);
 
    float inputPreampSq = mInputPreamp * mInputPreamp;
    float carrierPreampSq = mCarrierPreamp * mCarrierPreamp;

--- a/Source/WaveformViewer.cpp
+++ b/Source/WaveformViewer.cpp
@@ -66,44 +66,48 @@ void WaveformViewer::Process(double time)
 {
    PROFILER(WaveformViewer);
 
-   ComputeSliders(0);
-
-   if (!mEnabled)
-      return;
-
    SyncBuffers();
 
-   int lengthSamples = MIN(mLengthSamples, BUFFER_VIZ_SIZE);
-
-   int bufferSize = GetBuffer()->BufferSize();
-   IAudioReceiver* target = GetTarget();
-   if (target)
+   if (mEnabled)
    {
-      ChannelBuffer* out = target->GetBuffer();
+      ComputeSliders(0);
+
+      int lengthSamples = MIN(mLengthSamples, BUFFER_VIZ_SIZE);
+
+      int bufferSize = GetBuffer()->BufferSize();
       for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
       {
          if (ch == 0)
             BufferCopy(gWorkBuffer, GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
          else
             Add(gWorkBuffer, GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize());
+      }
+
+      for (int i = 0; i < bufferSize; ++i)
+         mAudioView[(i + mBufferVizOffset[!mDoubleBufferFlip]) % lengthSamples][!mDoubleBufferFlip] = gWorkBuffer[i];
+
+      float vizPhaseInc = GetPhaseInc(mDisplayFreq / 2);
+      mVizPhase[!mDoubleBufferFlip] += vizPhaseInc * bufferSize;
+      while (mVizPhase[!mDoubleBufferFlip] > FTWO_PI)
+      {
+         mVizPhase[!mDoubleBufferFlip] -= FTWO_PI;
+      }
+
+      mBufferVizOffset[!mDoubleBufferFlip] = (mBufferVizOffset[!mDoubleBufferFlip] + bufferSize) % lengthSamples;
+   }
+
+   IAudioReceiver* target = GetTarget();
+   if (target)
+   {
+      ChannelBuffer* out = target->GetBuffer();
+      for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
+      {
          Add(out->GetChannel(ch), GetBuffer()->GetChannel(ch), out->BufferSize());
          GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), GetBuffer()->BufferSize(), ch);
       }
    }
 
-   for (int i = 0; i < bufferSize; ++i)
-      mAudioView[(i + mBufferVizOffset[!mDoubleBufferFlip]) % lengthSamples][!mDoubleBufferFlip] = gWorkBuffer[i];
-
    GetBuffer()->Reset();
-
-   float vizPhaseInc = GetPhaseInc(mDisplayFreq / 2);
-   mVizPhase[!mDoubleBufferFlip] += vizPhaseInc * bufferSize;
-   while (mVizPhase[!mDoubleBufferFlip] > FTWO_PI)
-   {
-      mVizPhase[!mDoubleBufferFlip] -= FTWO_PI;
-   }
-
-   mBufferVizOffset[!mDoubleBufferFlip] = (mBufferVizOffset[!mDoubleBufferFlip] + bufferSize) % lengthSamples;
 }
 
 void WaveformViewer::DrawModule()
@@ -120,6 +124,9 @@ void WaveformViewer::DrawModule()
    mHueNoteSource->Draw();
    mSaturation->Draw();
    mBrightness->Draw();*/
+
+   if (!mEnabled)
+      return;
 
    ofPushStyle();
    ofPushMatrix();


### PR DESCRIPTION
Combined commit message:
```
Changed the following modules to use a bypass mechanism when disabled: `gain`, `audiometer`, `fftvocoder`, `dcoffset`, `feedback`, `inverter`, `lissajous`, `looper`, `looperrecorder`, `multitapdelay`, `notetable`, `samplecapturer`, `samplergrid`, `seaofgrain`, `send`, `spectrum`, `signalclamp`, `vocoder`, `waveformviewer`, `waveshaper`, `pulsechance`, `pulsedelayer` and `pulseflag`.
Made `spectrum` and `waveformviewer` function when the target is not connected.
Removed the enable/bypass checkbox on the `splitter`.
Minor rendering optimization when the modules `lissajous`, `spectrum` and `waveformviewer` are disabled/bypassed.
Fixed a bug in the `ringmodulator` module where it would not compute the sliders for every sample correctly.
Fixed a bug with the visualization of the output cable on a `looper`.
Fix a bug that inhibited removing the voicelimit in the `oscillator`, `fmsynth` and `karplusstrong` modules.
Added voiceId to the `notedisplayer`.
Added "pan" to `modulationvisualizer` and made the module resizable.
```

Please don't hesitate to poke me on discord if you have questions or want me to do things differently ;)