### PR TITLE
Fixed a bug in the cosine window of the granulators that caused clicky noises at the end of grains.

### DIFF
--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -139,7 +139,7 @@ void Grain::Spawn(Granulator* owner, double time, double pos, float speedMult, f
 inline double Grain::GetWindow(double time)
 {
    double phase = (time - mStartTime) * mStartToEndInv;
-   return .5 * (1 - juce::dsp::FastMathApproximations::cos<double>(phase * TWO_PI));
+   return .5 + .5 * juce::dsp::FastMathApproximations::cos<double>(phase * TWO_PI - PI);
 }
 
 void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float* output)


### PR DESCRIPTION
We figured out the approximation of the cosine function was off at the tailing end of the grains and found the following in the JUCE documentation:

>Provides a fast approximation of the function cos(x) using a Pade approximant continued fraction, calculated sample by sample.
> 
> Note: This is an approximation which works on a limited range. You are advised to use input values only between -pi and +pi for limiting the error.

Since the original code goes to `TWO_PI` we adjusted it to not go that high thus resolving the major inaccuracy of the approximation.