### PR TITLE
visual updates for recent patch cable changes

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -577,10 +577,31 @@ void ModularSynth::Draw(void* vg)
    TheSaveDataPanel->SetShowing(TheSaveDataPanel->GetModule());
    TheSaveDataPanel->UpdatePosition();
 
-   mModuleContainer.DrawPatchCables(!K(parentMinimized), !K(inFront));
-   mModuleContainer.Draw();
-   mModuleContainer.DrawPatchCables(!K(parentMinimized), K(inFront));
-   mModuleContainer.DrawUnclipped();
+   mModuleContainer.DrawContents();
+
+   IClickable* dropTarget = nullptr;
+   if (PatchCable::sActivePatchCable != nullptr)
+      dropTarget = PatchCable::sActivePatchCable->GetDropTarget();
+   if (dropTarget)
+   {
+      ofPushStyle();
+
+      ofSetColor(255, 255, 255, 100);
+      ofSetLineWidth(.5f);
+      ofFill();
+      ofRectangle rect = dropTarget->GetRect();
+
+      IDrawableModule* dropTargetModule = dynamic_cast<IDrawableModule*>(dropTarget);
+      if (dropTargetModule && dropTargetModule->HasTitleBar())
+      {
+         rect.y -= IDrawableModule::TitleBarHeight();
+         rect.height += IDrawableModule::TitleBarHeight();
+      }
+
+      ofRect(rect);
+
+      ofPopStyle();
+   }
 
    for (int i = 0; i < mLissajousDrawers.size(); ++i)
    {
@@ -662,10 +683,7 @@ void ModularSynth::Draw(void* vg)
       ofScale(uiScale, uiScale, uiScale);
       ofTranslate(mUILayerModuleContainer.GetDrawOffset().x, mUILayerModuleContainer.GetDrawOffset().y);
 
-      mUILayerModuleContainer.DrawPatchCables(!K(parentMinimized), K(inFront));
-      mUILayerModuleContainer.Draw();
-      mUILayerModuleContainer.DrawPatchCables(!K(parentMinimized), !K(inFront));
-      mUILayerModuleContainer.DrawUnclipped();
+      mUILayerModuleContainer.DrawContents();
 
       Profiler::Draw();
       DrawConsole();

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -59,7 +59,15 @@ void ModuleContainer::GetAllModules(std::vector<IDrawableModule*>& out)
    }
 }
 
-void ModuleContainer::Draw()
+void ModuleContainer::DrawContents()
+{
+   DrawPatchCables(!K(parentMinimized), !K(inFront));
+   DrawModules();
+   DrawPatchCables(!K(parentMinimized), K(inFront));
+   DrawUnclipped();
+}
+
+void ModuleContainer::DrawModules()
 {
    for (int i = (int)mModules.size() - 1; i >= 0; --i)
    {

--- a/Source/ModuleContainer.h
+++ b/Source/ModuleContainer.h
@@ -41,7 +41,8 @@ public:
 
    void SetOwner(IDrawableModule* owner) { mOwner = owner; }
    IDrawableModule* GetOwner() const { return mOwner; }
-   void Draw();
+   void DrawContents();
+   void DrawModules();
    void DrawPatchCables(bool parentMinimized, bool inFront);
    void DrawUnclipped();
    void PostRender();

--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -83,7 +83,7 @@ void MultitrackRecorder::DrawModule()
 
    mHeight = posY;
 
-   mModuleContainer.Draw();
+   mModuleContainer.DrawModules();
 }
 
 void MultitrackRecorder::AddTrack()

--- a/Source/PatchCable.cpp
+++ b/Source/PatchCable.cpp
@@ -150,28 +150,6 @@ void PatchCable::Render()
    ofPushStyle();
    ofNoFill();
 
-   IClickable* dropTarget = GetDropTarget();
-   if (dropTarget)
-   {
-      ofPushStyle();
-
-      ofSetColor(255, 255, 255, 100);
-      ofSetLineWidth(.5f);
-      ofFill();
-      ofRectangle rect = dropTarget->GetRect();
-
-      IDrawableModule* dropTargetModule = dynamic_cast<IDrawableModule*>(dropTarget);
-      if (dropTargetModule && dropTargetModule->HasTitleBar())
-      {
-         rect.y -= IDrawableModule::TitleBarHeight();
-         rect.height += IDrawableModule::TitleBarHeight();
-      }
-
-      ofRect(rect);
-
-      ofPopStyle();
-   }
-
    ConnectionType type = mOwner->GetConnectionType();
    ofColor lineColor = mOwner->GetColor();
    if (mHoveringOnSource && sActivePatchCable == nullptr && !TheSynth->IsGroupSelecting())

--- a/Source/PatchCable.h
+++ b/Source/PatchCable.h
@@ -92,6 +92,7 @@ public:
    void Destroy(bool fromUserClick);
    void SetTempDrawTarget(IClickable* target) { mTempDrawTarget = target; }
    void ShowQuickspawnForCable();
+   IClickable* GetDropTarget();
 
    void SetUIControlConnection(UIControlConnection* conn) { mUIControlConnection = conn; }
 
@@ -104,7 +105,6 @@ private:
    void SetCableTarget(IClickable* target);
    PatchCablePos GetPatchCablePos();
    ofVec2f FindClosestSide(float x, float y, float w, float h, ofVec2f start, ofVec2f startDirection, ofVec2f& endDirection);
-   IClickable* GetDropTarget();
 
    PatchCableSource* mOwner{ nullptr };
    IClickable* mTarget{ nullptr };

--- a/Source/Prefab.cpp
+++ b/Source/Prefab.cpp
@@ -97,17 +97,6 @@ bool Prefab::IsMouseHovered()
    return GetRect(false).contains(TheSynth->GetMouseX(GetOwningContainer()), TheSynth->GetMouseY(GetOwningContainer()));
 }
 
-void Prefab::CheckboxUpdated(Checkbox* checkbox, double time)
-{
-   if (checkbox == mEnabledCheckbox)
-   {
-      for (auto& module : mModuleContainer.GetModules())
-      {
-         module->SetEnabled(mEnabled);
-      }
-   }
-}
-
 bool Prefab::CanAddDropModules()
 {
    if (IsMouseHovered() && !TheSynth->IsGroupSelecting())
@@ -185,7 +174,7 @@ void Prefab::DrawModule()
    mDisbandButton->Draw();
    DrawTextNormal("remove", 18, 14);
 
-   mModuleContainer.Draw();
+   mModuleContainer.DrawModules();
 }
 
 void Prefab::DrawModuleUnclipped()
@@ -259,6 +248,17 @@ void Prefab::ButtonClicked(ClickButton* button, double time)
       for (auto* module : modules)
          GetOwningContainer()->TakeModule(module);
       GetOwningContainer()->DeleteModule(this);
+   }
+}
+
+void Prefab::CheckboxUpdated(Checkbox* checkbox, double time)
+{
+   if (checkbox == mEnabledCheckbox)
+   {
+      for (auto& module : mModuleContainer.GetModules())
+      {
+         module->SetEnabled(mEnabled);
+      }
    }
 }
 

--- a/Source/Prefab.h
+++ b/Source/Prefab.h
@@ -54,6 +54,7 @@ public:
    bool ShouldClipContents() override { return false; }
 
    void ButtonClicked(ClickButton* button, double time) override;
+   void CheckboxUpdated(Checkbox* checkbox, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SaveLayout(ofxJSONElement& moduleInfo) override;
@@ -84,7 +85,6 @@ private:
    bool CanAddDropModules();
    bool IsAddableModule(IDrawableModule* module);
    bool IsMouseHovered();
-   void CheckboxUpdated(Checkbox* checkbox, double time);
 
    void SavePrefab(std::string savePath);
    void UpdatePrefabName(std::string path);

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -532,10 +532,7 @@ void Push2Control::DrawToFramebuffer(NVGcontext* vg, NVGLUframebuffer* fb, float
       ofTranslate(TheSynth->GetDrawOffset().x, TheSynth->GetDrawOffset().y);
       ofTranslate(1500 / gDrawScale, -100 / gDrawScale); //center on display
 
-      TheSynth->GetRootContainer()->DrawPatchCables(!K(parentMinimized), !K(inFront));
-      TheSynth->GetRootContainer()->Draw();
-      TheSynth->GetRootContainer()->DrawPatchCables(!K(parentMinimized), K(inFront));
-      TheSynth->GetRootContainer()->DrawUnclipped();
+      TheSynth->GetRootContainer()->DrawContents();
 
       if (mDisplayModule != nullptr && !mDisplayModule->IsDeleted() &&
           mDisplayModule->GetOwningContainer() != nullptr && mDisplayModule->IsShowing())


### PR DESCRIPTION
- reduce module background alpha to better show cables running behind modules
- greatly reduce prefab alpha, to mitigate obscuring of cables within prefabs (fixes #1432) and also to make prefabs less imposing-looking
- change order of when cable drop highlight draws (fixes #1433)
