### PR TITLE
push 2 workflow improvements, to support a recent performance

### DIFF
--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -239,4 +239,11 @@ private:
    bool mGridSyncQueued{ false };
    bool mPush2VelocityHeld{ false };
    bool mPush2LengthHeld{ false };
+
+   enum class Push2GridDisplayMode
+   {
+      PerStep,
+      GridView
+   };
+   Push2GridDisplayMode mPush2GridDisplayMode{ Push2GridDisplayMode::PerStep };
 };

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -156,4 +156,10 @@ private:
    IntSlider* mGridControlOffsetYSlider{ nullptr };
 
    int mPush2HeldStep{ -1 };
+   enum class Push2GridDisplayMode
+   {
+      PerStep,
+      GridView
+   };
+   Push2GridDisplayMode mPush2GridDisplayMode{ Push2GridDisplayMode::PerStep };
 };

--- a/Source/PatchCableSource.h
+++ b/Source/PatchCableSource.h
@@ -160,6 +160,7 @@ public:
       height = 10;
    }
    void KeyPressed(int key, bool isRepeat);
+   bool IsHovered() const { return mHoverIndex != -1; }
 
    void SaveState(FileStreamOut& out);
    void LoadState(FileStreamIn& in);

--- a/Source/Push2Control.h
+++ b/Source/Push2Control.h
@@ -52,6 +52,7 @@ public:
    void CreateUIControls() override;
    void Poll() override;
    void Exit() override;
+   void KeyPressed(int key, bool isRepeat) override;
 
    void SetLed(MidiMessageType type, int index, int color, int flashColor = -1);
    void SetDisplayModule(IDrawableModule* module, bool addToHistory = true);
@@ -72,6 +73,9 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    int GetModuleSaveStateRev() const override { return 1; }
 
+   int GetGridControllerOption1Control() const;
+   int GetGridControllerOption2Control() const;
+
    static bool sDrawingPush2Display;
    static NVGcontext* sVG;
    static NVGLUframebuffer* sFB;
@@ -88,7 +92,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override
    {
       width = mWidth;
-      height = mHeight;
+      height = mHeight + (mShowManualGrid ? 98 : 0);
    }
    void OnClicked(float x, float y, bool right) override;
 
@@ -123,6 +127,7 @@ private:
    int GetNumDisplayPixels() const;
    bool AllowRepatch() const;
    void UpdateRoutingModules();
+   void SetGridControlInterface(IPush2GridController* controller, IDrawableModule* module);
 
    unsigned char* mPixels{ nullptr };
    const int kPixelRatio = 1;
@@ -147,9 +152,20 @@ private:
    std::vector<IDrawableModule*> mModules;
    float mModuleListOffset{ 0 };
    float mModuleListOffsetSmoothed{ 0 };
-   IDrawableModule* mModuleGrid[8 * 8];
+   std::array<IDrawableModule*, 8 * 8> mModuleGrid;
+   std::array<PatchCableSource*, 8 * 8> mModuleGridManualCables;
    ofRectangle mModuleGridRect;
 
+   enum class ModuleGridLayoutStyle
+   {
+      Automatic,
+      Manual
+   };
+
+   ModuleGridLayoutStyle mModuleGridLayoutStyle{ ModuleGridLayoutStyle::Automatic };
+   DropdownList* mModuleGridLayoutStyleDropdown{ nullptr };
+   bool mShowManualGrid{ false };
+   Checkbox* mShowManualGridCheckbox{ nullptr };
    std::vector<IUIControl*> mFavoriteControls;
    std::vector<IUIControl*> mSpawnModuleControls;
    bool mNewButtonHeld{ false };

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -131,6 +131,7 @@ private:
    FloatSlider* mVolSlider{ nullptr };
    int mPresetFileIndex{ -1 };
    DropdownList* mPresetFileSelector{ nullptr };
+   bool mPresetFileUpdateQueued{ false };
    ClickButton* mSavePresetFileButton{ nullptr };
    std::vector<std::string> mPresetFilePaths;
    ClickButton* mOpenEditorButton{ nullptr };


### PR DESCRIPTION
- add the ability to manually lay out the module grid view, so you can curate the modules you want quick access to
- add second grid view to notesequencer and notetable modules
- fix vstplugin assert when adjusting preset dropdown from push2
