### PR TITLE
Add controller definition for M-AUDIO Code 25 USB MIDI

### DIFF
--- a/resource/userdata_original/controllers/Code 25 USB MIDI.json
+++ b/resource/userdata_original/controllers/Code 25 USB MIDI.json
@@ -1,0 +1,62 @@
+{
+
+ "groups" : [
+    {
+        "rows": 1,
+        "cols": 1,
+        "position" : [ 50, 0 ],
+        "dimensions" : [ 28, 80 ],
+        "spacing" : [ 30, 30 ],
+        "controls" : [ 1 ],
+        "messageType" : "control",
+        "drawType" : "slider"
+    },
+    {
+        "rows": 1,
+        "cols": 5,
+        "position" : [ 200, 0 ],
+        "dimensions" : [ 28, 80 ],
+        "spacing" : [ 30, 30 ],
+        "controls" : [  7, 70, 75, 74, 71 ],
+        "messageType" : "control",
+        "drawType" : "slider"
+    },
+    {
+        "rows": 1,
+        "cols": 5,
+        "position" : [ 200, 100 ],
+        "dimensions" : [ 28, 20 ],
+        "spacing" : [ 30, 30 ],
+        "controls" : [ 91, 92, 93, 94, 10 ],
+        "messageType" : "control",
+        "drawType" : "button"
+    },
+    {
+        "rows": 2,
+        "cols": 2,
+        "position" : [ 400, 0 ],
+        "dimensions" : [ 28, 28 ],
+        "spacing" : [ 30, 30 ],
+        "controls" : [ 76, 73, 77, 78 ],
+        "messageType" : "control",
+        "drawType" : "knob",
+        "incremental" : false
+    },
+    {
+        "rows": 4,
+        "cols": 4,
+        "position" : [ 0, 120 ],
+        "dimensions" : [ 28, 28 ],
+        "spacing" : [ 30, 30 ],
+        "controls" : [
+            12, 13, 14, 15,
+             8,  9, 10, 11,
+             4,  5,  6,  7,
+             0,  1,  2,  3
+        ],
+        "colors" : [ 0, 127 ],
+        "messageType" : "note",
+        "drawType" : "button"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds M-AUDIO Code 25 USB MIDI keyboard controller ([manual here](https://www.manualslib.com/manual/1156270/M-Audio-Code25.html)) JSON file. I recently got my hands on this keyboard and wrote this JSON file to integrate it with BespokeSynth.