### PR TITLE
Improve location of system-provided jsonpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ message(STATUS "Python version: ${Python_VERSION}")
 message(STATUS "Python executable: ${Python_EXECUTABLE}")
 message(STATUS "Python library: ${Python_LIBRARIES}")
 
+if(BESPOKE_SYSTEM_JSONCPP)
+    find_package(jsoncpp REQUIRED)
+endif()
+
 if(NOT BESPOKE_SYSTEM_JUCE)
   message(STATUS "Using JUCE from ${BESPOKE_JUCE_LOCATION}")
   add_subdirectory(${BESPOKE_JUCE_LOCATION} ${CMAKE_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -824,7 +824,7 @@ endif ()
 target_link_libraries(BespokeSynth PRIVATE
     bespoke::exprtk
     bespoke::freeverb
-    $<IF:$<STREQUAL:${BESPOKE_SYSTEM_JSONCPP},OFF>,bespoke::json,jsoncpp>
+    $<IF:$<STREQUAL:${BESPOKE_SYSTEM_JSONCPP},OFF>,bespoke::json,jsoncpp_lib>
     bespoke::leathers
     bespoke::nanovg
     bespoke::psmove


### PR DESCRIPTION
On some operating systems, in particular Debian and Ubuntu, jsonpp headers do not reside in default header locations. Thus Debian builds with `BESPOKE_SYSTEM_JSONCPP` fail, as jsonpp headers reside under `/usr/include/jsoncpp/` while default header location is `/usr/include/`. A solution would be to ask CMake about jsonpp, which is implemented in this PR. I believe this should improve BespokeSynth's compatibility with operating systems. However, it would be nice to test that on other systems as well. I would be grateful if @dvzrv and @baconpaul could review it as they did with #636.