### PR TITLE
Add a callback for sysex messages in scripts

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -473,8 +473,13 @@ void MidiController::OnMidiPitchBend(MidiPitchBend& pitchBend)
 
 void MidiController::OnMidi(const MidiMessage& message)
 {
-   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !message.isSysEx()))
+   int is_sysex = message.isSysEx();
+   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !is_sysex))
       return;
+   if (is_sysex)
+      for (auto* script : mScriptListeners)
+         script->SysExReceived(message.getSysExData(), message.getSysExDataSize());
+
    mNoteOutput.SendMidi(message);
 }
 

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -895,6 +895,20 @@ void ScriptModule::oscMessageReceived(const OSCMessage& msg)
    RunCode(gTime, "on_osc(\"" + messageString + "\")");
 }
 
+void ScriptModule::SysExReceived(const uint8 * data, int data_size)
+{
+   // Avoid code injection by preventing the sysex payload to be interpreted as Python
+   // - convert the sysex payload to hex
+   // - use bytes.fromhex in Python to parse it
+   std::ostringstream ss;
+   ss << std::setfill('0') << std::setw(2) << std::hex;
+   for (size_t i = 0; i < data_size; i++)
+      ss << (int)data[i];
+   mMidiMessageQueueMutex.lock();
+   mMidiMessageQueue.push_back("on_sysex(bytes.fromhex('" + ss.str() + "'))");
+   mMidiMessageQueueMutex.unlock();
+}
+
 void ScriptModule::MidiReceived(MidiMessageType messageType, int control, float value, int channel)
 {
    mMidiMessageQueueMutex.lock();

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -71,6 +71,7 @@ public:
    double GetScheduledTime(double delayMeasureTime);
    void SetNumNoteOutputs(int num);
    void ConnectOscInput(int port);
+   void SysExReceived(const uint8_t * data, int data_size);
    void MidiReceived(MidiMessageType messageType, int control, float value, int channel);
    void OnModuleReferenceBound(IDrawableModule* target);
    void SetContext();


### PR DESCRIPTION
This allows python scripts to define a `on_sysex(data)` method that get called by the MidiController much like `on_midi`.

It's called for every sysex MIDI event and takes the raw payload as bytes.

I still have to fix some things before this can be merged:

- [ ] Add documentation
- [x] Prevent arbitrary code injection
- [ ] Fix linting issues