### PR TITLE
Propagate keypress in EQModule::KeyPressed method so that cables can be deleted with the key commands. Resolves: #1470.

### DIFF
--- a/Source/EQModule.cpp
+++ b/Source/EQModule.cpp
@@ -415,6 +415,7 @@ bool EQModule::MouseScrolled(float x, float y, float scrollX, float scrollY, boo
 
 void EQModule::KeyPressed(int key, bool isRepeat)
 {
+   IDrawableModule::KeyPressed(key, isRepeat);
    if (mHoveredFilterHandleIndex != -1)
    {
       auto* qSlider = mFilters[mHoveredFilterHandleIndex].mQSlider;


### PR DESCRIPTION
Propagate keypress in EQModule::KeyPressed method so that cables can be deleted with the key commands. Resolves: #1470.