### PR TITLE
trigger OBS build on push only

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,5 @@ workflow:
     - trigger_services:
          project: home:bespokesynth
          package: bespokesynth-nightly
+    - filters:
+         event: push


### PR DESCRIPTION
This should prevent rebuilds and unnecessary OBS checks on any GH event except Push.