### PR TITLE
Added layout for Arturia KeyLab mkII

### DIFF
--- a/resource/userdata_original/controllers/Arturia KeyLab mkII PADS.json
+++ b/resource/userdata_original/controllers/Arturia KeyLab mkII PADS.json
@@ -1,0 +1,18 @@
+{
+	"channelfilter": 10,
+	"groups": [
+		{
+			"rows": 4,
+			"cols": 4,
+			"position": [0, 0],
+			"dimensions": [40, 30],
+			"spacing": [45, 35],
+			"controls": [
+				36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+			],
+			"colors": [0, 127],
+			"messageType": "note",
+			"drawType": "button"
+		}
+	]
+}

--- a/resource/userdata_original/controllers/Arturia KeyLab mkII.json
+++ b/resource/userdata_original/controllers/Arturia KeyLab mkII.json
@@ -1,0 +1,221 @@
+{
+	"channelfilter": 1,
+	"groups": [
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [0, 150],
+			"dimensions": [18, 70],
+			"messageType": "pitchbend",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [30, 150],
+			"dimensions": [18, 70],
+			"controls": [1],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 5,
+			"position": [80, 130],
+			"dimensions": [16, 10],
+			"spacing": [20],
+			"controls": [52, 53, 54, 55, 56],
+			"messageType": "control",
+			"drawType": "button"
+		},
+		{
+			"rows": 1,
+			"cols": 5,
+			"position": [80, 150],
+			"dimensions": [16, 10],
+			"spacing": [20],
+			"controls": [57, 58, 59, 60, 61],
+			"messageType": "control",
+			"drawType": "button"
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [210, 120],
+			"dimensions": [16, 18],
+			"spacing": [20],
+			"controls": [74, 71, 76, 77, 93, 18, 19, 16],
+			"messageType": "control",
+			"drawType": "knob",
+			"incremental": true
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [210, 150],
+			"dimensions": [16, 48],
+			"spacing": [20],
+			"controls": [73, 75, 79, 72, 80, 81, 82, 83],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [210, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [22, 23, 24, 25],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [290, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [26, 27, 28, 29],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [380, 120],
+			"dimensions": [16, 18],
+			"spacing": [20],
+			"controls": [35, 36, 37, 38, 39, 40, 41, 42],
+			"messageType": "control",
+			"drawType": "knob",
+			"incremental": true
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [380, 150],
+			"dimensions": [16, 48],
+			"spacing": [20],
+			"controls": [67, 68, 69, 70, 87, 88, 89, 90],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [380, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [104, 105, 106, 107],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [460, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [108, 109, 110, 111],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [550, 120],
+			"dimensions": [16, 18],
+			"spacing": [20],
+			"controls": [44, 45, 46, 47, 48, 49, 51],
+			"messageType": "control",
+			"drawType": "knob",
+			"incremental": true
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position": [550, 150],
+			"dimensions": [16, 48],
+			"spacing": [20],
+			"controls": [96, 97, 98, 99, 10, 101, 102, 103],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [550, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [112, 113, 114, 115],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 4,
+			"position": [630, 210],
+			"dimensions": [16, 10],
+			"spacing": [20, 12],
+			"controls": [116, 117, 118, 119],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [730, 120],
+			"dimensions": [16, 18],
+			"controls": [17],
+			"messageType": "control",
+			"drawType": "knob",
+			"incremental": true
+		},
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [730, 150],
+			"dimensions": [16, 48],
+			"controls": [85],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [730, 210],
+			"dimensions": [16, 10],
+			"controls": [30],
+			"messageType": "control",
+			"drawType": "button",
+			"connection_type": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 128,
+			"position": [-235, 255],
+			"dimensions": [6, 40],
+			"spacing": [8, 25],
+			"controls": [
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+				18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+				34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+				50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
+				66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
+				82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+				98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+				111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+				124, 125, 126, 127
+			],
+			"messageType": "note",
+			"drawType": "button",
+			"connection_type": "slider"
+		}
+	]
+}


### PR DESCRIPTION
![keylab61mkii-topview-medium_orig](https://github.com/BespokeSynth/BespokeSynth/assets/20223093/82625a22-68e2-45e1-aefa-e75052d3f098)

![image](https://github.com/BespokeSynth/BespokeSynth/assets/20223093/9aca7b29-f13e-4376-8054-48a6e7d9bd2a)

I included all 128 midi notes because the keyboard includes a transpose feature that lets you reach all of them. I could alternatively split the notes into two or three rows, but since this is a keyboard, I felt this way would be the best.

In the zip file linked below are a user mode keymap and a settings preset, both can be loaded with the Arturia MIDI Control Center. Without them, the third bank will not be accessible (there's only 9 physical encoder + fader + button columns) and the rightmost column will not be mapped in the second and third bank, but the rest works with stock settings as well. I could modify this layout such that it is 100% compatible with the stock settings, but they don't utilize all three available banks for some reason, so I feel like this is the best compromise. It would be great if there was a way to guide users to documentation mentioning these presets though.

I only have a KeyLab mkII 61 but this should work on the other versions just fine I think, they only differ in the amount of keys.

[KeyLab mkII Keymap + Settings.zip](https://github.com/BespokeSynth/BespokeSynth/files/14058200/KeyLab.mkII.Keymap.%2B.Settings.zip)
