### PR TITLE
Youtube download fix

### DIFF
--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -625,13 +625,6 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    if (mSample)
       mSample->SetPlayPosition(0);
 
-   auto tempDownloadName = ofToString(this) + "_youtube.m4a";
-   {
-      auto file = juce::File(ofToDataPath(tempDownloadName));
-      if (file.existsAsFile())
-         file.deleteFile();
-   }
-
    auto tempConvertedName = ofToString(this) + "_youtube.wav";
    {
       auto file = juce::File(ofToDataPath(tempConvertedName));
@@ -651,7 +644,7 @@ void SamplePlayer::DownloadYoutube(std::string url, std::string title)
    args.add("--ffmpeg-location");
    args.add(UserPrefs.ffmpeg_path.Get());
    args.add("-o");
-   args.add(ofToDataPath(tempDownloadName));
+   args.add(ofToDataPath(tempConvertedName));
 
    mRunningProcessType = RunningProcessType::DownloadYoutube;
 


### PR DESCRIPTION
Fix for youtube downloading in SamplePlayer when using yt-dlp (audio was saved as .m4a.wav)