### PR TITLE
Fix setting patch target (via scripts) not working for some modules

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -551,7 +551,8 @@ void IDrawableModule::SetTarget(IClickable* target)
 {
    PatchCableSource* source = mMainPatchCableSource;
    size_t idx = 0;
-   while (source == nullptr || !source->Enabled()) {
+   while (source == nullptr || !source->Enabled())
+   {
       // Find first patch cable in the list that's enabled.
       if (!(idx < mPatchCableSources.size()))
          return;

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -1366,3 +1366,13 @@ bool IDrawableModule::IsSpawningOnTheFly(const ofxJSONElement& moduleInfo)
       return false;
    return moduleInfo["onthefly"].asBool();
 }
+
+PatchCableSource* IDrawableModule::GetPatchCableSource(int index)
+{
+   if (index == 0)
+   {
+      if (mMainPatchCableSource != nullptr || mPatchCableSources.empty())
+         return mMainPatchCableSource;
+   }
+   return mPatchCableSources[index];
+}

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -549,10 +549,16 @@ void IDrawableModule::DrawConnection(IClickable* target)
 
 void IDrawableModule::SetTarget(IClickable* target)
 {
-   if (mMainPatchCableSource != nullptr)
-      mMainPatchCableSource->SetTarget(target);
-   else if (!mPatchCableSources.empty())
-      mPatchCableSources[0]->SetTarget(target);
+   PatchCableSource* source = mMainPatchCableSource;
+   size_t idx = 0;
+   while (source == nullptr || !source->Enabled()) {
+      // Find first patch cable in the list that's enabled.
+      if (!(idx < mPatchCableSources.size()))
+         return;
+
+      source = mPatchCableSources[idx++];
+   }
+   source->SetTarget(target);
 }
 
 void IDrawableModule::SetUpPatchCables(std::string targets)

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -189,13 +189,7 @@ public:
    virtual bool DrawToPush2Screen() { return false; }
 
    //IPatchable
-   PatchCableSource* GetPatchCableSource(int index = 0) override
-   {
-      if (index == 0 && (mMainPatchCableSource != nullptr || mPatchCableSources.empty()))
-         return mMainPatchCableSource;
-      else
-         return mPatchCableSources[index];
-   }
+   PatchCableSource* GetPatchCableSource(int index = 0) override;
    std::vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
 
    static void FindClosestSides(float xThis, float yThis, float wThis, float hThis, float xThat, float yThat, float wThat, float hThat, float& startX, float& startY, float& endX, float& endY, bool sidesOnly = false);


### PR DESCRIPTION
This should fix #1539. I had it fixed for 3 days, but I'm just now making the PR.
It might be worthwhile extending the functionality by allowing to select which source to patch (or add a new one), or to change the main source (if that doesn't break anything), but for now it suffices.