### PR TITLE
Fix the default for modwheel.

### DIFF
--- a/Source/ModulationChain.h
+++ b/Source/ModulationChain.h
@@ -73,7 +73,7 @@ struct ModulationParameters
    float pan{ 0 };
 
    static constexpr float kDefaultPitchBend{ 0 };
-   static constexpr float kDefaultModWheel{ .5f };
+   static constexpr float kDefaultModWheel{ 0 };
    static constexpr float kDefaultPressure{ .5f };
 };
 


### PR DESCRIPTION
The default for modwheel should be 0 since this is the "neutral" position of the modwheel. When you push the modwheel to hte max this value will become 2 and when pulling to the min it will become -2.

`0.5` is therefore a incorrect default.