### PR TITLE
PatchCableSource tweaks for a couple modules. Resolves: #1539.

### DIFF
--- a/Source/AudioLevelToCV.cpp
+++ b/Source/AudioLevelToCV.cpp
@@ -54,8 +54,6 @@ void AudioLevelToCV::CreateUIControls()
    FloatSliderUpdated(mAttackSlider, 0, gTime);
    FloatSliderUpdated(mReleaseSlider, 0, gTime);
 
-   RemovePatchCableSource(GetPatchCableSource());
-
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    AddPatchCableSource(mTargetCable);

--- a/Source/AudioLevelToCV.cpp
+++ b/Source/AudioLevelToCV.cpp
@@ -54,7 +54,7 @@ void AudioLevelToCV::CreateUIControls()
    FloatSliderUpdated(mAttackSlider, 0, gTime);
    FloatSliderUpdated(mReleaseSlider, 0, gTime);
 
-   GetPatchCableSource()->SetEnabled(false);
+   RemovePatchCableSource(GetPatchCableSource());
 
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
@@ -148,4 +148,37 @@ void AudioLevelToCV::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void AudioLevelToCV::SetUpFromSaveData()
 {
+}
+
+void AudioLevelToCV::SaveState(FileStreamOut& out)
+{
+   out << GetModuleSaveStateRev();
+
+   IDrawableModule::SaveState(out);
+}
+
+void AudioLevelToCV::LoadState(FileStreamIn& in, int rev)
+{
+   if (rev < 1)
+   {
+      // Temporary additional cable source
+      mTargetCable = new PatchCableSource(this, kConnectionType_Audio);
+      mTargetCable->SetModulatorOwner(this);
+      AddPatchCableSource(mTargetCable);
+   }
+
+   IDrawableModule::LoadState(in, rev);
+
+   if (rev < 1)
+   {
+      auto target = GetPatchCableSource(1)->GetTarget();
+      if (target != nullptr)
+         GetPatchCableSource()->SetTarget(target);
+      RemovePatchCableSource(GetPatchCableSource(1));
+      mTargetCable = GetPatchCableSource();
+   }
+
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 }

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -61,6 +61,9 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
+   void SaveState(FileStreamOut& out) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    bool IsEnabled() const override { return mEnabled; }
 

--- a/Source/AudioLevelToCV.h
+++ b/Source/AudioLevelToCV.h
@@ -42,6 +42,7 @@ public:
    static bool AcceptsAudio() { return true; }
    static bool AcceptsNotes() { return false; }
    static bool AcceptsPulses() { return false; }
+   bool ShouldSuppressAutomaticOutputCable() override { return true; }
 
    void CreateUIControls() override;
 

--- a/Source/AudioToCV.cpp
+++ b/Source/AudioToCV.cpp
@@ -44,8 +44,6 @@ void AudioToCV::CreateUIControls()
    mMinSlider = new FloatSlider(this, "min", mGainSlider, kAnchor_Below, 100, 15, &mDummyMin, 0, 1);
    mMaxSlider = new FloatSlider(this, "max", mMinSlider, kAnchor_Below, 100, 15, &mDummyMax, 0, 1);
 
-   RemovePatchCableSource(GetPatchCableSource());
-
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    AddPatchCableSource(mTargetCable);

--- a/Source/AudioToCV.cpp
+++ b/Source/AudioToCV.cpp
@@ -44,7 +44,7 @@ void AudioToCV::CreateUIControls()
    mMinSlider = new FloatSlider(this, "min", mGainSlider, kAnchor_Below, 100, 15, &mDummyMin, 0, 1);
    mMaxSlider = new FloatSlider(this, "max", mMinSlider, kAnchor_Below, 100, 15, &mDummyMax, 0, 1);
 
-   GetPatchCableSource()->SetEnabled(false);
+   RemovePatchCableSource(GetPatchCableSource());
 
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
@@ -121,4 +121,37 @@ void AudioToCV::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void AudioToCV::SetUpFromSaveData()
 {
+}
+
+void AudioToCV::SaveState(FileStreamOut& out)
+{
+   out << GetModuleSaveStateRev();
+
+   IDrawableModule::SaveState(out);
+}
+
+void AudioToCV::LoadState(FileStreamIn& in, int rev)
+{
+   if (rev < 1)
+   {
+      // Temporary additional cable source
+      mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
+      mTargetCable->SetModulatorOwner(this);
+      AddPatchCableSource(mTargetCable);
+   }
+
+   IDrawableModule::LoadState(in, rev);
+
+   if (rev < 1)
+   {
+      const auto target = GetPatchCableSource(1)->GetTarget();
+      if (target != nullptr)
+         GetPatchCableSource()->SetTarget(target);
+      RemovePatchCableSource(GetPatchCableSource(1));
+      mTargetCable = GetPatchCableSource();
+   }
+
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 }

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -61,6 +61,9 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
+   void SaveState(FileStreamOut& out) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    bool IsEnabled() const override { return mEnabled; }
 

--- a/Source/AudioToCV.h
+++ b/Source/AudioToCV.h
@@ -42,6 +42,7 @@ public:
    static bool AcceptsAudio() { return true; }
    static bool AcceptsNotes() { return false; }
    static bool AcceptsPulses() { return false; }
+   bool ShouldSuppressAutomaticOutputCable() override { return true; }
 
    void CreateUIControls() override;
 

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -39,7 +39,8 @@ void EnvelopeModulator::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
 
-   GetPatchCableSource()->SetEnabled(false);
+   // Remove the note patch cable source
+   RemovePatchCableSource(GetPatchCableSource());
 
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
@@ -172,7 +173,24 @@ void EnvelopeModulator::SaveState(FileStreamOut& out)
 
 void EnvelopeModulator::LoadState(FileStreamIn& in, int rev)
 {
+   if (rev < 1)
+   {
+      // Temporary additional cable source
+      mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
+      mTargetCable->SetModulatorOwner(this);
+      AddPatchCableSource(mTargetCable);
+   }
+
    IDrawableModule::LoadState(in, rev);
+
+   if (rev < 1)
+   {
+      const auto target = GetPatchCableSource(1)->GetTarget();
+      if (target != nullptr)
+         GetPatchCableSource()->SetTarget(target);
+      RemovePatchCableSource(GetPatchCableSource(1));
+      mTargetCable = GetPatchCableSource();
+   }
 
    if (ModularSynth::sLoadingFileSaveStateRev < 423)
       in >> rev;

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -39,9 +39,6 @@ void EnvelopeModulator::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
 
-   // Remove the note patch cable source
-   RemovePatchCableSource(GetPatchCableSource());
-
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    AddPatchCableSource(mTargetCable);

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -85,7 +85,7 @@ public:
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;
-   int GetModuleSaveStateRev() const override { return 0; }
+   int GetModuleSaveStateRev() const override { return 1; }
 
 private:
    void OnClicked(float x, float y, bool right) override;

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -48,6 +48,7 @@ public:
    static bool AcceptsAudio() { return false; }
    static bool AcceptsNotes() { return true; }
    static bool AcceptsPulses() { return true; }
+   bool ShouldSuppressAutomaticOutputCable() override { return true; }
    void Delete() { delete this; }
    void DrawModule() override;
 

--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -83,7 +83,7 @@ void IDrawableModule::CreateUIControls()
       type = kConnectionType_Grid;
    else if (dynamic_cast<IPulseSource*>(this))
       type = kConnectionType_Pulse;
-   
+
    if (type != kConnectionType_Special && !ShouldSuppressAutomaticOutputCable())
    {
       mPatchCableSources.push_back(new PatchCableSource(this, type));

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -137,7 +137,7 @@ public:
       mTypeName = type;
       mModuleCategory = category;
    }
-   void SetTarget(IClickable* target);
+   void SetTarget(IClickable* target, bool skipDisabledCableSource = false);
    void SetUpPatchCables(std::string targets);
    void AddPatchCableSource(PatchCableSource* source);
    void RemovePatchCableSource(PatchCableSource* source);
@@ -189,13 +189,7 @@ public:
    virtual bool DrawToPush2Screen() { return false; }
 
    //IPatchable
-   PatchCableSource* GetPatchCableSource(int index = 0) override
-   {
-      if (index == 0 && (mMainPatchCableSource != nullptr || mPatchCableSources.empty()))
-         return mMainPatchCableSource;
-      else
-         return mPatchCableSources[index];
-   }
+   PatchCableSource* GetPatchCableSource(int index = 0) override;
    std::vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
 
    static void FindClosestSides(float xThis, float yThis, float wThis, float hThis, float xThat, float yThat, float wThat, float hThat, float& startX, float& startY, float& endX, float& endY, bool sidesOnly = false);
@@ -260,7 +254,6 @@ private:
 
    ofMutex mSliderMutex;
 
-   PatchCableSource* mMainPatchCableSource{ nullptr };
    std::vector<PatchCableSource*> mPatchCableSources;
 };
 

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -137,7 +137,7 @@ public:
       mTypeName = type;
       mModuleCategory = category;
    }
-   void SetTarget(IClickable* target, bool skipDisabledCableSource = false);
+   void SetTarget(IClickable* target);
    void SetUpPatchCables(std::string targets);
    void AddPatchCableSource(PatchCableSource* source);
    void RemovePatchCableSource(PatchCableSource* source);
@@ -162,6 +162,7 @@ public:
    bool CanReceiveAudio() { return mCanReceiveAudio; }
    bool CanReceiveNotes() { return mCanReceiveNotes; }
    bool CanReceivePulses() { return mCanReceivePulses; }
+   virtual bool ShouldSuppressAutomaticOutputCable() { return false; }
 
    virtual void CheckboxUpdated(Checkbox* checkbox, double time) {}
 
@@ -189,7 +190,13 @@ public:
    virtual bool DrawToPush2Screen() { return false; }
 
    //IPatchable
-   PatchCableSource* GetPatchCableSource(int index = 0) override;
+   PatchCableSource* GetPatchCableSource(int index = 0) override
+   {
+      if (index == 0 && (mMainPatchCableSource != nullptr || mPatchCableSources.empty()))
+         return mMainPatchCableSource;
+      else
+         return mPatchCableSources[index];
+   }
    std::vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
 
    static void FindClosestSides(float xThis, float yThis, float wThis, float hThis, float xThat, float yThat, float wThat, float hThat, float& startX, float& startY, float& endX, float& endY, bool sidesOnly = false);
@@ -254,6 +261,7 @@ private:
 
    ofMutex mSliderMutex;
 
+   PatchCableSource* mMainPatchCableSource{ nullptr };
    std::vector<PatchCableSource*> mPatchCableSources;
 };
 

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -727,16 +727,16 @@ PYBIND11_EMBEDDED_MODULE(module, m)
          IClickable* target = TheSynth->FindModule(targetPath);
          if (target == nullptr)
             target = TheSynth->FindUIControl(targetPath);
-         module.SetTarget(target, true);
+         module.SetTarget(target);
       })
       .def("set_target", [](IDrawableModule& module, int cableSourceIndex, std::string targetPath)
       {
          IClickable* target = TheSynth->FindModule(targetPath);
          if (target == nullptr)
             target = TheSynth->FindUIControl(targetPath);
-         const auto cable_source = module.GetPatchCableSource(cableSourceIndex);
-         if (cable_source)
-            cable_source->SetTarget(target);
+         const auto cableSource = module.GetPatchCableSource(cableSourceIndex);
+         if (cableSource)
+            cableSource->SetTarget(target);
       })
       .def("get_target", [](IDrawableModule& module)
       {

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -727,7 +727,16 @@ PYBIND11_EMBEDDED_MODULE(module, m)
          IClickable* target = TheSynth->FindModule(targetPath);
          if (target == nullptr)
             target = TheSynth->FindUIControl(targetPath);
-         module.SetTarget(target);
+         module.SetTarget(target, true);
+      })
+      .def("set_target", [](IDrawableModule& module, int cableSourceIndex, std::string targetPath)
+      {
+         IClickable* target = TheSynth->FindModule(targetPath);
+         if (target == nullptr)
+            target = TheSynth->FindUIControl(targetPath);
+         const auto cable_source = module.GetPatchCableSource(cableSourceIndex);
+         if (cable_source)
+            cable_source->SetTarget(target);
       })
       .def("get_target", [](IDrawableModule& module)
       {

--- a/Source/VinylTempoControl.cpp
+++ b/Source/VinylTempoControl.cpp
@@ -48,8 +48,6 @@ void VinylTempoControl::CreateUIControls()
    IDrawableModule::CreateUIControls();
    mUseVinylControlCheckbox = new Checkbox(this, "control", 4, 2, &mUseVinylControl);
 
-   GetPatchCableSource()->SetEnabled(false);
-
    mTargetCable = new PatchCableSource(this, kConnectionType_Modulator);
    mTargetCable->SetModulatorOwner(this);
    AddPatchCableSource(mTargetCable);
@@ -134,6 +132,39 @@ void VinylTempoControl::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void VinylTempoControl::SetUpFromSaveData()
 {
+}
+
+void VinylTempoControl::SaveState(FileStreamOut& out)
+{
+   out << GetModuleSaveStateRev();
+
+   IDrawableModule::SaveState(out);
+}
+
+void VinylTempoControl::LoadState(FileStreamIn& in, int rev)
+{
+   if (rev < 1)
+   {
+      // Temporary additional cable source
+      mTargetCable = new PatchCableSource(this, kConnectionType_Audio);
+      mTargetCable->SetModulatorOwner(this);
+      AddPatchCableSource(mTargetCable);
+   }
+
+   IDrawableModule::LoadState(in, rev);
+
+   if (rev < 1)
+   {
+      auto target = GetPatchCableSource(1)->GetTarget();
+      if (target != nullptr)
+         GetPatchCableSource()->SetTarget(target);
+      RemovePatchCableSource(GetPatchCableSource(1));
+      mTargetCable = GetPatchCableSource();
+   }
+
+   if (ModularSynth::sLoadingFileSaveStateRev < 423)
+      in >> rev;
+   LoadStateValidate(rev <= GetModuleSaveStateRev());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -66,6 +66,7 @@ public:
    static bool AcceptsAudio() { return true; }
    static bool AcceptsNotes() { return false; }
    static bool AcceptsPulses() { return false; }
+   bool ShouldSuppressAutomaticOutputCable() override { return true; }
 
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    void CreateUIControls() override;
@@ -84,6 +85,9 @@ public:
    void SaveLayout(ofxJSONElement& moduleInfo) override;
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
+   void SaveState(FileStreamOut& out) override;
+   void LoadState(FileStreamIn& in, int rev) override;
+   int GetModuleSaveStateRev() const override { return 1; }
 
    bool IsEnabled() const override { return mEnabled; }
 


### PR DESCRIPTION
PatchCableSource tweaks for a couple modules. Resolves: #1539.

- Made it possible to set the target using scripts for the modules: `audiotocv`, `envelope` and `leveltocv`.
- Added a new `set_target` script method with an additional `cableSourceIndex` parameter. 
- Removed hidden main patchcablesource from the modules: `audiotocv`, `envelope` and `leveltocv`.
- Removed the use of a `mMainPatchCableSource` cleaning up the code a bit.

This uses some of the suggestions made in #1544 but is not compatible with that PR (they conflict).
Resolves the same bug but with a multifaceted approach and some code cleanup of runtime data.