### PR TITLE
Add a checkbox to toggle the resetting of the transport on `songbuilder` scene change. Resolves: #1391.

### DIFF
--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -87,8 +87,6 @@ void SongBuilder::CreateUIControls()
    UIBLOCK_SHIFTRIGHT();
    CHECKBOX(mActivateFirstSceneOnStopCheckbox, "activate first scene on stop", &mActivateFirstSceneOnStop);
    UIBLOCK_NEWLINE();
-   CHECKBOX(mResetOnSceneChangeCheckbox, "reset transport", &mResetOnSceneChange);
-   UIBLOCK_NEWLINE();
    BUTTON_STYLE(mPlaySequenceButton, "play", ButtonDisplayStyle::kPlay);
    UIBLOCK_SHIFTRIGHT();
    BUTTON_STYLE(mStopSequenceButton, "stop", ButtonDisplayStyle::kStop);
@@ -153,8 +151,6 @@ void SongBuilder::DrawModule()
    mActivateFirstSceneOnStopCheckbox->SetShowing(ShowSongSequencer());
    mActivateFirstSceneOnStopCheckbox->SetPosition(gridStartX, 3);
    mActivateFirstSceneOnStopCheckbox->Draw();
-   mResetOnSceneChangeCheckbox->SetShowing(ShowSongSequencer());
-   mResetOnSceneChangeCheckbox->Draw();
    mChangeQuantizeSelector->SetPosition(gridStartX, kGridStartY + kTargetTabHeightTop - 29);
    mChangeQuantizeSelector->Draw();
    mAddTargetButton->SetPosition(gridStartX + kSceneTabWidth - 22, kGridStartY + 8);
@@ -832,6 +828,8 @@ void SongBuilder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 
 void SongBuilder::LoadLayout(const ofxJSONElement& moduleInfo)
 {
+   mModuleSaveData.LoadBool("reset_transport_every_sequencer_scene", moduleInfo, true);
+
    if (IsSpawningOnTheFly(moduleInfo))
    {
       mScenes.push_back(new SongScene("off"));
@@ -852,6 +850,7 @@ void SongBuilder::LoadLayout(const ofxJSONElement& moduleInfo)
 
 void SongBuilder::SetUpFromSaveData()
 {
+   mResetOnSceneChange = mModuleSaveData.GetBool("reset_transport_every_sequencer_scene");
 }
 
 void SongBuilder::SaveState(FileStreamOut& out)

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -87,6 +87,8 @@ void SongBuilder::CreateUIControls()
    UIBLOCK_SHIFTRIGHT();
    CHECKBOX(mActivateFirstSceneOnStopCheckbox, "activate first scene on stop", &mActivateFirstSceneOnStop);
    UIBLOCK_NEWLINE();
+   CHECKBOX(mResetOnSceneChangeCheckbox, "reset transport", &mResetOnSceneChange);
+   UIBLOCK_NEWLINE();
    BUTTON_STYLE(mPlaySequenceButton, "play", ButtonDisplayStyle::kPlay);
    UIBLOCK_SHIFTRIGHT();
    BUTTON_STYLE(mStopSequenceButton, "stop", ButtonDisplayStyle::kStop);
@@ -151,6 +153,8 @@ void SongBuilder::DrawModule()
    mActivateFirstSceneOnStopCheckbox->SetShowing(ShowSongSequencer());
    mActivateFirstSceneOnStopCheckbox->SetPosition(gridStartX, 3);
    mActivateFirstSceneOnStopCheckbox->Draw();
+   mResetOnSceneChangeCheckbox->SetShowing(ShowSongSequencer());
+   mResetOnSceneChangeCheckbox->Draw();
    mChangeQuantizeSelector->SetPosition(gridStartX, kGridStartY + kTargetTabHeightTop - 29);
    mChangeQuantizeSelector->Draw();
    mAddTargetButton->SetPosition(gridStartX + kSceneTabWidth - 22, kGridStartY + 8);
@@ -318,7 +322,8 @@ void SongBuilder::OnTimeEvent(double time)
          else
          {
             SetActiveSceneById(time, mSequencerSceneId[mSequenceStepIndex]);
-            mWantResetClock = true;
+            if (mResetOnSceneChange)
+               mWantResetClock = true;
          }
       }
    }

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -199,6 +199,8 @@ private:
 
    bool mUseSequencer{ false };
    Checkbox* mUseSequencerCheckbox{ nullptr };
+   bool mResetOnSceneChange{ false };
+   Checkbox* mResetOnSceneChangeCheckbox{ nullptr };
    bool mActivateFirstSceneOnStop{ true };
    Checkbox* mActivateFirstSceneOnStopCheckbox{ nullptr };
    NoteInterval mChangeQuantizeInterval{ NoteInterval::kInterval_1n };

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -199,8 +199,7 @@ private:
 
    bool mUseSequencer{ false };
    Checkbox* mUseSequencerCheckbox{ nullptr };
-   bool mResetOnSceneChange{ false };
-   Checkbox* mResetOnSceneChangeCheckbox{ nullptr };
+   bool mResetOnSceneChange{ true };
    bool mActivateFirstSceneOnStop{ true };
    Checkbox* mActivateFirstSceneOnStopCheckbox{ nullptr };
    NoteInterval mChangeQuantizeInterval{ NoteInterval::kInterval_1n };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2008,6 +2008,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 
 songbuilder~large-scale organizer to arrange settings into scenes and then sequence them. this is bespoke's "song mode"
 ~use sequencer~show scene sequencer
+~reset transport~reset tranport when switching scenes
 ~activate first scene on stop~when stopping, activate the first scene. it is recommended that you use the first scene as an "off" scene, and have it disable all song elements.
 ~play~play the sequence
 ~stop~stop the sequence

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2008,7 +2008,6 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 
 songbuilder~large-scale organizer to arrange settings into scenes and then sequence them. this is bespoke's "song mode"
 ~use sequencer~show scene sequencer
-~reset transport~reset tranport when switching scenes
 ~activate first scene on stop~when stopping, activate the first scene. it is recommended that you use the first scene as an "off" scene, and have it disable all song elements.
 ~play~play the sequence
 ~stop~stop the sequence


### PR DESCRIPTION
Add a checkbox to toggle the resetting of the transport on `songbuilder` scene change. Resolves: #1391.
This allows for polymeters and not transport locked sequencers while using the `songbuilder`.

The default is currently not to reset transport which is different behavior from before this patch but to me this behavior seems more intuitive (but if you want the original as default it is a simple change).