### PR TITLE
Remove mMainPatchCableSource entirely

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -549,19 +549,18 @@ void IDrawableModule::DrawConnection(IClickable* target)
 
 void IDrawableModule::SetTarget(IClickable* target)
 {
-   if (mMainPatchCableSource != nullptr)
-      mMainPatchCableSource->SetTarget(target);
-   else if (!mPatchCableSources.empty())
+   if (!mPatchCableSources.empty())
       mPatchCableSources[0]->SetTarget(target);
 }
 
 void IDrawableModule::SetUpPatchCables(std::string targets)
 {
-   assert(mMainPatchCableSource != nullptr);
+   PatchCableSource* source = GetPatchCableSource();
+   assert(source != nullptr);
    std::vector<std::string> targetVec = ofSplitString(targets, ",");
    if (targetVec.empty() || targets == "")
    {
-      mMainPatchCableSource->Clear();
+      source->Clear();
    }
    else
    {
@@ -569,7 +568,7 @@ void IDrawableModule::SetUpPatchCables(std::string targets)
       {
          IClickable* target = dynamic_cast<IClickable*>(TheSynth->FindModule(targetVec[i]));
          if (target)
-            mMainPatchCableSource->AddPatchCable(target);
+            source->AddPatchCable(target);
       }
    }
 }

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -192,10 +192,9 @@ public:
    //IPatchable
    PatchCableSource* GetPatchCableSource(int index = 0) override
    {
-      if (index == 0 && (mMainPatchCableSource != nullptr || mPatchCableSources.empty()))
-         return mMainPatchCableSource;
-      else
+      if (index < mPatchCableSources.size())
          return mPatchCableSources[index];
+      return nullptr;
    }
    std::vector<PatchCableSource*> GetPatchCableSources() { return mPatchCableSources; }
 
@@ -261,7 +260,6 @@ private:
 
    ofMutex mSliderMutex;
 
-   PatchCableSource* mMainPatchCableSource{ nullptr };
    std::vector<PatchCableSource*> mPatchCableSources;
 };
 


### PR DESCRIPTION
As mentioned in https://github.com/BespokeSynth/BespokeSynth/pull/1548#issuecomment-2004061003, reintroduction of `mMainPatchCableSource` wasn't necessary, as it wasn't set anymore. This also fixes a crash when calling `SetUpPatchCables` because it required `mMainPatchCableSource` to be set.