### PR TITLE
VST node placement in Debug: Assert fix

### DIFF
--- a/Source/VSTPlayhead.cpp
+++ b/Source/VSTPlayhead.cpp
@@ -33,8 +33,16 @@ juce::Optional<juce::AudioPlayHead::PositionInfo> VSTPlayhead::getPosition() con
    juce::AudioPlayHead::LoopPoints loopPoint;
    timeSignature.numerator = TheTransport->GetTimeSigTop();
    timeSignature.denominator = TheTransport->GetTimeSigBottom();
+
+   juce::Optional<juce::AudioPlayHead::TimeSignature> posTM = pos.getTimeSignature();
+
    loopPoint.ppqStart = 0;
-   loopPoint.ppqEnd = 480 * pos.getTimeSignature()->denominator;
+   loopPoint.ppqEnd = 480;
+
+   if (posTM)
+   {
+      loopPoint.ppqEnd *= posTM->denominator;
+   }
 
    pos.setBpm(TheTransport->GetTempo());
    pos.setTimeSignature(timeSignature);


### PR DESCRIPTION
Fix for Pos sometimes having a null time signature, and causing assert in Debug when you place a VST node