### PR TITLE
Added new voicesetter node

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -701,6 +701,8 @@ target_sources(BespokeSynth PRIVATE
     Vocoder.h
     VocoderCarrierInput.cpp
     VocoderCarrierInput.h
+    VoiceSetter.cpp
+    VoiceSetter.h
     VolcaBeatsControl.cpp
     VolcaBeatsControl.h
     WaveformViewer.cpp

--- a/Source/ModuleFactory.cpp
+++ b/Source/ModuleFactory.cpp
@@ -262,6 +262,7 @@
 #include "PitchToValue.h"
 #include "RhythmSequencer.h"
 #include "DotSequencer.h"
+#include "VoiceSetter.h"
 
 #include <juce_core/juce_core.h>
 
@@ -471,6 +472,7 @@ ModuleFactory::ModuleFactory()
    REGISTER(PitchToValue, pitchtovalue, kModuleCategory_Modulator);
    REGISTER(RhythmSequencer, rhythmsequencer, kModuleCategory_Note);
    REGISTER(DotSequencer, dotsequencer, kModuleCategory_Instrument);
+   REGISTER(VoiceSetter, voicesetter, kModuleCategory_Note);
 
    //REGISTER_EXPERIMENTAL(MidiPlayer, midiplayer, kModuleCategory_Instrument);
    REGISTER_HIDDEN(Autotalent, autotalent, kModuleCategory_Audio);

--- a/Source/VoiceSetter.cpp
+++ b/Source/VoiceSetter.cpp
@@ -30,12 +30,11 @@ void VoiceSetter::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
 
-   mVoiceSlider = new IntSlider(this, "Voice Index", 5, 2, 80, 15, &mVoiceIdx, 0, kMaxJuceMidiChannels - 1);
+   mVoiceSlider = new IntSlider(this, "voice index", 5, 2, 80, 15, &mVoiceIdx, 0, kNumVoices - 1);
 }
 
 void VoiceSetter::DrawModule()
 {
-
    if (Minimized() || IsVisible() == false)
       return;
 
@@ -65,10 +64,4 @@ void VoiceSetter::LoadLayout(const ofxJSONElement& moduleInfo)
 void VoiceSetter::SetUpFromSaveData()
 {
    SetUpPatchCables(mModuleSaveData.GetString("target"));
-}
-
-void VoiceSetter::Resize(float w, float h)
-{
-   mWidth = w;
-   mHeight = h;
 }

--- a/Source/VoiceSetter.cpp
+++ b/Source/VoiceSetter.cpp
@@ -1,0 +1,74 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  VoiceSetter.cpp
+//  Bespoke
+//
+//  Created by Ryan Challinor on 6/17/15.
+//
+//
+
+#include "VoiceSetter.h"
+#include "SynthGlobals.h"
+
+void VoiceSetter::CreateUIControls()
+{
+   IDrawableModule::CreateUIControls();
+
+   mVoiceSlider = new IntSlider(this, "Voice Index", 5, 2, 80, 15, &mVoiceIdx, 0, kMaxJuceMidiChannels - 1);
+}
+
+void VoiceSetter::DrawModule()
+{
+
+   if (Minimized() || IsVisible() == false)
+      return;
+
+   mVoiceSlider->Draw();
+}
+
+void VoiceSetter::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
+{
+   if (slider == mVoiceSlider)
+      mNoteOutput.Flush(time);
+}
+
+void VoiceSetter::PlayNote(double time, int pitch, int velocity, int voiceIdx, ModulationParameters modulation)
+{
+   voiceIdx = mVoiceIdx;
+
+   PlayNoteOutput(time, pitch, velocity, voiceIdx, modulation);
+}
+
+void VoiceSetter::LoadLayout(const ofxJSONElement& moduleInfo)
+{
+   mModuleSaveData.LoadString("target", moduleInfo);
+
+   SetUpFromSaveData();
+}
+
+void VoiceSetter::SetUpFromSaveData()
+{
+   SetUpPatchCables(mModuleSaveData.GetString("target"));
+}
+
+void VoiceSetter::Resize(float w, float h)
+{
+   mWidth = w;
+   mHeight = h;
+}

--- a/Source/VoiceSetter.h
+++ b/Source/VoiceSetter.h
@@ -1,0 +1,74 @@
+/**
+    bespoke synth, a software modular synthesizer
+    Copyright (C) 2021 Ryan Challinor (contact: awwbees@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+//
+//  VoiceSetter.h
+//  Bespoke
+//
+//  Created by Ryan Challinor on 6/17/15.
+//
+//
+
+#ifndef __Bespoke__VoiceSetter__
+#define __Bespoke__VoiceSetter__
+
+#include "NoteEffectBase.h"
+
+class VoiceSetter : public NoteEffectBase, public IDrawableModule, public IIntSliderListener
+{
+public:
+   VoiceSetter() = default;
+   static IDrawableModule* Create() { return new VoiceSetter(); }
+   static bool AcceptsAudio() { return false; }
+   static bool AcceptsNotes() { return true; }
+   static bool AcceptsPulses() { return false; }
+
+   void CreateUIControls() override;
+
+   //INoteReceiver
+   void PlayNote(double time, int pitch, int velocity, int voiceIdx = -1, ModulationParameters modulation = ModulationParameters()) override;
+
+   void LoadLayout(const ofxJSONElement& moduleInfo) override;
+   void SetUpFromSaveData() override;
+
+   bool IsResizable() const override { return true; }
+   void Resize(float w, float h) override;
+
+   bool IsEnabled() const override { return true; }
+
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
+
+private:
+   //IDrawableModule
+   void DrawModule() override;
+
+   void GetModuleDimensions(float& width, float& height) override
+   {
+      width = mWidth;
+      height = mHeight;
+   }
+
+   static const int kMaxJuceMidiChannels = 16;
+
+   float mWidth{ 90 };
+   float mHeight{ 20 };
+
+   int mVoiceIdx{ 0 };
+   IntSlider* mVoiceSlider{ nullptr };
+};
+
+#endif /* defined(__Bespoke__VoiceSetter__) */

--- a/Source/VoiceSetter.h
+++ b/Source/VoiceSetter.h
@@ -45,9 +45,6 @@ public:
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
 
-   bool IsResizable() const override { return true; }
-   void Resize(float w, float h) override;
-
    bool IsEnabled() const override { return true; }
 
    void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
@@ -61,8 +58,6 @@ private:
       width = mWidth;
       height = mHeight;
    }
-
-   static const int kMaxJuceMidiChannels = 16;
 
    float mWidth{ 90 };
    float mHeight{ 20 };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -747,7 +747,7 @@ vocoder~frequency band-based vocoder. this must be paired with a "vocodercarrier
 
 
 voicesetter~set a specific Voice channel index for a note
-~Voice Index~current set voice channel index
+~voice index~current set voice channel index
 
 
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -746,6 +746,10 @@ vocoder~frequency band-based vocoder. this must be paired with a "vocodercarrier
 ~ring~how long it should take the bands to "cool down"
 
 
+voicesetter~set a specific Voice channel index for a note
+~Voice Index~current set voice channel index
+
+
 
 takerecorder~[abandoned module, possibly broken]
 ~start~[todo]


### PR DESCRIPTION
Added new voicesetter node for setting the voice channel on notes. 

This is useful in combination with UseVoicesAsChannel on the VST plugin node as some plugins (like Kontakt) let you send different midi channels to different instruments, which is good alternative in some cases to duplicating the VST node in Bespoke for each instrument (some VSTs are quite CPU heavy).