### PR TITLE
Simplify polyphony manager - part 1

### DIFF
--- a/Source/FMSynth.cpp
+++ b/Source/FMSynth.cpp
@@ -64,7 +64,11 @@ FMSynth::FMSynth()
    mVoiceParams.mPhaseOffset2 = 0;
    mVoiceParams.mVol = 1.f;
 
-   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new FMVoice(owner)); }, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner)
+                 {
+                    return std::unique_ptr<IMidiVoice>(new FMVoice(owner));
+                 },
+                 &mVoiceParams);
 }
 
 void FMSynth::CreateUIControls()

--- a/Source/FMSynth.cpp
+++ b/Source/FMSynth.cpp
@@ -64,7 +64,7 @@ FMSynth::FMSynth()
    mVoiceParams.mPhaseOffset2 = 0;
    mVoiceParams.mVol = 1.f;
 
-   mPolyMgr.Init(kVoiceType_FM, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new FMVoice(owner)); }, &mVoiceParams);
 }
 
 void FMSynth::CreateUIControls()

--- a/Source/IMidiVoice.h
+++ b/Source/IMidiVoice.h
@@ -27,7 +27,6 @@
 #define additiveSynth_IMidiVoice_h
 
 #include "ModulationChain.h"
-#include "Profiler.h"
 
 class IVoiceParams;
 

--- a/Source/KarplusStrong.cpp
+++ b/Source/KarplusStrong.cpp
@@ -24,7 +24,6 @@
 //
 
 #include "KarplusStrong.h"
-#include "OpenFrameworksPort.h"
 #include "SynthGlobals.h"
 #include "IAudioReceiver.h"
 #include "ModularSynth.h"
@@ -36,7 +35,7 @@ KarplusStrong::KarplusStrong()
 , mNoteInputBuffer(this)
 , mWriteBuffer(gBufferSize)
 {
-   mPolyMgr.Init(kVoiceType_Karplus, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new KarplusStrongVoice(owner)); }, &mVoiceParams);
 
    AddChild(&mBiquad);
    mBiquad.SetPosition(150, 15);

--- a/Source/KarplusStrong.cpp
+++ b/Source/KarplusStrong.cpp
@@ -35,7 +35,11 @@ KarplusStrong::KarplusStrong()
 , mNoteInputBuffer(this)
 , mWriteBuffer(gBufferSize)
 {
-   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new KarplusStrongVoice(owner)); }, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner)
+                 {
+                    return std::unique_ptr<IMidiVoice>(new KarplusStrongVoice(owner));
+                 },
+                 &mVoiceParams);
 
    AddChild(&mBiquad);
    mBiquad.SetPosition(150, 15);

--- a/Source/PolyphonyMgr.cpp
+++ b/Source/PolyphonyMgr.cpp
@@ -25,10 +25,6 @@
 
 #include "PolyphonyMgr.h"
 #include "IMidiVoice.h"
-#include "FMVoice.h"
-#include "KarplusStrongVoice.h"
-#include "SingleOscillatorVoice.h"
-#include "SampleVoice.h"
 #include "SynthGlobals.h"
 #include "Profiler.h"
 
@@ -39,43 +35,12 @@ PolyphonyMgr::PolyphonyMgr(IDrawableModule* owner)
 {
 }
 
-void PolyphonyMgr::Init(VoiceType type, IVoiceParams* params)
+void PolyphonyMgr::Init(VoiceConstructor type, IVoiceParams* params)
 {
-   if (type == kVoiceType_FM)
+   for (int i = 0; i < kNumVoices; ++i)
    {
-      for (int i = 0; i < kNumVoices; ++i)
-      {
-         mVoices[i].mVoice = new FMVoice(mOwner);
-         mVoices[i].mVoice->SetVoiceParams(params);
-      }
-   }
-   else if (type == kVoiceType_Karplus)
-   {
-      for (int i = 0; i < kNumVoices; ++i)
-      {
-         mVoices[i].mVoice = new KarplusStrongVoice(mOwner);
-         mVoices[i].mVoice->SetVoiceParams(params);
-      }
-   }
-   else if (type == kVoiceType_SingleOscillator)
-   {
-      for (int i = 0; i < kNumVoices; ++i)
-      {
-         mVoices[i].mVoice = new SingleOscillatorVoice(mOwner);
-         mVoices[i].mVoice->SetVoiceParams(params);
-      }
-   }
-   else if (type == kVoiceType_Sampler)
-   {
-      for (int i = 0; i < kNumVoices; ++i)
-      {
-         mVoices[i].mVoice = new SampleVoice(mOwner);
-         mVoices[i].mVoice->SetVoiceParams(params);
-      }
-   }
-   else
-   {
-      assert(false); //unsupported voice type
+      mVoices[i].mVoice = type(mOwner);
+      mVoices[i].mVoice->SetVoiceParams(params);
    }
 }
 

--- a/Source/PolyphonyMgr.cpp
+++ b/Source/PolyphonyMgr.cpp
@@ -39,12 +39,6 @@ PolyphonyMgr::PolyphonyMgr(IDrawableModule* owner)
 {
 }
 
-PolyphonyMgr::~PolyphonyMgr()
-{
-   for (int i = 0; i < kNumVoices; ++i)
-      delete mVoices[i].mVoice;
-}
-
 void PolyphonyMgr::Init(VoiceType type, IVoiceParams* params)
 {
    if (type == kVoiceType_FM)
@@ -127,13 +121,13 @@ void PolyphonyMgr::Start(double time, int pitch, float amount, int voiceIdx, Mod
       }
    }
 
-   IMidiVoice* voice = mVoices[voiceIdx].mVoice;
-   assert(voice);
-   if (!voice->IsDone(time) && (!preserveVoice || modulation.pan != voice->GetPan()))
+   assert(mVoices[voiceIdx].mVoice);
+   IMidiVoice& voice = *mVoices[voiceIdx].mVoice;
+   if (!voice.IsDone(time) && (!preserveVoice || modulation.pan != voice.GetPan()))
    {
       //ofLog() << "fading stolen voice " << voiceIdx << " at " << time;
       mFadeOutWorkBuffer.Clear();
-      voice->Process(time, &mFadeOutWorkBuffer, mOversampling);
+      voice.Process(time, &mFadeOutWorkBuffer, mOversampling);
       for (int i = 0; i < kVoiceFadeSamples; ++i)
       {
          float fade = 1 - (float(i) / kVoiceFadeSamples);
@@ -142,11 +136,11 @@ void PolyphonyMgr::Start(double time, int pitch, float amount, int voiceIdx, Mod
       }
    }
    if (!preserveVoice)
-      voice->ClearVoice();
-   voice->SetPitch(pitch);
-   voice->SetModulators(modulation);
-   voice->Start(time, amount);
-   voice->SetPan(modulation.pan);
+      voice.ClearVoice();
+   voice.SetPitch(pitch);
+   voice.SetModulators(modulation);
+   voice.Start(time, amount);
+   voice.SetPan(modulation.pan);
    mLastVoice = voiceIdx;
 
    mVoices[voiceIdx].mPitch = pitch;

--- a/Source/PolyphonyMgr.h
+++ b/Source/PolyphonyMgr.h
@@ -72,7 +72,6 @@ private:
    int mLastVoice{ -1 };
    ChannelBuffer mFadeOutBuffer{ kVoiceFadeSamples };
    ChannelBuffer mFadeOutWorkBuffer{ kVoiceFadeSamples };
-   float mWorkBuffer[2048]{};
    int mFadeOutBufferPos{ 0 };
    IDrawableModule* mOwner;
    int mVoiceLimit{ kNumVoices };

--- a/Source/PolyphonyMgr.h
+++ b/Source/PolyphonyMgr.h
@@ -26,8 +26,7 @@
 #ifndef __additiveSynth__PolyphonyMgr__
 #define __additiveSynth__PolyphonyMgr__
 
-#include <iostream>
-#include "OpenFrameworksPort.h"
+#include <memory>
 #include "SynthGlobals.h"
 #include "ChannelBuffer.h"
 
@@ -51,7 +50,7 @@ enum VoiceType
 struct VoiceInfo
 {
    float mPitch{ -1 };
-   IMidiVoice* mVoice{ nullptr };
+   std::unique_ptr<IMidiVoice> mVoice{ nullptr };
    double mTime{ 0 };
    bool mNoteOn{ false };
    float mActivity{ 0 };
@@ -61,7 +60,6 @@ class PolyphonyMgr
 {
 public:
    PolyphonyMgr(IDrawableModule* owner);
-   ~PolyphonyMgr();
 
    void Init(VoiceType type,
              IVoiceParams* mVoiceParams);

--- a/Source/PolyphonyMgr.h
+++ b/Source/PolyphonyMgr.h
@@ -39,14 +39,6 @@ class IVoiceParams;
 class IDrawableModule;
 struct ModulationParameters;
 
-enum VoiceType
-{
-   kVoiceType_Karplus,
-   kVoiceType_FM,
-   kVoiceType_SingleOscillator,
-   kVoiceType_Sampler
-};
-
 struct VoiceInfo
 {
    float mPitch{ -1 };
@@ -56,12 +48,14 @@ struct VoiceInfo
    float mActivity{ 0 };
 };
 
+using VoiceConstructor = std::unique_ptr<IMidiVoice> (*)(IDrawableModule* owner);
+
 class PolyphonyMgr
 {
 public:
    PolyphonyMgr(IDrawableModule* owner);
 
-   void Init(VoiceType type,
+   void Init(VoiceConstructor type,
              IVoiceParams* mVoiceParams);
 
    void Start(double time, int pitch, float amount, int voiceIdx, ModulationParameters modulation);

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -50,7 +50,11 @@ Sampler::Sampler()
    mVoiceParams.mDetectedFreq = -1;
    mVoiceParams.mLoop = false;
 
-   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new SampleVoice(owner)); }, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner)
+                 {
+                    return std::unique_ptr<IMidiVoice>(new SampleVoice(owner));
+                 },
+                 &mVoiceParams);
 
    //mWriteBuffer.SetNumActiveChannels(2);
 }

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -50,7 +50,7 @@ Sampler::Sampler()
    mVoiceParams.mDetectedFreq = -1;
    mVoiceParams.mLoop = false;
 
-   mPolyMgr.Init(kVoiceType_Sampler, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new SampleVoice(owner)); }, &mVoiceParams);
 
    //mWriteBuffer.SetNumActiveChannels(2);
 }

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -59,7 +59,7 @@ SingleOscillator::SingleOscillator()
    mVoiceParams.mSoften = 0;
    mVoiceParams.mLiteCPUMode = false;
 
-   mPolyMgr.Init(kVoiceType_SingleOscillator, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new SingleOscillatorVoice(owner)); }, &mVoiceParams);
 }
 
 namespace

--- a/Source/SingleOscillator.cpp
+++ b/Source/SingleOscillator.cpp
@@ -59,7 +59,11 @@ SingleOscillator::SingleOscillator()
    mVoiceParams.mSoften = 0;
    mVoiceParams.mLiteCPUMode = false;
 
-   mPolyMgr.Init([](IDrawableModule* owner){ return std::unique_ptr<IMidiVoice>(new SingleOscillatorVoice(owner)); }, &mVoiceParams);
+   mPolyMgr.Init([](IDrawableModule* owner)
+                 {
+                    return std::unique_ptr<IMidiVoice>(new SingleOscillatorVoice(owner));
+                 },
+                 &mVoiceParams);
 }
 
 namespace


### PR DESCRIPTION
I wanted to use `PolyphonyMgr`'s functionality to implement a certain fun feature :)
Although I need to refactor & split it first to decouple it from voice playback.
This PR un-hardcodes selecting voice type by replacing the voice type enum with passed-in constructor function.