### PR TITLE
collection of minor fixes

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -3245,6 +3245,7 @@ IDrawableModule* ModularSynth::SpawnModuleOnTheFly(ModuleFactory::Spawnable spaw
    {
       std::string presetFilePath = ofToDataPath("presets/" + spawnable.mPresetModuleType + "/" + spawnable.mLabel);
       ModuleSaveDataPanel::LoadPreset(module, presetFilePath);
+      module->SetName(GetUniqueName(juce::String(spawnable.mLabel).replace(".preset", "").toStdString(), modules).c_str());
    }
 
    return module;

--- a/Source/PulseSequence.cpp
+++ b/Source/PulseSequence.cpp
@@ -160,7 +160,7 @@ void PulseSequence::Step(double time, float velocity, int flags)
    else if (flags & kPulseFlag_Random)
       mStep = gRandom() % mLength;
 
-   if (flags & kPulseFlag_SyncToTransport)
+   if (!mHasExternalPulseSource || (flags & kPulseFlag_SyncToTransport))
    {
       mStep = TheTransport->GetSyncedStep(time, this, mTransportListenerInfo, mLength);
    }

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -110,6 +110,7 @@ private:
    IntSlider* mResetLengthSlider{ nullptr };
    int mCustomDivisor{ 8 };
    IntSlider* mCustomDivisorSlider{ nullptr };
+   ClickButton* mRestartFreeTimeButton{ nullptr };
 
    TransportListenerInfo* mTransportListenerInfo{ nullptr };
 };

--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -222,26 +222,26 @@ void DrawAudioBuffer(float width, float height, const float* buffer, float start
    ofPopStyle();
 }
 
-void Add(float* buff1, const float* buff2, int bufferSize)
+void Add(float* dst, const float* src, int bufferSize)
 {
 #ifdef USE_VECTOR_OPS
-   FloatVectorOperations::add(buff1, buff2, bufferSize);
+   FloatVectorOperations::add(dst, src, bufferSize);
 #else
    for (int i = 0; i < bufferSize; ++i)
    {
-      buff1[i] += buff2[i];
+      dst[i] += src[i];
    }
 #endif
 }
 
-void Subtract(float* buff1, const float* buff2, int bufferSize)
+void Subtract(float* dst, const float* src, int bufferSize)
 {
 #ifdef USE_VECTOR_OPS
-   FloatVectorOperations::subtract(buff1, buff2, bufferSize);
+   FloatVectorOperations::subtract(dst, src, bufferSize);
 #else
    for (int i = 0; i < bufferSize; ++i)
    {
-      buff1[i] -= buff2[i];
+      dst[i] -= src[i];
    }
 #endif
 }
@@ -258,14 +258,14 @@ void Mult(float* buff, float val, int bufferSize)
 #endif
 }
 
-void Mult(float* buff1, const float* buff2, int bufferSize)
+void Mult(float* dst, const float* src, int bufferSize)
 {
 #ifdef USE_VECTOR_OPS
-   FloatVectorOperations::multiply(buff1, buff2, bufferSize);
+   FloatVectorOperations::multiply(dst, src, bufferSize);
 #else
    for (int i = 0; i < bufferSize; ++i)
    {
-      buff1[i] *= buff2[i];
+      dst[i] *= src[i];
    }
 #endif
 }

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -507,9 +507,9 @@ void TitleBar::DrawModuleUnclipped()
          ofVec2f pos(50, ofGetHeight() / GetOwningContainer()->GetDrawScale() - 100);
          const float kWidth = 600;
          const float kHeight = 70;
-         ofSetColor(80, 80, 80);
+         ofSetColor(80, 80, 80, 150);
          ofRect(pos.x, pos.y, kWidth, kHeight);
-         ofSetColor(120, 120, 120);
+         ofSetColor(120, 120, 120, 150);
          ofRect(pos.x, pos.y, kWidth * drawControl->GetMidiValue(), kHeight);
          ofSetColor(255, 255, 255);
          DrawTextBold(displayString, pos.x + 20, pos.y + 50, 40);

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -209,6 +209,7 @@ pulser~send pulse messages at an interval
 ~random~tell pulsed modules to randomize their position
 ~reset~length of sequence before sending reset pulse
 ~div~measure division, when using "div" as the interval
+~restart~restart timer on "free" counter
 
 
 


### PR DESCRIPTION
- make pulser "free" mode timer restartable
- make pulsesequence step default to aligning to global transport, like other similar devices
- adjust transparency of midi slider interaction popup
- make spawned presets use the filename as their default name
- change variable names in Add(), Subtract(), and Mult() for clarity
