### PR TITLE
Adds the ability for the user to configure their visual Frame Rate

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -323,7 +323,8 @@ public:
          }
       }
 
-      startTimerHz(60);
+      UserPrefs.LastTargetFramerate = UserPrefs.target_framerate.Get();
+      startTimerHz(UserPrefs.target_framerate.Get());
    }
 
    void shutdown() override
@@ -343,6 +344,13 @@ public:
          return;
 
       mSynth.LockRender(true);
+
+      if (UserPrefs.LastTargetFramerate != UserPrefs.target_framerate.Get())
+      {
+         stopTimer();
+         UserPrefs.LastTargetFramerate = UserPrefs.target_framerate.Get();
+         startTimerHz(UserPrefs.target_framerate.Get());
+      }
 
       juce::Point<int> mouse = Desktop::getMousePosition();
       mouse -= mScreenPosition;

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -287,9 +287,9 @@ public:
 
    static std::string ToStringLeadingZeroes(int number);
 
+   float LastTargetFramerate;
    ofxJSONElement mUserPrefsFile;
    std::vector<UserPref*> mUserPrefs;
-
    UserPrefDropdownString devicetype{ "devicetype", "auto", 200, UserPrefCategory::General };
    UserPrefDropdownString audio_output_device{ "audio_output_device", "auto", 350, UserPrefCategory::General };
    UserPrefDropdownString audio_input_device{ "audio_input_device", "none", 350, UserPrefCategory::General };
@@ -330,11 +330,11 @@ public:
    UserPrefFloat background_r{ "background_r", 0.09f, 0, 1, UserPrefCategory::Graphics };
    UserPrefFloat background_g{ "background_g", 0.09f, 0, 1, UserPrefCategory::Graphics };
    UserPrefFloat background_b{ "background_b", 0.09f, 0, 1, UserPrefCategory::Graphics };
+   UserPrefFloat target_framerate{ "target_framerate", 60, 30, 144, UserPrefCategory::Graphics };
    UserPrefFloat motion_trails{ "motion_trails", 1, 0, 2, UserPrefCategory::Graphics };
    UserPrefBool draw_module_highlights{ "draw_module_highlights", true, UserPrefCategory::Graphics };
    UserPrefTextEntryFloat mouse_offset_x{ "mouse_offset_x", 0, -100, 100, 5, UserPrefCategory::Graphics };
-   UserPrefTextEntryFloat mouse_offset_y
-   {
+   UserPrefTextEntryFloat mouse_offset_y{
       "mouse_offset_y",
 #if BESPOKE_MAC
       -4,


### PR DESCRIPTION
Handy for a smoother appearance on high refresh rate monitors, or also for squeezing more CPU cycles out of an intense music session.

Default frame rate remains 60.

Wishlisted on #1466

https://github.com/BespokeSynth/BespokeSynth/assets/42283444/ad41705a-1967-44b4-9f0c-aaca1c6df477
