### PR TITLE
Add memory block & custom stream API to `FileStream`s

### DIFF
--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -29,7 +29,8 @@
 //static
 bool FileStreamIn::s32BitMode = false;
 
-static std::unique_ptr<juce::FileOutputStream> MakeFileOutStream(const std::string& path) {
+static std::unique_ptr<juce::FileOutputStream> MakeFileOutStream(const std::string& path)
+{
    auto stream = std::make_unique<juce::FileOutputStream>(juce::File{ path });
    stream->setPosition(0);
    stream->truncate();

--- a/Source/FileStream.cpp
+++ b/Source/FileStream.cpp
@@ -155,23 +155,24 @@ FileStreamIn& FileStreamIn::operator>>(double& var)
 
 FileStreamIn& FileStreamIn::operator>>(std::string& var)
 {
-   uint64_t len;
+   uint64_t len64;
    if (s32BitMode)
    {
       uint32_t len32;
       mStream->read(&len32, sizeof(len32));
-      len = len32;
+      len64 = len32;
    }
    else
    {
-      mStream->read(&len, sizeof(len));
+      mStream->read(&len64, sizeof(len64));
    }
 
    if (TheSynth->IsLoadingModule())
-      LoadStateValidate(len < sMaxStringLength); //probably garbage beyond this point
+      LoadStateValidate(len64 < sMaxStringLength); //probably garbage beyond this point
    else
-      assert(len < sMaxStringLength); //probably garbage beyond this point
+      assert(len64 < sMaxStringLength); //probably garbage beyond this point
 
+   size_t len = len64;
    var.resize(len);
    mStream->read(var.data(), len);
    return *this;

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -40,7 +40,9 @@ namespace juce
 class FileStreamOut
 {
 public:
-   explicit FileStreamOut(std::unique_ptr<juce::OutputStream> stream) : mStream(std::move(stream)) {}
+   explicit FileStreamOut(std::unique_ptr<juce::OutputStream> stream)
+   : mStream(std::move(stream))
+   {}
    explicit FileStreamOut(const std::string& file);
    explicit FileStreamOut(juce::MemoryBlock& block, bool appendToExistingBlockContent = true);
    FileStreamOut(const char*) = delete; // Hint: UTF-8 encoded std::string required
@@ -63,7 +65,9 @@ private:
 class FileStreamIn
 {
 public:
-   explicit FileStreamIn(std::unique_ptr<juce::InputStream> stream) : mStream(std::move(stream)) {}
+   explicit FileStreamIn(std::unique_ptr<juce::InputStream> stream)
+   : mStream(std::move(stream))
+   {}
    explicit FileStreamIn(const std::string& file);
    explicit FileStreamIn(const juce::MemoryBlock& block);
    FileStreamIn(const char*) = delete; // Hint: UTF-8 encoded std::string required

--- a/Source/FileStream.h
+++ b/Source/FileStream.h
@@ -33,14 +33,16 @@
 
 namespace juce
 {
-   class FileInputStream;
-   class FileOutputStream;
+   class InputStream;
+   class OutputStream;
 }
 
 class FileStreamOut
 {
 public:
+   explicit FileStreamOut(std::unique_ptr<juce::OutputStream> stream) : mStream(std::move(stream)) {}
    explicit FileStreamOut(const std::string& file);
+   explicit FileStreamOut(juce::MemoryBlock& block, bool appendToExistingBlockContent = true);
    FileStreamOut(const char*) = delete; // Hint: UTF-8 encoded std::string required
    ~FileStreamOut();
    FileStreamOut& operator<<(const int& var);
@@ -55,13 +57,15 @@ public:
    juce::int64 GetSize() const;
 
 private:
-   std::unique_ptr<juce::FileOutputStream> mStream;
+   std::unique_ptr<juce::OutputStream> mStream;
 };
 
 class FileStreamIn
 {
 public:
+   explicit FileStreamIn(std::unique_ptr<juce::InputStream> stream) : mStream(std::move(stream)) {}
    explicit FileStreamIn(const std::string& file);
+   explicit FileStreamIn(const juce::MemoryBlock& block);
    FileStreamIn(const char*) = delete; // Hint: UTF-8 encoded std::string required
    ~FileStreamIn();
    FileStreamIn& operator>>(int& var);
@@ -81,7 +85,7 @@ public:
    static const int sMaxStringLength = 999999; //the primary thing that might hit this limit is the json layout file (one user has had a file that exceeded a length of 100000)
 
 private:
-   std::unique_ptr<juce::FileInputStream> mStream;
+   std::unique_ptr<juce::InputStream> mStream;
 };
 
 #endif /* defined(__Bespoke__FileStream__) */

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2712,8 +2712,9 @@ void ModularSynth::LogEvent(std::string event, LogEventType type)
 
 IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
 {
+   juce::MemoryBlock block;
    {
-      FileStreamOut out(ofToDataPath("tmp"));
+      FileStreamOut out(block);
       module->SaveState(out);
    }
 
@@ -2733,7 +2734,7 @@ IDrawableModule* ModularSynth::DuplicateModule(IDrawableModule* module)
    newModule->SetName(module->Name()); //temporarily rename to the same as what we duplicated, so we can load state properly
 
    {
-      FileStreamIn in(ofToDataPath("tmp"));
+      FileStreamIn in(block);
       mIsLoadingModule = true;
       mIsDuplicatingModule = true;
       newModule->LoadState(in, newModule->LoadModuleSaveStateRev(in));

--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -352,16 +352,10 @@ void Snapshots::SetSnapshot(int idx, double time)
 
             if (control->ShouldSerializeForSnapshot() && !i->mString.empty())
             {
-               std::string tempFileName = ofToDataPath("tmpread" + ofToString(this));
-               juce::MemoryOutputStream outputStream;
-               juce::Base64::convertFromBase64(outputStream, i->mString);
-               {
-                  FileStreamOut out(tempFileName);
-                  out.WriteGeneric(outputStream.getData(), outputStream.getDataSize());
-               }
-               FileStreamIn in(tempFileName);
+               juce::MemoryBlock outputStream;
+               outputStream.fromBase64Encoding(i->mString);
+               FileStreamIn in(outputStream);
                control->LoadState(in, true);
-               juce::File(tempFileName).deleteFile();
             }
          }
          else
@@ -929,18 +923,11 @@ Snapshots::Snapshot::Snapshot(IUIControl* control, Snapshots* snapshots)
 
    if (control->ShouldSerializeForSnapshot())
    {
-      std::string tempFileName = ofToDataPath("tmpsave" + ofToString(this));
-      juce::int64 size;
+      juce::MemoryBlock tempBlock;
       {
-         FileStreamOut out(tempFileName);
+         FileStreamOut out(tempBlock);
          control->SaveState(out);
-         size = out.GetSize();
       }
-      FileStreamIn in(tempFileName);
-      char* data = new char[size];
-      in.ReadGeneric(data, size);
-      mString = juce::Base64::toBase64(data, size).toStdString();
-      delete[] data;
-      juce::File(tempFileName).deleteFile();
+      mString = tempBlock.toBase64Encoding().toStdString();
    }
 }


### PR DESCRIPTION
It makes `FileStreamInput/Output` APIs use base `juce::Input/OutputStream` classes instead of file-specific ones, so that you can serialize from/to `MemoryBlock`s (and other streams).
As a result, using a temporary file when duplicating modules (!) and using Snapshot is no longer necessary.
It also allows my temporary implementation for a `PolyphonicContainer` to duplicate modules fast without interacting with the OS.