### PR TITLE
Added mouse click based velocity support to KeyboardDisplay

### DIFF
--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -103,7 +103,7 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
                   else
                      kOffsetVal = mHeight;
 
-                  int noteVelocity = std::min(127, int(floor((y + (kOffsetVal) * 0.25f) / (kOffsetVal) * 127)));
+                  int noteVelocity = std::min(127, int(floor((y + kOffsetVal * 0.25f) / kOffsetVal * 127)));
 
                   if (mPlayingMousePitch == -1 || !mLatch)
                   {

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -97,14 +97,14 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
                   int pitch = i + RootKey();
 
                   float kOffsetVal;
-                  
+
                   if (isBlackKey)
-                     kOffsetVal = mHeight/2.2f;
+                     kOffsetVal = mHeight / 2.2f;
                   else
                      kOffsetVal = mHeight;
-                  
-                  int noteVelocity = std::min(127, int(floor((y + (kOffsetVal) * 0.25f) / (kOffsetVal)*127)));
-                  
+
+                  int noteVelocity = std::min(127, int(floor((y + (kOffsetVal) * 0.25f) / (kOffsetVal) * 127)));
+
                   if (mPlayingMousePitch == -1 || !mLatch)
                   {
                      PlayNote(time, pitch, noteVelocity);

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -95,16 +95,26 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
                if ((pass == 0 && isBlackKey) || (pass == 1 && !isBlackKey))
                {
                   int pitch = i + RootKey();
+
+                  float kOffsetVal;
+                  
+                  if (isBlackKey)
+                     kOffsetVal = mHeight/2.2f;
+                  else
+                     kOffsetVal = mHeight;
+                  
+                  int noteVelocity = std::min(127, int(floor((y + (kOffsetVal) * 0.25f) / (kOffsetVal)*127)));
+                  
                   if (mPlayingMousePitch == -1 || !mLatch)
                   {
-                     PlayNote(time, pitch, 127);
+                     PlayNote(time, pitch, noteVelocity);
                      mPlayingMousePitch = pitch;
                   }
                   else
                   {
                      bool newNote = (mPlayingMousePitch != pitch);
                      if (newNote)
-                        PlayNote(time, pitch, 127);
+                        PlayNote(time, pitch, noteVelocity);
                      PlayNote(time, mPlayingMousePitch, 0);
                      mPlayingMousePitch = newNote ? pitch : -1;
                   }

--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -96,14 +96,23 @@ void KeyboardDisplay::OnClicked(float x, float y, bool right)
                {
                   int pitch = i + RootKey();
 
-                  float kOffsetVal;
+                  float minVelocityY;
+                  float maxVelocityY;
 
                   if (isBlackKey)
-                     kOffsetVal = mHeight / 2.2f;
+                  {
+                     minVelocityY = 0;
+                     maxVelocityY = (mHeight / 2) * .9f;
+                  }
                   else
-                     kOffsetVal = mHeight;
+                  {
+                     minVelocityY = mHeight / 2;
+                     maxVelocityY = mHeight * .9f;
+                  }
 
-                  int noteVelocity = std::min(127, int(floor((y + kOffsetVal * 0.25f) / kOffsetVal * 127)));
+                  int noteVelocity = 127;
+                  if (mGetVelocityFromClickHeight)
+                     noteVelocity = (int)ofMap(y, minVelocityY, maxVelocityY, 20, 127, K(clamp));
 
                   if (mPlayingMousePitch == -1 || !mLatch)
                   {
@@ -320,6 +329,7 @@ void KeyboardDisplay::LoadLayout(const ofxJSONElement& moduleInfo)
    mModuleSaveData.LoadBool("typing_control", moduleInfo, false);
    mModuleSaveData.LoadBool("latch", moduleInfo, false);
    mModuleSaveData.LoadBool("show_scale", moduleInfo, false);
+   mModuleSaveData.LoadBool("get_velocity_from_click_height", moduleInfo, true);
 
    SetUpFromSaveData();
 }
@@ -332,6 +342,7 @@ void KeyboardDisplay::SetUpFromSaveData()
    mTypingInput = mModuleSaveData.GetBool("typing_control");
    mLatch = mModuleSaveData.GetBool("latch");
    mShowScale = mModuleSaveData.GetBool("show_scale");
+   mGetVelocityFromClickHeight = mModuleSaveData.GetBool("get_velocity_from_click_height");
 }
 
 void KeyboardDisplay::SaveState(FileStreamOut& out)

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -89,6 +89,7 @@ private:
    bool mTypingInput{ false };
    bool mLatch{ false };
    bool mShowScale{ false };
+   bool mGetVelocityFromClickHeight{ false };
    std::array<float, 128> mLastOnTime{};
    std::array<float, 128> mLastOffTime{};
 };


### PR DESCRIPTION
In action:

https://github.com/BespokeSynth/BespokeSynth/assets/42283444/611c58bc-0655-423a-95e3-372d7c90029c

Should work with keyboards of any size, velocity depends on the y value of the click position. Where most of the white area being where the clicks are registered at full power.

PS: Ignore the white outline, it's something else I'm working on and not present in this PR.