### PR TITLE
Add arturia minilab 3 midi controller and midiplus minicontrol

### DIFF
--- a/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI PADS.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI PADS.json
@@ -1,0 +1,17 @@
+{
+    "channelfilter": 10,
+    "groups" : [
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 0, 0 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls" : [ 36, 37, 38, 39 , 40, 41, 42, 43 ],
+          "colors" : [ 0, 127],
+          "messageType" : "note",
+          "drawType" : "button"
+       }
+    ]
+ }
+ 

--- a/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI.json
@@ -1,0 +1,91 @@
+{
+    "channelfilter": 1,
+    "groups" : [
+        {
+            "rows": 1,
+            "cols": 2,
+            "position" : [ 0, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [ 113, 115 ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "button"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 35 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "messageType" : "pitchbend",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 30, 35 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "controls" : [1],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 2,
+            "cols": 7,
+            "position" : [ 100, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [
+                 74, 71, 76, 77, 93, 73, 75,
+                 18, 19, 16, 17, 91, 79, 72
+                ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+        {
+            "rows": 2,
+            "cols": 1,
+            "position" : [ 65, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [
+                 112,
+                 114
+                ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "slider",
+            "incremental": true
+        },
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 65, 70 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls" : [ 22, 23, 24, 25, 26, 27, 28, 29 ],
+          "colors" : [ 0, 127],
+          "messageType" : "control",
+          "drawType" : "button"
+       },
+       {
+        "rows": 1,
+        "cols": 25,
+        "position" : [ 65, 110 ],
+        "dimensions" : [14, 84],
+        "spacing" : [16, 30],
+        "controls" : [
+            48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61,
+            62, 63, 64, 65, 66, 67, 68,
+            69, 70, 71, 72
+          ],
+        "colors" : [ 0, 127],
+        "messageType" : "note",
+        "drawType" : "button"
+     }
+    ]
+ }

--- a/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab 3 MIDI.json
@@ -7,7 +7,7 @@
             "position" : [ 0, 0 ],
             "dimensions" : [28, 28],
             "spacing" : [30, 30],
-            "controls" : [ 113, 115 ],
+            "controls" : [ 27, 0 ],
             "colors" : [ 0, 127],
             "messageType" : "control",
             "drawType" : "button"
@@ -33,40 +33,93 @@
         },
         {
             "rows": 2,
-            "cols": 7,
+            "cols": 4,
             "position" : [ 100, 0 ],
             "dimensions" : [28, 28],
             "spacing" : [30, 30],
             "controls" : [
-                 74, 71, 76, 77, 93, 73, 75,
-                 18, 19, 16, 17, 91, 79, 72
+                 86, 87, 89, 90, 
+                 110, 111, 116, 117
                 ],
             "colors" : [ 0, 127],
             "messageType" : "control",
             "drawType" : "knob"
         },
         {
-            "rows": 2,
+            "rows": 1,
             "cols": 1,
             "position" : [ 65, 0 ],
             "dimensions" : [28, 28],
             "spacing" : [30, 30],
             "controls" : [
-                 112,
-                 114
+                 118
                 ],
             "colors" : [ 0, 127],
             "messageType" : "control",
-            "drawType" : "slider",
-            "incremental": true
+            "drawType" : "button"
         },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 65, 30 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 30],
+            "controls" : [
+                 28
+                ],
+            "colors" : [ 0, 127],
+            "messageType" : "control",
+            "drawType" : "knob",
+        },
+
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 225, 0 ],
+            "dimensions" : [28, 60],
+            "spacing" : [30, 0],
+            "controls" : [14],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 255, 0 ],
+            "dimensions" : [28, 60],
+            "spacing" : [30, 0],
+            "controls" : [15],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 285, 0 ],
+            "dimensions" : [28, 60],
+            "spacing" : [30, 0],
+            "controls" : [30],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 315, 0 ],
+            "dimensions" : [28, 60],
+            "spacing" : [64, 0],
+            "controls" : [31],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+
        {
           "rows": 1,
           "cols": 8,
           "position" : [ 65, 70 ],
           "dimensions" : [28, 28],
           "spacing" : [32, 30],
-          "controls" : [ 22, 23, 24, 25, 26, 27, 28, 29 ],
+          "controls" : [ 36, 37, 38, 39, 40, 41, 42, 43 ],
           "colors" : [ 0, 127],
           "messageType" : "control",
           "drawType" : "button"

--- a/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
+++ b/resource/userdata_original/controllers/Arturia MiniLab mkII MIDI 1.json
@@ -58,7 +58,7 @@
             "colors" : [ 0, 127],
             "messageType" : "control",
             "drawType" : "slider",
-            "incremental": true,
+            "incremental": true
         },
        {
           "rows": 1,
@@ -89,4 +89,3 @@
      }
     ]
  }
- 

--- a/resource/userdata_original/controllers/MIDIPLUS minicontrol PADS.json
+++ b/resource/userdata_original/controllers/MIDIPLUS minicontrol PADS.json
@@ -1,0 +1,17 @@
+{
+    "channelfilter": 10,
+    "groups" : [
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 0, 0 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls": [ 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "colors" : [ 0, 127],
+          "messageType" : "note",
+          "drawType" : "button"
+       }
+    ]
+ }
+ 

--- a/resource/userdata_original/controllers/MIDIPLUS minicontrol.json
+++ b/resource/userdata_original/controllers/MIDIPLUS minicontrol.json
@@ -1,0 +1,100 @@
+{
+    "channelfilter": 1,
+    "groups" : [
+
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 46 ],
+            "dimensions" : [60, 20],
+            "spacing" : [30],
+            "controls" : [7],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 72 ],
+            "dimensions" : [28, 50],
+            "spacing" : [30],
+            "messageType" : "pitchbend",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 32, 72 ],
+            "dimensions" : [28, 50],
+            "spacing" : [30],
+            "controls" : [1],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 0],
+            "controls" : [12],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 30, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 0],
+            "controls" : [13],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 60, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 0],
+            "controls" : [14],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 90, 0 ],
+            "dimensions" : [28, 28],
+            "spacing" : [30, 0],
+            "controls" : [15],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+
+       {
+          "rows": 1,
+          "cols": 8,
+          "position" : [ 130, 0 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 30],
+          "controls" : [ 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "colors" : [ 0, 127],
+          "messageType" : "control",
+          "drawType" : "button"
+       },
+       {
+        "rows": 1,
+        "cols": 32,
+        "position" : [ 65, 45 ],
+        "dimensions" : [14, 84],
+        "spacing" : [16, 30],
+        "controls" : [
+            41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72
+          ],
+        "colors" : [ 0, 127],
+        "messageType" : "note",
+        "drawType" : "button"
+     }
+    ]
+ }


### PR DESCRIPTION
- [Why] Do the pads (on channel 10) have to be separate midicontrollers?
- Arturia Minilab 3 cc28 is a knob, but it only appears to move between 0.48 and 0.52?
  - This is a brand new Minilab3 *Alpine White*
    - https://www.arturia.com/store/hybrid-synths/minilab3
    - https://www.arturia.com/store/hybrid-synths/minilab3alpinewhite
    - https://www.amazon.com/Arturia-Controller-All-One-Multi-Color/dp/B0CL4QNN4K
  - Is there something in addition to `'drawType': "knob"` that I need for this to work?
  - I tried: "incremental" (?)
  - Pushing the knob in (cc118) does work
  - Twisting the knob, it only appears to move between 0.48 and 0.52? 
 
- MIDIplus minicontrol
  - This is a brand new MIDIplus minicontrol:
    - https://www.midiplus.com.tw/en/product-detail/Minicontrol/
    - https://www.amazon.com/midiplus-32-Key-minicontrol-Keyboard-Controller/dp/B01E5GGLSY
  - Same question about why pads have to be a separate controller; I also left the pad button numbers in for this one.

(I have no business or paid relation with either vendor. I just copied the Arturia MiniLAB mkII controller JSON files and modified them for these devices.)