### PR TITLE
Add `get_name` python method to get the name of modules.

### DIFF
--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -765,6 +765,10 @@ PYBIND11_EMBEDDED_MODULE(module, m)
       {
          module.SetName(name.c_str());
       })
+      .def("get_name", [](IDrawableModule& module)
+      {
+         return module.Name();
+      })
       .def("delete", [](IDrawableModule& module)
       {
          module.GetOwningContainer()->DeleteModule(&module, !K(fail));


### PR DESCRIPTION
Add `get_name` python method to get the name of modules.

Helpful when wanting to target uicontrols with dynamically generated code where you may not know the name of the module:

![BespokeSynth_20240428_125938](https://github.com/BespokeSynth/BespokeSynth/assets/211381/2dcb7b04-1029-40b8-a1cb-b9e652bd642e)
