### PR TITLE
Refresh the parameter dropdown list on ParamInfo change

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -563,7 +563,7 @@ void VSTPlugin::Poll()
       if (numParameters <= kMaxParametersInDropdown) // update the dropdown in this case
       {
          mShowParameterDropdown->Clear();
-         for (int i=0; i<numParameters; ++i)
+         for (int i = 0; i < numParameters; ++i)
          {
             mShowParameterDropdown->AddLabel(mParameterSliders[i].mDisplayName.c_str(), i);
             mParameterSliders[i].mInSelectorList = true;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -533,7 +533,7 @@ void VSTPlugin::CreateParameterSliders()
       else
          mParameterSliders[i].mID = "param_" + ofToString(parameters[i]->getParameterIndex());
       mParameterSliders[i].mShowing = false;
-      if (numParameters <= 30) //only show parameters in list if there are a small number. if there are many, make the user adjust them in the VST before they can be controlled
+      if (numParameters <= kMaxParametersInDropdown) //only show parameters in list if there are a small number. if there are many, make the user adjust them in the VST before they can be controlled
       {
          mShowParameterDropdown->AddLabel(mParameterSliders[i].mDisplayName.c_str(), i);
          mParameterSliders[i].mInSelectorList = true;
@@ -558,6 +558,16 @@ void VSTPlugin::Poll()
          mParameterSliders[i].mDisplayName = parameters[i]->getName(64).toStdString();
          if (mParameterSliders[i].mSlider != nullptr)
             mParameterSliders[i].mSlider->SetOverrideDisplayName(mParameterSliders[i].mDisplayName);
+      }
+
+      if (numParameters <= kMaxParametersInDropdown) // update the dropdown in this case
+      {
+         mShowParameterDropdown->Clear();
+         for (int i=0; i<numParameters; ++i)
+         {
+            mShowParameterDropdown->AddLabel(mParameterSliders[i].mDisplayName.c_str(), i);
+            mParameterSliders[i].mInSelectorList = true;
+         }
       }
    }
    if (mDisplayMode == kDisplayMode_Sliders)

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -201,6 +201,7 @@ private:
    DisplayMode mDisplayMode{ DisplayMode::kDisplayMode_Sliders };
    int mShowParameterIndex{ -1 };
    DropdownList* mShowParameterDropdown{ nullptr };
+   static constexpr int kMaxParametersInDropdown{30};
    int mTemporarilyDisplayedParamIndex{ -1 };
 
    /*

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -201,7 +201,7 @@ private:
    DisplayMode mDisplayMode{ DisplayMode::kDisplayMode_Sliders };
    int mShowParameterIndex{ -1 };
    DropdownList* mShowParameterDropdown{ nullptr };
-   static constexpr int kMaxParametersInDropdown{30};
+   static constexpr int kMaxParametersInDropdown{ 30 };
    int mTemporarilyDisplayedParamIndex{ -1 };
 
    /*


### PR DESCRIPTION
If (1) Parameter Names change and (2) Parameter Count is less than 30, the code to update parameter names didn't update the in-use mShowParameterDropdown. Correct this omission, and since I needed the length in two spots, move the "30" to "kMaxParametersInDropdown"

Turns out, by the way, that Airwindows Consolidated is a plugin which (1) changes parameter names and (2) has parameter count less than 30. So you know, some enlightened self interest in this PR!