### PR TITLE
Allow for snapping to the center of the module while holding `shift` as well as `control` as opposed to only the top left corner.

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1252,8 +1252,8 @@ void ModularSynth::MouseMoved(int intX, int intY)
          newY = round((newY - mMoveModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mMoveModule->TitleBarHeight();
          if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
          {
-            newX -= std::fmodf(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
-            newY -= std::fmodf(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+            newX -= std::fmod(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmod(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
          }
       }
 
@@ -1441,8 +1441,8 @@ void ModularSynth::MouseDragged(int intX, int intY, int button, const juce::Mous
          newY = round((newY - mLastClickedModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mLastClickedModule->TitleBarHeight();
          if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
          {
-            newX -= std::fmodf(mLastClickedModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
-            newY -= std::fmodf(mLastClickedModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+            newX -= std::fmod(mLastClickedModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmod(mLastClickedModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
          }
       }
 
@@ -1466,8 +1466,8 @@ void ModularSynth::MouseDragged(int intX, int intY, int button, const juce::Mous
          newY = round((newY - mMoveModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mMoveModule->TitleBarHeight();
          if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
          {
-            newX -= std::fmodf(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
-            newY -= std::fmodf(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+            newX -= std::fmod(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmod(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
          }
       }
 

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1250,6 +1250,11 @@ void ModularSynth::MouseMoved(int intX, int intY)
       {
          newX = round(newX / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get();
          newY = round((newY - mMoveModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mMoveModule->TitleBarHeight();
+         if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
+         {
+            newX -= std::fmodf(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmodf(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+         }
       }
 
       mMoveModule->Move(newX - oldX, newY - oldY);
@@ -1434,6 +1439,11 @@ void ModularSynth::MouseDragged(int intX, int intY, int button, const juce::Mous
       {
          newX = round(newX / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get();
          newY = round((newY - mLastClickedModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mLastClickedModule->TitleBarHeight();
+         if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
+         {
+            newX -= std::fmodf(mLastClickedModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmodf(mLastClickedModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+         }
       }
 
       float adjustedDragX = newX - oldX;
@@ -1454,6 +1464,11 @@ void ModularSynth::MouseDragged(int intX, int intY, int button, const juce::Mous
       {
          newX = round(newX / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get();
          newY = round((newY - mMoveModule->TitleBarHeight()) / UserPrefs.grid_snap_size.Get()) * UserPrefs.grid_snap_size.Get() + mMoveModule->TitleBarHeight();
+         if (GetKeyModifiers() & kModifier_Shift) // Snap to center of the module
+         {
+            newX -= std::fmodf(mMoveModule->GetRect().width / 2, UserPrefs.grid_snap_size.Get());
+            newY -= std::fmodf(mMoveModule->GetRect().height / 2, UserPrefs.grid_snap_size.Get());
+         }
       }
 
       mMoveModule->Move(newX - oldX, newY - oldY);


### PR DESCRIPTION
![image](https://github.com/BespokeSynth/BespokeSynth/assets/211381/e3410d9e-fe1e-4170-8506-ebe1d088eb61)
