### PR TITLE
When the valuesetter is disabled also don't allow sending updates when the button is pressed. Resolves: #1587.

### DIFF
--- a/Source/ValueSetter.cpp
+++ b/Source/ValueSetter.cpp
@@ -94,7 +94,7 @@ void ValueSetter::OnPulse(double time, float velocity, int flags)
 
 void ValueSetter::ButtonClicked(ClickButton* button, double time)
 {
-   if (button == mButton && mLastClickTime != time)
+   if (mEnabled && button == mButton && mLastClickTime != time)
    {
       mLastClickTime = time;
       Go(time);


### PR DESCRIPTION
When the `valuesetter` is disabled also don't allow sending updates when the button is pressed. Resolves: #1587.