### PR TITLE
Don't use file path hash for plugins lookup.

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,5 +3,5 @@ workflow:
     - trigger_services:
          project: home:bespokesynth
          package: bespokesynth-nightly
-    - filters:
+  filters:
          event: push

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,5 @@ workflow:
     - trigger_services:
          project: home:bespokesynth
          package: bespokesynth-nightly
+    - filters:
+         event: push

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -180,12 +180,45 @@ namespace VSTLookup
       return "";
    }
 
+   juce::String cutOffIdHash(juce::String inputString)
+   {
+
+      // Split the string based on '-'
+      juce::StringArray parts;
+      parts.addTokens(inputString, "-", "");
+
+      // Check if there are at least two parts
+      if (parts.size() >= 2)
+      {
+         // Remove the second part from the right
+         parts.remove(parts.size() - 2);
+
+         // Join the remaining parts back into a string
+         juce::String result = parts.joinIntoString("-");
+
+         // Output the result
+         return result;
+      }
+      return inputString;
+   }
+
    bool GetPluginDesc(juce::PluginDescription& desc, juce::String pluginId)
    {
       auto types = TheSynth->GetKnownPluginList().getTypes();
+      auto cutId = cutOffIdHash(pluginId);
+
       for (int i = 0; i < types.size(); ++i)
       {
          if (types[i].createIdentifierString() == pluginId)
+         {
+            desc = types[i];
+            return true;
+         }
+      }
+
+      for (int i = 0; i < types.size(); ++i)
+      {
+         if (cutOffIdHash(types[i].createIdentifierString()) == cutId)
          {
             desc = types[i];
             return true;

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -182,21 +182,13 @@ namespace VSTLookup
 
    juce::String cutOffIdHash(juce::String inputString)
    {
-
-      // Split the string based on '-'
       juce::StringArray parts;
       parts.addTokens(inputString, "-", "");
 
-      // Check if there are at least two parts
       if (parts.size() >= 2)
       {
-         // Remove the second part from the right
          parts.remove(parts.size() - 2);
-
-         // Join the remaining parts back into a string
          juce::String result = parts.joinIntoString("-");
-
-         // Output the result
          return result;
       }
       return inputString;

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -148,6 +148,7 @@ private:
    juce::MidiBuffer mFutureMidiBuffer;
    juce::CriticalSection mMidiInputLock;
    std::atomic<bool> mRescanParameterNames{ false };
+   juce::String cutOffIdHash(juce::String);
    int mNumInputChannels{ 2 };
    int mNumOutputChannels{ 2 };
 


### PR DESCRIPTION
As it turned out that `createIdentifierString()` [createIdentifierString()](https://forum.juce.com/t/createidentifierstring-is-not-independent-of-the-plug-ins-file-location/58890) is not platform or even file path independent.
So this function adds a second step in plugin lookup (without a file path hash) after trying to find by exact `IdentifierString`.