### PR TITLE
Fix for Euclidean Sequencer: Random note buttons would set all notes to 3 when using random octave range 0

### DIFF
--- a/Source/EuclideanSequencer.cpp
+++ b/Source/EuclideanSequencer.cpp
@@ -519,8 +519,7 @@ void EuclideanSequencer::RandomizeNote(int ringIndex, bool force)
          // 0 = 0 1 2 3
          if ((int)mRndOctaveLo == 0 && (int)mRndOctaveHi == 0)
          {
-            for (int j = 0; j < mEuclideanSequencerRings.size(); ++j)
-               mEuclideanSequencerRings[j]->SetPitch(i);
+            mEuclideanSequencerRings[i]->SetPitch(i);
          }
          else
          {


### PR DESCRIPTION
When using random note octave hi-lo range 0 to 0, any random note button would change all notes to have value 3.
Fixed so this special octave range 0-0 now assigns notes 0 1 2 3 again, as it was originally intended for drum notes.