### PR TITLE
add support for template projects (.bskt)

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -316,7 +316,7 @@ public:
       for (int i = 0; i < JUCEApplication::getCommandLineParameterArray().size(); ++i)
       {
          juce::String argument = JUCEApplication::getCommandLineParameterArray()[i];
-         if (argument.endsWith(".bsk"))
+         if (argument.endsWith(".bsk") || argument.endsWith(".bskt"))
          {
             mSynth.SetStartupSaveStateFile(argument.toStdString());
             break;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2815,7 +2815,7 @@ void ModularSynth::SaveLayoutAsPopup()
 
 void ModularSynth::SaveCurrentState()
 {
-   if (mCurrentSaveStatePath.empty() || mCurrentSaveStateIsTemplate)
+   if (mCurrentSaveStatePath.empty() || IsCurrentSaveStateATemplate())
    {
       SaveStatePopup();
       return;
@@ -2839,7 +2839,7 @@ void ModularSynth::SaveStatePopup()
    String savestateDirPath = ofToDataPath("savestate/");
    String templateName = "";
    String date = ofGetTimestampString("%Y-%m-%d_%H-%M");
-   if (mCurrentSaveStateIsTemplate)
+   if (IsCurrentSaveStateATemplate())
       templateName = File(mCurrentSaveStatePath).getFileNameWithoutExtension().toStdString() + "_";
 
    targetFile = File(savestateDirPath + templateName + date + ".bsk");
@@ -2952,8 +2952,6 @@ void ModularSynth::LoadState(std::string file)
 
    mCurrentSaveStatePath = file;
    File savePath(mCurrentSaveStatePath);
-   if (savePath.getFileExtension().toStdString() == ".bskt")
-      mCurrentSaveStateIsTemplate = true;
    std::string filename = savePath.getFileName().toStdString();
    mMainComponent->getTopLevelComponent()->setName("bespoke synth - " + filename);
 
@@ -2963,6 +2961,14 @@ void ModularSynth::LoadState(std::string file)
    mIsLoadingState = false;
    LockRender(false);
    mAudioThreadMutex.Unlock();
+}
+
+bool ModularSynth::IsCurrentSaveStateATemplate() const
+{
+   if (mCurrentSaveStatePath == "")
+      return false;
+   File savePath(mCurrentSaveStatePath);
+   return savePath.getFileExtension().toStdString() == ".bskt";
 }
 
 IAudioReceiver* ModularSynth::FindAudioReceiver(std::string name, bool fail)

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -388,6 +388,7 @@ private:
    bool mWantReloadInitialLayout{ false };
    std::string mCurrentSaveStatePath;
    std::string mStartupSaveStateFile;
+   bool mCurrentSaveStateIsTemplate{ false };
 
    Sample* mHeldSample{ nullptr };
 

--- a/Source/ModularSynth.h
+++ b/Source/ModularSynth.h
@@ -306,6 +306,7 @@ private:
    void FindCircularDependencies();
    bool FindCircularDependencySearch(std::list<IAudioSource*> chain, IAudioSource* searchFrom);
    void ClearCircularDependencyMarkers();
+   bool IsCurrentSaveStateATemplate() const;
 
    void ReadClipboardTextFromSystem();
 
@@ -388,7 +389,6 @@ private:
    bool mWantReloadInitialLayout{ false };
    std::string mCurrentSaveStatePath;
    std::string mStartupSaveStateFile;
-   bool mCurrentSaveStateIsTemplate{ false };
 
    Sample* mHeldSample{ nullptr };
 


### PR DESCRIPTION
This adds support for template projects, which are the same as a regular project but have the `.bskt` file extension. Attempting to save an open project file that has the template extension will prompt you to save it as a file of the same name, but with a date appended and with the `.bsk` extension instead.

Ex: `/path/my_cool_project.bskt` -> `~/Documents/BespokeSynth/savestate/my_cool_project_2024-06-15_21-02.bsk`