### PR TITLE
Various improvements to git repository and code editing experience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+insert_final_newline = false
+charset = utf-8
+
+# c, cpp, h, hpp files and .i
+[*.{i,{c,h}{,pp}}]
+indent_style = space
+indent_size = 3

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Convert line endings to match the system style
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,9 @@ paket-files/
 # CodeRush
 .cr/
 
+# ccls (language server)
+.ccls-cache/
+
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc


### PR DESCRIPTION
- [.editorconfig](https://editorconfig.org) - tells editors how files should look (different from clang-format)
- [.gitattributes: text](https://git-scm.com/docs/gitattributes#_text) - settings for git, here it's being used to convert line endings to the defaults for the host
- .gitignore - ignore `.ccls-cache` folder, created by the ccls language server

Please review the options in `.editorconfig`. I think they should be right, but I'd like to make sure. I chose them based on the contents of `.clang-format` and existing files.