### PR TITLE
Set curvelooper size on load

### DIFF
--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -244,6 +244,7 @@ void CurveLooper::SetUpFromSaveData()
 {
    mWidth = mModuleSaveData.GetInt("width");
    mHeight = mModuleSaveData.GetInt("height");
+   Resize(mWidth, mHeight);
 }
 
 void CurveLooper::SaveState(FileStreamOut& out)


### PR DESCRIPTION
The curvelooper wasn't setting the size of its curve region on load, which lead to things like this when alt-dragging it

![image](https://github.com/BespokeSynth/BespokeSynth/assets/24578572/db891e1c-b51a-4d7b-964f-858489e9e174)

With this fix, this is the alt-drag behavior:
![image](https://github.com/BespokeSynth/BespokeSynth/assets/24578572/d3bc9a43-fba8-4869-8ebb-e81fd7370c5c)
