### PR TITLE
Fix a crash when the length in the curvelooper is forcibly set to 0. Resolves: #1606.

### DIFF
--- a/Source/CurveLooper.cpp
+++ b/Source/CurveLooper.cpp
@@ -106,7 +106,9 @@ void CurveLooper::OnTransportAdvanced(float amount)
 
 float CurveLooper::GetPlaybackPosition()
 {
-   if (mLength < 0)
+   if (mLength == 0)
+      mLength = 1;
+   else if (mLength < 0)
    {
       float ret = TheTransport->GetMeasurePos(gTime) * (-mLength);
       return FloatWrap(ret, 1);


### PR DESCRIPTION
Fix a crash when the length in the curvelooper is forcibly set to 0. Resolves: #1606.