### PR TITLE
Fix circlesequencer playnote issues when using offsets

### DIFF
--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -305,7 +305,7 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
    PROFILER(CircleSequencerRing);
 
    TransportListenerInfo info(nullptr, kInterval_CustomDivisor, OffsetInfo(mOffset, false), false);
-   info.mCustomDivisor = mLength;
+   info.mCustomDivisor = mLength + (mLength == 1); // +1 if mLength(Steps) == 1: fixes not playing onset 1 when mLength = 1: force oldStep <> newStep
 
    double remainderMs;
    const int oldStep = TheTransport->GetQuantized(NextBufferTime(true) - gBufferSizeMs, &info);
@@ -313,7 +313,7 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
    const int oldMeasure = TheTransport->GetMeasure(NextBufferTime(true) - gBufferSizeMs);
    const int newMeasure = TheTransport->GetMeasure(NextBufferTime(true));
 
-   if ((oldMeasure != newMeasure || oldStep != newStep) && mSteps[newStep] > 0)
+   if (oldStep != newStep && mSteps[newStep] > 0)
    {
       const double time = NextBufferTime(true) - remainderMs;
       mOwner->PlayNoteOutput(time, mPitch, mSteps[newStep] * 127, -1);


### PR DESCRIPTION
This fixes 2 issues in circlesequencer.
Backported from euclideansequencer where this was fixed already.

issue 1: 1 step + positive offset: note is played on measure change, instead of offset time.
![image](https://github.com/user-attachments/assets/1b70a5d2-91fc-4419-a716-a6288a01afdc)

issue 2: 2 step + positive offset: note is played twice, on offset time and on measure change.
![image](https://github.com/user-attachments/assets/cf5ae02a-d1d1-41d8-a53c-33225781547c)

See attached bsk in zip for example project reproducing these 2 bugs
[circleseq playnote bug.zip](https://github.com/user-attachments/files/16624322/circleseq.playnote.bug.zip)

Issue was mentioned in Discord, no bug report on github:
https://discord.com/channels/846834873254805554/846834873254805557/1270190336030937158
