### PR TITLE
Remove unused `<iostream>`, `<stdio.h>` includes

### DIFF
--- a/Source/ADSR.h
+++ b/Source/ADSR.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <vector>
 #include <array>
 #include "OpenFrameworksPort.h"

--- a/Source/AbletonLink.h
+++ b/Source/AbletonLink.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <memory>
 
 #include "IDrawableModule.h"

--- a/Source/Amplifier.h
+++ b/Source/Amplifier.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/Arpeggiator.h
+++ b/Source/Arpeggiator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Transport.h"

--- a/Source/AudioSend.h
+++ b/Source/AudioSend.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "RollingBuffer.h"

--- a/Source/Autotalent.h
+++ b/Source/Autotalent.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/BandVocoder.h
+++ b/Source/BandVocoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "RollingBuffer.h"

--- a/Source/BeatBloks.h
+++ b/Source/BeatBloks.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "INoteReceiver.h"

--- a/Source/Beats.h
+++ b/Source/Beats.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "IDrawableModule.h"

--- a/Source/BiquadFilterEffect.h
+++ b/Source/BiquadFilterEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "DropdownList.h"
 #include "Slider.h"

--- a/Source/BitcrushEffect.h
+++ b/Source/BitcrushEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/BoundsToPulse.h
+++ b/Source/BoundsToPulse.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioReceiver.h"
 #include "INoteSource.h"
 #include "Slider.h"

--- a/Source/BufferShuffler.h
+++ b/Source/BufferShuffler.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/CFMessaging/KontrolKommunicator.cpp
+++ b/Source/CFMessaging/KontrolKommunicator.cpp
@@ -25,6 +25,7 @@
 #include "KontrolKommunicator.h"
 #include <mach/mach.h>
 #include "NIMessage.h"
+#include <iostream>
 
 #define KEYS_MESSAGE "75 67 56 02  73 79 65 4b"
 #define RKEY_MESSAGE "75 67 56 02  79 65 4b 52"

--- a/Source/CFMessaging/NIMessage.h
+++ b/Source/CFMessaging/NIMessage.h
@@ -26,7 +26,8 @@
 #ifndef CFMessaging_NIMessage_h
 #define CFMessaging_NIMessage_h
 
-#include <iostream>
+#include <cstdint>
+#include <string>
 
 typedef struct
 {

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IUIControl.h"
 #include "CanvasElement.h"
 

--- a/Source/Capo.h
+++ b/Source/Capo.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/ChaosEngine.h
+++ b/Source/ChaosEngine.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "Checkbox.h"

--- a/Source/ChordHolder.h
+++ b/Source/ChordHolder.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/Chorder.h
+++ b/Source/Chorder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "Transport.h"
 #include "UIGrid.h"
 #include "Slider.h"

--- a/Source/ClipArranger.h
+++ b/Source/ClipArranger.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioReceiver.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/ClipLauncher.h
+++ b/Source/ClipLauncher.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "IDrawableModule.h"

--- a/Source/CommentDisplay.h
+++ b/Source/CommentDisplay.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "TextEntry.h"

--- a/Source/Compressor.h
+++ b/Source/Compressor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/ControlSequencer.h
+++ b/Source/ControlSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "UIGrid.h"
 #include "ClickButton.h"

--- a/Source/ControlTactileFeedback.h
+++ b/Source/ControlTactileFeedback.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/ControllingSong.h
+++ b/Source/ControllingSong.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "Checkbox.h"

--- a/Source/DCRemoverEffect.h
+++ b/Source/DCRemoverEffect.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <iostream>
 #include "IAudioEffect.h"
 #include "BiquadFilter.h"
 

--- a/Source/DebugAudioSource.h
+++ b/Source/DebugAudioSource.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "IDrawableModule.h"

--- a/Source/DelayEffect.h
+++ b/Source/DelayEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "RollingBuffer.h"
 #include "Slider.h"

--- a/Source/DistortionEffect.h
+++ b/Source/DistortionEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Checkbox.h"
 #include "Slider.h"

--- a/Source/DotSequencer.h
+++ b/Source/DotSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "ClickButton.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "Sample.h"
 #include "INoteReceiver.h"

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "Sample.h"
 #include "INoteReceiver.h"

--- a/Source/EQModule.h
+++ b/Source/EQModule.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/EffectChain.h
+++ b/Source/EffectChain.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/EuclideanSequencer.h
+++ b/Source/EuclideanSequencer.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "Transport.h"
 #include "UIGrid.h"
 #include "Slider.h"

--- a/Source/FFT.h
+++ b/Source/FFT.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "SynthGlobals.h"
 
 // Variables for FFT routine

--- a/Source/FFTtoAdditive.h
+++ b/Source/FFTtoAdditive.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "FFT.h"

--- a/Source/FMSynth.h
+++ b/Source/FMSynth.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "PolyphonyMgr.h"
 #include "FMVoice.h"

--- a/Source/FilterViz.h
+++ b/Source/FilterViz.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "Slider.h"

--- a/Source/FloatSliderLFOControl.h
+++ b/Source/FloatSliderLFOControl.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Checkbox.h"
 #include "Transport.h"

--- a/Source/FollowingSong.h
+++ b/Source/FollowingSong.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "Checkbox.h"

--- a/Source/FourOnTheFloor.h
+++ b/Source/FourOnTheFloor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "Transport.h"

--- a/Source/FreeverbEffect.h
+++ b/Source/FreeverbEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/FreqDelay.h
+++ b/Source/FreqDelay.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/FreqDomainBoilerplate.h
+++ b/Source/FreqDomainBoilerplate.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "FFT.h"

--- a/Source/GateEffect.h
+++ b/Source/GateEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/GlobalControls.h
+++ b/Source/GlobalControls.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "Slider.h"

--- a/Source/GridModule.h
+++ b/Source/GridModule.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/GridSliders.h
+++ b/Source/GridSliders.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Checkbox.h"
 #include "DropdownList.h"

--- a/Source/InputChannel.h
+++ b/Source/InputChannel.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "DropdownList.h"

--- a/Source/Inverter.h
+++ b/Source/Inverter.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 

--- a/Source/KarplusStrong.h
+++ b/Source/KarplusStrong.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "PolyphonyMgr.h"
 #include "KarplusStrongVoice.h"

--- a/Source/Kicker.h
+++ b/Source/Kicker.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/KompleteKontrol.h
+++ b/Source/KompleteKontrol.h
@@ -26,7 +26,6 @@
 #ifndef __Bespoke__KompleteKontrol__
 #define __Bespoke__KompleteKontrol__
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "Checkbox.h"

--- a/Source/LFOController.h
+++ b/Source/LFOController.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "DropdownList.h"
 #include "Slider.h"

--- a/Source/LabelDisplay.h
+++ b/Source/LabelDisplay.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <utility>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "Scale.h"
 #include "Checkbox.h"
 #include "Slider.h"

--- a/Source/LaunchpadNoteDisplayer.h
+++ b/Source/LaunchpadNoteDisplayer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 

--- a/Source/LinkwitzRileyFilter.h
+++ b/Source/LinkwitzRileyFilter.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "SynthGlobals.h"
 
 class CLinkwitzRiley_4thOrder

--- a/Source/LinnstrumentControl.h
+++ b/Source/LinnstrumentControl.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "MidiDevice.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/Lissajous.h
+++ b/Source/Lissajous.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/LiveGranulator.h
+++ b/Source/LiveGranulator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/Looper.h
+++ b/Source/Looper.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "RollingBuffer.h"

--- a/Source/LooperGranulator.h
+++ b/Source/LooperGranulator.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IDrawableModule.h"
 #include "UIGrid.h"
 #include "ClickButton.h"

--- a/Source/LooperRecorder.h
+++ b/Source/LooperRecorder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "RollingBuffer.h"
 #include "RadioButton.h"

--- a/Source/M185Sequencer.h
+++ b/Source/M185Sequencer.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "ClickButton.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/Metronome.h
+++ b/Source/Metronome.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "EnvOscillator.h"
 #include "IDrawableModule.h"

--- a/Source/MidiClockIn.h
+++ b/Source/MidiClockIn.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "MidiDevice.h"
 #include "IDrawableModule.h"
 #include "DropdownList.h"

--- a/Source/MidiClockOut.h
+++ b/Source/MidiClockOut.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "MidiDevice.h"
 #include "IDrawableModule.h"
 #include "DropdownList.h"

--- a/Source/MidiControlChange.h
+++ b/Source/MidiControlChange.h
@@ -27,8 +27,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "MidiDevice.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/MidiOutput.h
+++ b/Source/MidiOutput.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "MidiDevice.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/ModuleSaveDataPanel.h
+++ b/Source/ModuleSaveDataPanel.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Checkbox.h"
 #include "Slider.h"

--- a/Source/Monophonify.h
+++ b/Source/Monophonify.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/MultibandCompressor.h
+++ b/Source/MultibandCompressor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/MultitrackRecorder.h
+++ b/Source/MultitrackRecorder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Slider.h"
 #include "ClickButton.h"

--- a/Source/Muter.h
+++ b/Source/Muter.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Checkbox.h"
 #include "Ramp.h"

--- a/Source/Neighborhooder.h
+++ b/Source/Neighborhooder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/NoiseEffect.h
+++ b/Source/NoiseEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/NoteEcho.h
+++ b/Source/NoteEcho.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "Slider.h"

--- a/Source/NoteFilter.h
+++ b/Source/NoteFilter.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <stdio.h>
 #include "NoteEffectBase.h"
 
 class NoteFilter : public NoteEffectBase, public IDrawableModule

--- a/Source/NoteFlusher.h
+++ b/Source/NoteFlusher.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/NoteHocket.h
+++ b/Source/NoteHocket.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "Slider.h"

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "Transport.h"
 #include "Checkbox.h"

--- a/Source/NoteOctaver.h
+++ b/Source/NoteOctaver.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/NoteRouter.h
+++ b/Source/NoteRouter.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "INoteSource.h"

--- a/Source/NoteSinger.h
+++ b/Source/NoteSinger.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioReceiver.h"
 #include "INoteSource.h"
 #include "Slider.h"

--- a/Source/NoteSorter.h
+++ b/Source/NoteSorter.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "TextEntry.h"

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"
 #include "Transport.h"

--- a/Source/NoteStepper.h
+++ b/Source/NoteStepper.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "Slider.h"

--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"
 #include "DropdownList.h"

--- a/Source/NoteTransformer.h
+++ b/Source/NoteTransformer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/OSCOutput.h
+++ b/Source/OSCOutput.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "TextEntry.h"

--- a/Source/OpenFrameworksPort.h
+++ b/Source/OpenFrameworksPort.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <assert.h>

--- a/Source/Oscillator.h
+++ b/Source/Oscillator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "SynthGlobals.h"
 #include "ADSR.h"
 

--- a/Source/OutputChannel.h
+++ b/Source/OutputChannel.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "DropdownList.h"

--- a/Source/PSMoveController.h
+++ b/Source/PSMoveController.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "PSMoveMgr.h"
 #include "Checkbox.h"

--- a/Source/PanicButton.h
+++ b/Source/PanicButton.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 

--- a/Source/Panner.h
+++ b/Source/Panner.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/PitchShiftEffect.h
+++ b/Source/PitchShiftEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "PitchShifter.h"

--- a/Source/Polyrhythms.h
+++ b/Source/Polyrhythms.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "Transport.h"
 #include "UIGrid.h"
 #include "Slider.h"

--- a/Source/Producer.h
+++ b/Source/Producer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"

--- a/Source/PulseRouter.h
+++ b/Source/PulseRouter.h
@@ -28,7 +28,6 @@ bespoke synth, a software modular synthesizer
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "RadioButton.h"

--- a/Source/PulseSequence.h
+++ b/Source/PulseSequence.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Transport.h"
 #include "DropdownList.h"

--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -26,7 +26,7 @@
 */
 
 #pragma once
-#include <iostream>
+
 #include "IDrawableModule.h"
 #include "Transport.h"
 #include "Checkbox.h"

--- a/Source/Pulser.h
+++ b/Source/Pulser.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Transport.h"
 #include "Checkbox.h"

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Checkbox.h"
 #include "Slider.h"

--- a/Source/RadioSequencer.h
+++ b/Source/RadioSequencer.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "UIGrid.h"
 #include "Checkbox.h"

--- a/Source/RandomNoteGenerator.h
+++ b/Source/RandomNoteGenerator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <stdio.h>
 #include "IDrawableModule.h"
 #include "INoteSource.h"
 #include "Transport.h"

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "INoteReceiver.h"
 #include "ADSR.h"

--- a/Source/Rewriter.h
+++ b/Source/Rewriter.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/RhythmSequencer.h
+++ b/Source/RhythmSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Transport.h"

--- a/Source/RingModulator.h
+++ b/Source/RingModulator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/SampleBrowser.h
+++ b/Source/SampleBrowser.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Sample.h"
 #include "ClickButton.h"

--- a/Source/SampleFinder.h
+++ b/Source/SampleFinder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "EnvOscillator.h"
 #include "INoteReceiver.h"

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "PolyphonyMgr.h"
 #include "SampleVoice.h"

--- a/Source/SamplerGrid.h
+++ b/Source/SamplerGrid.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"

--- a/Source/SaveStateLoader.h
+++ b/Source/SaveStateLoader.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <utility>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"

--- a/Source/ScaleDetect.h
+++ b/Source/ScaleDetect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "ClickButton.h"

--- a/Source/ScriptStatus.h
+++ b/Source/ScriptStatus.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "ClickButton.h"

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "EnvOscillator.h"
 #include "IDrawableModule.h"

--- a/Source/SignalGenerator.h
+++ b/Source/SignalGenerator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "INoteReceiver.h"
 #include "IDrawableModule.h"

--- a/Source/SingleOscillator.h
+++ b/Source/SingleOscillator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioSource.h"
 #include "PolyphonyMgr.h"
 #include "SingleOscillatorVoice.h"

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <limits>
 #include "TextEntry.h"
 #include "Ramp.h"

--- a/Source/SliderSequencer.h
+++ b/Source/SliderSequencer.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "Transport.h"
 #include "Checkbox.h"
 #include "Slider.h"

--- a/Source/SlowLayers.h
+++ b/Source/SlowLayers.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "RollingBuffer.h"

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "UIGrid.h"
 #include "ClickButton.h"

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <iostream>
 #include "ClickButton.h"
 #include "IDrawableModule.h"
 #include "INoteReceiver.h"

--- a/Source/SpectralDisplay.h
+++ b/Source/SpectralDisplay.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/Splitter.h
+++ b/Source/Splitter.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "RollingBuffer.h"

--- a/Source/StepSequencer.h
+++ b/Source/StepSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "Transport.h"
 #include "Checkbox.h"
 #include "UIGrid.h"

--- a/Source/StutterControl.h
+++ b/Source/StutterControl.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "Checkbox.h"

--- a/Source/SustainPedal.h
+++ b/Source/SustainPedal.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Checkbox.h"

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <climits>
 #include "IUIControl.h"
 #include "SynthGlobals.h"

--- a/Source/TimerDisplay.h
+++ b/Source/TimerDisplay.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "OpenFrameworksPort.h"
 #include "ClickButton.h"

--- a/Source/Transport.h
+++ b/Source/Transport.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "Slider.h"
 #include "ClickButton.h"

--- a/Source/TransposeFrom.h
+++ b/Source/TransposeFrom.h
@@ -26,7 +26,6 @@
 */
 
 #pragma once
-#include <iostream>
 
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioEffect.h"
 #include "Slider.h"
 #include "Checkbox.h"

--- a/Source/VelocitySetter.h
+++ b/Source/VelocitySetter.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/VelocityStepSequencer.h
+++ b/Source/VelocityStepSequencer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "Transport.h"

--- a/Source/VinylTempoControl.h
+++ b/Source/VinylTempoControl.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IDrawableModule.h"
 #include "IAudioProcessor.h"
 #include "IModulator.h"

--- a/Source/Vocoder.h
+++ b/Source/Vocoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "FFT.h"

--- a/Source/VocoderCarrierInput.h
+++ b/Source/VocoderCarrierInput.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 

--- a/Source/VolcaBeatsControl.h
+++ b/Source/VolcaBeatsControl.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 #include "INoteSource.h"

--- a/Source/WaveformViewer.h
+++ b/Source/WaveformViewer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "IAudioProcessor.h"
 #include "IDrawableModule.h"
 #include "Slider.h"

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <iostream>
 #include "NoteEffectBase.h"
 #include "IDrawableModule.h"
 


### PR DESCRIPTION
Feels like build times have been going up lately, so I'm looking into that a bit.

This change gets rid of the unused (copy-pasted?) `#include <iostream>` (and the odd `<stdio.h>`). It won't help build times much by itself, but removing this heavy `#include` from ~150 individual headers makes the few really busy ones easier to spot.