### PR TITLE
SongBuilder: Fix crash on switch from "Jump" to "Switch" mode

### DIFF
--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -293,6 +293,7 @@ void SongBuilder::OnTimeEvent(double time)
 
    if (mQueuedScene != -1 &&
        (mChangeQuantizeInterval == kInterval_None ||
+        mChangeQuantizeInterval == kInterval_Free ||
         TheTransport->GetMeasure(time + TheTransport->GetListenerInfo(this)->mOffsetInfo.mOffset) % (int)TheTransport->GetMeasureFraction(mChangeQuantizeInterval) == 0))
    {
       SetActiveScene(time, mQueuedScene);


### PR DESCRIPTION
Fixes #1635

The crash was caused by a modulo by zero in this code:

https://github.com/BespokeSynth/BespokeSynth/blob/8fa9efbbce20d4cde21d4d7fb7ac5a53cb4e2213/Source/SongBuilder.cpp#L294-L300

It's called every measure and checks whether to switch scenes. As long as there's a queued scene, "Switch" and "Jump" always switch at the end of a measure though, so the 3rd condition of the `if` doesn't make sense for them.[^1]

[^1]: For "Switch" and "Jump", `GetMeasureFraction` hits the `default` case, which always returns a value < 1.

The `if` already skips the quantization for "Jump" (`kInterval_None`), so let's do the same for "Switch" (`kInterval_Free`).

Side note:
The patch already loads up in "Switch" mode, but it doesn't crash because `mQueuedScene` stays -1, which the `if` rejects first thing. But while in "Jump" mode, `OnTimeEvent` gets called twice per measure, once with a valid `mQueuedScene` and once with -1. So "Switch" could see a valid `mQueuedScene` from "Jump", causing the crash.