### PR TITLE
Correctly set the number of channels within `seaofgrain` so that mono input is processed correctly. Resolves: #1642.

### DIFF
--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -128,7 +128,7 @@ void SeaOfGrain::Process(double time)
    ComputeSliders(0);
    int numChannels = 2;
    SyncBuffers(numChannels);
-   mRecordBuffer.SetNumChannels(GetBuffer()->NumActiveChannels());
+   mRecordBuffer.SetNumChannels(numChannels);
 
    int bufferSize = target->GetBuffer()->BufferSize();
    ChannelBuffer* out = target->GetBuffer();


### PR DESCRIPTION
Correctly set the number of channels within `seaofgrain` so that mono input is processed correctly. Resolves: #1642.