### PR TITLE
Increase midi pages to 32 from 10. Resolves: #1624.

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -66,7 +66,7 @@ MidiController::MidiController()
 void MidiController::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mControllerList = new DropdownList(this, "controller", 3, 2, &mControllerIndex, 157);
+   mControllerList = new DropdownList(this, "controller", 3, 2, &mControllerIndex, 165);
    mMappingDisplayModeSelector = new RadioButton(this, "mappingdisplay", mControllerList, kAnchor_Below, (int*)&mMappingDisplayMode, kRadioHorizontal);
    mBindCheckbox = new Checkbox(this, "bind (hold shift)", mMappingDisplayModeSelector, kAnchor_Below, &mBindMode);
    mPageSelector = new DropdownList(this, "page", mBindCheckbox, kAnchor_Right, &mControllerPage);
@@ -1248,12 +1248,12 @@ void MidiController::DrawModule()
       if (mIsConnected)
       {
          ofSetColor(ofColor::green);
-         DrawTextNormal("connected", 165, 13);
+         DrawTextNormal("connected", 173, 13);
       }
       else
       {
          ofSetColor(ofColor::red);
-         DrawTextNormal("not connected", 165, 13);
+         DrawTextNormal("not connected", 173, 13);
       }
       ofPopStyle();
 
@@ -1520,7 +1520,7 @@ void MidiController::GetModuleDimensions(float& width, float& height)
    }
    else
    {
-      width = 163;
+      width = 171;
       height = 54;
    }
 }

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -39,7 +39,7 @@
 
 #define MIDI_PITCH_BEND_CONTROL_NUM 999
 #define MIDI_PAGE_WIDTH 1000
-#define MAX_MIDI_PAGES 10
+#define MAX_MIDI_PAGES 32
 
 enum MidiMessageType
 {


### PR DESCRIPTION
Increase midi pages to 32 from 10. Resolves: #1624.

Not sure if this causes any issues with existing mappings but from what I could see in the code this should be fine. The memory usage of having 32 is negligible and I suspect the performance impact is too (I can't really test as I don't have a midi controller with me).