### PR TITLE
Made the `circlesequencer` support up to 32nd notes. Resolves: #1610.

### DIFF
--- a/Source/CircleSequencer.cpp
+++ b/Source/CircleSequencer.cpp
@@ -320,7 +320,12 @@ void CircleSequencerRing::OnTransportAdvanced(float amount)
    {
       const double time = NextBufferTime(true) - remainderMs;
       mOwner->PlayNoteOutput(time, mPitch, mSteps[newStep] * 127, -1);
-      mOwner->PlayNoteOutput(time + TheTransport->GetDuration(kInterval_16n), mPitch, 0, -1);
+      NoteInterval interval = kInterval_16n;
+      if (mLength > 10 && mLength < 24)
+         interval = kInterval_32n;
+      else if (mLength >= 24)
+         interval = kInterval_64n;
+      mOwner->PlayNoteOutput(time + TheTransport->GetDuration(interval), mPitch, 0, -1);
    }
 }
 

--- a/Source/CircleSequencer.h
+++ b/Source/CircleSequencer.h
@@ -35,7 +35,7 @@
 
 class CircleSequencer;
 
-#define CIRCLE_SEQUENCER_MAX_STEPS 10
+#define CIRCLE_SEQUENCER_MAX_STEPS 32
 
 class CircleSequencerRing
 {


### PR DESCRIPTION
Made the `circlesequencer` support up to 32nd notes. Resolves: #1610.

![BespokeSynth_20241009_094706](https://github.com/user-attachments/assets/34d3a8db-c0b7-44bb-9bb7-f33102c5c75f)
