### PR TITLE
Force a poll to properly rebuild the buffers when the `multitrackrecorder` is cleared. Resolves: #1604.

### DIFF
--- a/Source/MultitrackRecorder.cpp
+++ b/Source/MultitrackRecorder.cpp
@@ -445,6 +445,7 @@ void MultitrackRecorderTrack::Clear()
       delete recordChunk;
    mRecordChunks.clear();
    mRecordingLength = 0;
+   MultitrackRecorderTrack::Poll();
 }
 
 void MultitrackRecorderTrack::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)


### PR DESCRIPTION
Force a poll to properly rebuild the buffers when the `multitrackrecorder` is cleared. Resolves: #1604.

There might be a better way but "this works :tm:". 

Maybe the code in Poll should be in Process, perhaps with a conditional bool that is set in the Clear method? Poke me if you want me to take that approach instead ;)