### PR TITLE
Made it so the `pitchsetter` does not flush the notes when the pitch slider was changed but tries to preserve polyphony as much as possible instead. Resolves #1543.

### DIFF
--- a/Source/PitchSetter.h
+++ b/Source/PitchSetter.h
@@ -63,5 +63,7 @@ private:
    }
 
    int mPitch{ 36 };
+   bool mFlushOnChange{ false };
+   std::array<int, 128> mNotes;
    IntSlider* mPitchSlider{ nullptr };
 };


### PR DESCRIPTION
Made it so the `pitchsetter` does not flush the notes when the pitch slider was changed but tries to preserve polyphony as much as possible instead. Resolves #1543.

Also made it possible to go back to the original behavior with a triangle menu option.