### PR TITLE
Fixed a bug in the `drumsequencer` when the numrows triangle menu option was set lower than a previously saved snapshot causing "disabled" rows to still send notes. Resolves: #820.

### DIFF
--- a/Source/StepSequencer.cpp
+++ b/Source/StepSequencer.cpp
@@ -750,7 +750,7 @@ int StepSequencer::GetMetaStep(double time)
 
 bool StepSequencer::IsMetaStepActive(double time, int col, int row)
 {
-   return mMetaStepMasks[GetMetaStepMaskIndex(col, row)] & (1 << GetMetaStep(time));
+   return mMetaStepMasks[GetMetaStepMaskIndex(col, row)] & (1 << GetMetaStep(time)) && row < mNumRows;
 }
 
 bool StepSequencer::HasGridController()


### PR DESCRIPTION
Fixed a bug in the `drumsequencer` when the numrows triangle menu option was set lower than a previously saved snapshot causing "disabled" rows to still send notes. Resolves: #820.