### PR TITLE
Allow a single `notetable` module to span the entire note range. Resolves: #839.

### DIFF
--- a/Source/NoteTable.h
+++ b/Source/NoteTable.h
@@ -137,7 +137,7 @@ private:
    FloatSlider* mRandomizePitchRangeSlider{ nullptr };
    ClickButton* mClearButton{ nullptr };
 
-   static constexpr int kMaxLength = 32;
+   static constexpr int kMaxLength = 128;
 
    std::array<double, kMaxLength> mLastColumnPlayTime{};
    std::array<bool[128], kMaxLength> mLastColumnNoteOnPitches{};


### PR DESCRIPTION
Allow a single `notetable` module to span the entire note range. Resolves: #839.

Seems to work like a charm but may have issues with grid controllers (I have not tested this).