### PR TITLE
Fixed a crash in the `songbuilder` module when a new connection cable was canceled. Resolves: #1665.

### DIFF
--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -449,8 +449,8 @@ void SongBuilder::PostRepatch(PatchCableSource* cable, bool fromUserClick)
             mTargets.erase(mTargets.begin() + targetIndex);
          }
       }
-
-      mTargets[targetIndex]->mHadTarget = (mTargets[targetIndex]->GetTarget() != nullptr);
+      if (!mTargets.empty() && mTargets.size() > targetIndex)
+         mTargets[targetIndex]->mHadTarget = (mTargets[targetIndex]->GetTarget() != nullptr);
    }
 }
 


### PR DESCRIPTION
Fixed a crash in the `songbuilder` module when a new connection cable was canceled. Resolves: #1665.