### PR TITLE
Pulsetrain love. Resolves: #953. Resolves: #1127.

### DIFF
--- a/Source/PulseTrain.h
+++ b/Source/PulseTrain.h
@@ -65,6 +65,10 @@ public:
    //UIGridListener
    void GridUpdated(UIGrid* grid, int col, int row, float value, float oldValue) override;
 
+   //IDrawableModule
+   bool IsResizable() const override { return true; }
+   void Resize(float w, float h) override;
+
    //IClickable
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
@@ -92,7 +96,9 @@ private:
 
    void Step(double time, float velocity, int flags);
 
-   static const int kMaxSteps = 32;
+   static const int kMaxSteps = 128;
+   float mWidth{ 254 };
+   float mHeight{ 58 };
    float mVels[kMaxSteps]{};
    int mLength{ 8 };
    IntSlider* mLengthSlider{ nullptr };
@@ -102,8 +108,7 @@ private:
    bool mResetOnStart{ true };
    Checkbox* mResetOnStartCheckbox{ nullptr };
 
-   static const int kIndividualStepCables = 16;
-   PatchCableSource* mStepCables[kIndividualStepCables]{ nullptr };
+   PatchCableSource* mStepCables[kMaxSteps]{ nullptr };
 
    UIGrid* mVelocityGrid{ nullptr };
 };


### PR DESCRIPTION
- Increased the limit of the `pulsetrain` from 32 to 128 and fixed a crash when going beyond the maximum. Resolves: #953.
- Don't render the finished step in the `pulsetrain` module. Resolves: #1127. 
- Made `pulsetrain` resizable.