### PR TITLE
Enhanced midicontroller deviceOutName devicename matching In and Out

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2287,7 +2287,7 @@ void MidiController::ConnectDevice()
    ResyncControllerState();
 
    std::string deviceInName = mControllerList->GetLabel(mControllerIndex);
-   std::string deviceOutName = String(deviceInName).replace("Input", "Output").replace("input", "output").toStdString();
+   std::string deviceOutName = String(deviceInName).replace("Input", "Output").replace("input", "output").replace(" In ", " Out ").toStdString();
    bool hasOutput = false;
    for (const auto& device : MidiOutput::getAvailableDevices())
    {


### PR DESCRIPTION
The `midicontroller` deviceout is generated from the devicein name by replacing the word Input to Output.

My MIDI devicename is "MIDISPORT 4x4 In A", "MIDISPORT 4x4 In B", etc... with matching output names like "MIDISPORT 4x4 Out A".

My deviceout would always be empty, even when manually selecting the correct device in the triangle/properties screen from the deviceout pulldown menu.

I have created a small fix and added a replace command to search for " In " and replace it with " Out ".
I have added spaces to avoid matching parts of words containing the string "In".

It is working now with my MIDI devices.

Possible future enhancement:
A better solution would be to keep automapping the output device, but when the user manually selects a deviceout from the triangle/properties screen, that selection should be kept, until a new midi input is selected in the main screen.