### PR TITLE
Fix incorrect version comparison in CanvasElement loading. Resolves: #1682.

### DIFF
--- a/Source/CanvasElement.cpp
+++ b/Source/CanvasElement.cpp
@@ -449,7 +449,7 @@ void NoteCanvasElement::LoadState(FileStreamIn& in)
 
    in >> mVelocity;
 
-   if (kNCESaveStateRev > 0)
+   if (rev > 0)
    {
       mPitchBendCurve.LoadState(in);
       mModWheelCurve.LoadState(in);


### PR DESCRIPTION
Fix incorrect version comparison in CanvasElement loading. Resolves: #1682.