### PR TITLE
`keyboarddisplay` tweaks.

### DIFF
--- a/Source/KeyboardDisplay.cpp
+++ b/Source/KeyboardDisplay.cpp
@@ -201,16 +201,16 @@ void KeyboardDisplay::RefreshOctaveCount()
 
       int elements = static_cast<int>(ratio / baseRatioForOneElement);
 
-      elements = std::clamp(elements, 1, 10);
+      elements = std::clamp(elements, 1, 11);
 
-      if (mRootOctave + elements > 9) //Ensure that we can't go into octaves where it begins to break...
-         mRootOctave = 10 - mNumOctaves;
+      if (mRootOctave + elements > 10) //Ensure that we can't go into octaves where it begins to break...
+         mRootOctave = 11 - mNumOctaves;
       mNumOctaves = elements;
    }
    else
    {
       mNumOctaves = mForceNumOctaves;
-      mRootOctave = 10 - mNumOctaves;
+      mRootOctave = 11 - mNumOctaves;
    }
 }
 
@@ -224,6 +224,8 @@ void KeyboardDisplay::DrawKeyboard(int x, int y, int w, int h)
    {
       for (int i = 0; i < NumKeys(); ++i)
       {
+         if (i + RootKey() > 127)
+            break;
          bool isBlackKey;
          ofRectangle key = GetKeyboardKeyRect(i + RootKey(), w, h, isBlackKey);
 
@@ -247,7 +249,7 @@ void KeyboardDisplay::DrawKeyboard(int x, int y, int w, int h)
       for (int i = 0; i < NumKeys(); i += 7)
       {
          ofSetColor(108, 37, 62, 255);
-         DrawTextNormal("C" + std::to_string(oct), keySpace * 0.5f - 6.5f + i * keySpace, h - 8, 12);
+         DrawTextNormal(NoteName(oct * 12, false, true), keySpace * 0.5f - 6.5f + i * keySpace, h - 8, 12);
          oct++;
       }
    }
@@ -255,7 +257,7 @@ void KeyboardDisplay::DrawKeyboard(int x, int y, int w, int h)
    ofPushStyle();
    ofFill();
    ofSetLineWidth(2);
-   for (int pitch = RootKey(); pitch < RootKey() + NumKeys(); ++pitch)
+   for (int pitch = RootKey(); pitch < MIN(RootKey() + NumKeys(), mLastOnTime.size()); ++pitch)
    {
       if (gTime >= mLastOnTime[pitch] && (gTime <= mLastOffTime[pitch] || mLastOffTime[pitch] < mLastOnTime[pitch]))
       {
@@ -321,7 +323,7 @@ void KeyboardDisplay::OnKeyPressed(int key, bool isRepeat)
       if (res.mOctaveShift != 0)
       {
          int newRootOctave = mRootOctave + res.mOctaveShift;
-         if (newRootOctave > 0 && newRootOctave + mNumOctaves <= 12)
+         if (newRootOctave >= 0 && newRootOctave + mNumOctaves < 12)
             mRootOctave = newRootOctave;
       }
       if (res.mPitch != -1)

--- a/Source/KeyboardDisplay.h
+++ b/Source/KeyboardDisplay.h
@@ -94,7 +94,7 @@ private:
    bool mShowScale{ false };
    bool mGetVelocityFromClickHeight{ false };
    bool mHideLabels{ false };
-   std::array<float, 128> mLastOnTime{};
-   std::array<float, 128> mLastOffTime{};
+   std::array<double, 128> mLastOnTime{};
+   std::array<double, 128> mLastOffTime{};
    std::unordered_map<int, int> mKeyPressRegister{};
 };


### PR DESCRIPTION
Fixed a crash in `keyboarddisplay` module when notes greater than 127 in value where drawn.
Tweaked the `keyboarddisplay` so it can't render notes with a value greater than 127.
Fixed the octave note text being off by 2 octaves in the `keyboarddisplay` module.
Allowed displaying the full note range in the `keyboarddisplay` module.
Fixed a bug where the lowest octave displayed in the `keyboarddisplay` module wasn't the lowest possible.
Fixed a bug where the `keyboarddisplay` module was using float instead of double for time calculations.