### PR TITLE
`effectchain` loading fix. Resolves: #203. Resolves: #748.

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -783,12 +783,20 @@ IUIControl* IDrawableModule::FindUIControl(const char* name, bool fail /*=true*/
    return nullptr;
 }
 
-IDrawableModule* IDrawableModule::FindChild(const char* name, bool fail) const
+IDrawableModule* IDrawableModule::FindChild(const std::string name, bool fail) const
 {
+   if (name.empty())
+      return nullptr;
    for (int i = 0; i < mChildren.size(); ++i)
    {
-      if (strcmp(mChildren[i]->Name(), name) == 0)
+      if (strcmp(mChildren[i]->Name(), name.c_str()) == 0)
          return mChildren[i];
+   }
+   if (mTypeName == "effectchain") // Due to an issue in the past where child modules of the effectchain module weren't saving their names correctly we are going to try and fix the loading here.
+   {
+      auto child = FindChild(name.substr(0, name.length() - 1), false);
+      if (child)
+         return child;
    }
    if (fail)
       throw UnknownModuleException(name);
@@ -1411,7 +1419,7 @@ void IDrawableModule::LoadState(FileStreamIn& in, int rev)
          std::string childName;
          in >> childName;
          //ofLog() << "Loading " << childName;
-         IDrawableModule* child = FindChild(childName.c_str(), true);
+         IDrawableModule* child = FindChild(childName, true);
          LoadStateValidate(child);
          child->LoadState(in, child->LoadModuleSaveStateRev(in));
       }

--- a/Source/IDrawableModule.h
+++ b/Source/IDrawableModule.h
@@ -104,7 +104,7 @@ public:
    virtual void OnUIControlRequested(const char* name) {}
    void AddChild(IDrawableModule* child);
    void RemoveChild(IDrawableModule* child);
-   IDrawableModule* FindChild(const char* name, bool fail) const;
+   IDrawableModule* FindChild(const std::string name, bool fail) const;
    void GetDimensions(float& width, float& height) override;
    virtual void GetModuleDimensions(float& width, float& height)
    {

--- a/Source/ModuleContainer.cpp
+++ b/Source/ModuleContainer.cpp
@@ -433,7 +433,7 @@ IDrawableModule* ModuleContainer::FindModule(std::string name, bool fail)
          IDrawableModule* child = nullptr;
          try
          {
-            child = mModules[i]->FindChild(tokens[1].c_str(), fail);
+            child = mModules[i]->FindChild(tokens[1], fail);
          }
          catch (UnknownModuleException& e)
          {


### PR DESCRIPTION
Fixed an issue where some old savestates couldn't be loaded due to an issue in the past where the saving of the names of submodules of the `effectchain` module weren't saving their name. Resolves: #203. Resolves: #748.