### PR TITLE
Resolved a bug where the LFO would output NaN values when the length was set to zero. Fixes: #1692. Several fixes to the biquad filter to resolve NaNs. Fixes: #1693. Fixes: #1129. Fixes: #1141.

### DIFF
--- a/Source/BiquadFilter.cpp
+++ b/Source/BiquadFilter.cpp
@@ -63,7 +63,7 @@ void BiquadFilter::UpdateFilterCoeff()
 
    double norm;
    double V = pow(10, fabs(mDbGain) / 20.0);
-   double K = tan(M_PI * (mF / mSampleRate));
+   double K = tan(M_PI * ofClamp(mF / mSampleRate, 0, 0.499999));
    switch (mType)
    {
       case kFilterType_Lowpass:

--- a/Source/BiquadFilter.h
+++ b/Source/BiquadFilter.h
@@ -85,6 +85,8 @@ private:
 
 inline float BiquadFilter::Filter(float in)
 {
+   if (std::isnan(in))
+      return 0;
    double out = in * mA0 + mZ1;
    mZ1 = in * mA1 + mZ2 - mB1 * out;
    mZ2 = in * mA2 - mB2 * out;

--- a/Source/BiquadFilter.h
+++ b/Source/BiquadFilter.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
+
+#include "OpenFrameworksPort.h"
 
 enum FilterType
 {
@@ -85,10 +88,10 @@ private:
 
 inline float BiquadFilter::Filter(float in)
 {
-   if (std::isnan(in))
-      return 0;
-   double out = in * mA0 + mZ1;
+   double out = ofClamp(in * mA0 + mZ1, std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
    mZ1 = in * mA1 + mZ2 - mB1 * out;
    mZ2 = in * mA2 - mB2 * out;
+   if (std::isnan(out) || std::isinf(out))
+      Clear();
    return out;
 }

--- a/Source/LFO.cpp
+++ b/Source/LFO.cpp
@@ -66,8 +66,10 @@ float LFO::CalculatePhase(int samplesIn /*= 0*/, bool doTransform /* = true*/) c
 
 float LFO::TransformPhase(float phase) const
 {
-   if (mLength != 1)
+   if (mLength != 1 && mLength > 0)
       phase = int(phase) + ofClamp((phase - int(phase)) / mLength, 0, 1);
+   else if (mLength != 1)
+      phase = 0;
    return phase;
 }
 
@@ -80,7 +82,7 @@ float LFO::Value(int samplesIn /*= 0*/, float forcePhase /*= -1*/) const
 
    float phase = CalculatePhase(samplesIn);
 
-   if (forcePhase != -1)
+   if (forcePhase != -1 && !std::isnan(forcePhase))
       phase = forcePhase;
 
    phase *= FTWO_PI;
@@ -104,7 +106,7 @@ float LFO::Value(int samplesIn /*= 0*/, float forcePhase /*= -1*/) const
       nonstandardOsc = true;
 
       double perlinPos = gTime + gInvSampleRateMs * samplesIn;
-      if (forcePhase != -1)
+      if (forcePhase != -1 && !std::isnan(forcePhase))
          perlinPos += forcePhase * 1000;
       double perlinPhase = perlinPos * mFreeRate / 1000.0f;
       sample = sPerlinNoise.noise(perlinPhase, mPerlinSeed, -perlinPhase);


### PR DESCRIPTION
* Resolved a bug where the LFO would output NaN values when the length was set to zero. Resolves: #1692. 
* Made it so the biquad filter can recover from NaN values. Resolves: #1693.
* NaN fixes in the biquad filter with extreme values (altered min and max on frequency and Q). Resolves: #1141 and #1129.
