### PR TITLE
Changed AllowLookahead default to on in the `notelooper` module. This seems to behave the best in most common cases as opposed to it being off.

### DIFF
--- a/Source/NoteLooper.cpp
+++ b/Source/NoteLooper.cpp
@@ -392,7 +392,7 @@ void NoteLooper::DropdownUpdated(DropdownList* list, int oldVal, double time)
 void NoteLooper::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadString("target", moduleInfo);
-   mModuleSaveData.LoadBool("allow_lookahead", moduleInfo, false);
+   mModuleSaveData.LoadBool("allow_lookahead", moduleInfo, true);
 
    SetUpFromSaveData();
 }

--- a/Source/NoteLooper.h
+++ b/Source/NoteLooper.h
@@ -117,7 +117,7 @@ private:
    Canvas* mCanvas{ nullptr };
    ClickButton* mClearButton{ nullptr };
    int mVoiceRoundRobin{ kNumVoices - 1 };
-   bool mAllowLookahead{ false };
+   bool mAllowLookahead{ true };
 
    std::array<ModulationParameters, kNumVoices + 1> mVoiceModulations{};
    std::array<int, kNumVoices> mVoiceMap{};


### PR DESCRIPTION
Changed AllowLookahead default to on in the `notelooper` module. This seems to behave the best in most common cases as opposed to it being off.

Related to #930.