### PR TITLE
add new "list" mode to `snapshots`, and make that the default mode

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -428,6 +428,9 @@ void ModularSynth::Poll()
       mArrangeDependenciesWhenLoadCompletes = false;
    }
 
+   if (gHoveredUIControl != nullptr && gHoveredUIControl->IsShowing() == false)
+      gHoveredUIControl = nullptr;
+
    ++sFrameCount;
 }
 

--- a/Source/ModuleSaveData.h
+++ b/Source/ModuleSaveData.h
@@ -49,6 +49,8 @@ public:
    void SetFloat(std::string prop, float val, float min, float max, bool isTextField);
    void SetBool(std::string prop, bool val);
    void SetString(std::string prop, std::string val);
+   template <class T>
+   void SetEnum(std::string prop, T val) { SetInt(prop, (int)val); }
 
    void SetExtents(std::string prop, float min, float max);
 

--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -32,6 +32,13 @@
 
 std::vector<IUIControl*> Snapshots::sSnapshotHighlightControls;
 
+namespace
+{
+   const int kListRowHeight = 15;
+   const int kMinNumListRows = 4;
+   const int kListModeGridWidth = 137;
+}
+
 Snapshots::Snapshots()
 {
 }
@@ -44,15 +51,13 @@ Snapshots::~Snapshots()
 void Snapshots::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mGrid = new UIGrid("uigrid", 5, 38, 120, 50, 8, 3, this);
-   mBlendTimeSlider = new FloatSlider(this, "blend", 5, 20, 70, 15, &mBlendTime, 0, 5000);
-   mCurrentSnapshotSelector = new DropdownList(this, "snapshot", 35, 3, &mCurrentSnapshot, 64);
-   mRandomizeButton = new ClickButton(this, "random", 78, 20);
-   mAddButton = new ClickButton(this, "add", 101, 3);
-   mClearButton = new ClickButton(this, "clear", mAddButton, kAnchor_Right);
-   mStoreCheckbox = new Checkbox(this, "store", mClearButton, kAnchor_Right, &mStoreMode);
+   mGrid = new UIGrid("uigrid", 5, 38, kListModeGridWidth, kMinNumListRows * kListRowHeight, 1, kMinNumListRows, this);
+   mBlendTimeSlider = new FloatSlider(this, "blend", 5, 20, 87, 15, &mBlendTime, 0, 5000);
+   mCurrentSnapshotSelector = new DropdownList(this, "snapshot", 35, 3, &mCurrentSnapshot, 80);
+   mRandomizeButton = new ClickButton(this, "random", mBlendTimeSlider, kAnchor_Right);
+   mAddButton = new ClickButton(this, "add", mCurrentSnapshotSelector, kAnchor_Right);
+   mStoreCheckbox = new Checkbox(this, "store", mAddButton, kAnchor_Right, &mStoreMode);
    mDeleteCheckbox = new Checkbox(this, "delete", mStoreCheckbox, kAnchor_Right, &mDeleteMode);
-   mAutoStoreOnSwitchCheckbox = new Checkbox(this, "auto-store on switch", mStoreCheckbox, kAnchor_Below, &mAutoStoreOnSwitch);
    mSnapshotLabelEntry = new TextEntry(this, "snapshot label", -1, -1, 12, &mSnapshotLabel);
 
    {
@@ -78,7 +83,7 @@ void Snapshots::CreateUIControls()
    }
 
    for (int i = 0; i < 32; ++i)
-      mCurrentSnapshotSelector->AddLabel(ofToString(i).c_str(), i);
+      mCurrentSnapshotSelector->AddLabel(("snapshot" + ofToString(i)).c_str(), i);
 }
 
 void Snapshots::Init()
@@ -118,41 +123,80 @@ void Snapshots::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
 
+   if (IKeyboardFocusListener::GetActiveKeyboardFocus() != mSnapshotLabelEntry)
+      mSnapshotRenameIndex = -1;
+   mSnapshotLabelEntry->SetShowing(mSnapshotRenameIndex != -1);
+
+   if (mDisplayMode == DisplayMode::Grid)
+   {
+      ofVec2f pos = mGrid->GetPosition(K(local));
+      mSnapshotLabelEntry->SetPosition(pos.x, pos.y);
+      mStoreCheckbox->PositionTo(mGrid, kAnchor_Below);
+      mDeleteCheckbox->PositionTo(mStoreCheckbox, kAnchor_Right_Padded);
+   }
+
+   if (mDisplayMode == DisplayMode::List)
+   {
+      ofVec2f pos = mGrid->GetPosition(K(local));
+      pos.y += mSnapshotRenameIndex * kListRowHeight;
+      mSnapshotLabelEntry->SetPosition(pos.x, pos.y);
+
+      mStoreCheckbox->PositionTo(mGrid, kAnchor_Below);
+      mDeleteCheckbox->PositionTo(mStoreCheckbox, kAnchor_Right_Padded);
+   }
+
    mGrid->Draw();
    mBlendTimeSlider->Draw();
    mCurrentSnapshotSelector->Draw();
    mRandomizeButton->Draw();
    mAddButton->Draw();
-   mSnapshotLabelEntry->SetPosition(3, mGrid->GetRect(K(local)).getMaxY() + 3);
-   mSnapshotLabelEntry->Draw();
-   mClearButton->Draw();
    mStoreCheckbox->Draw();
    mDeleteCheckbox->Draw();
-   mAutoStoreOnSwitchCheckbox->Draw();
+
+   if (mDisplayMode == DisplayMode::List)
+   {
+      for (int i = 0; i < (int)mSnapshotCollection.size(); ++i)
+      {
+         if (!mSnapshotCollection[i].mSnapshots.empty() && mSnapshotRenameIndex != i)
+         {
+            std::string label = mSnapshotCollection[i].mLabel;
+            ofVec2f pos = mGrid->GetCellPosition(i % mGrid->GetCols(), i / mGrid->GetCols()) + mGrid->GetPosition(true);
+            DrawTextNormal(label, pos.x + 5, pos.y + 12);
+         }
+      }
+   }
 
    int hover = mGrid->CurrentHover();
    bool storeMode = (GetKeyModifiers() == kModifier_Shift) || mStoreMode;
    bool deleteMode = (GetKeyModifiers() == kModifier_Alt) || mDeleteMode;
-   if (storeMode || deleteMode)
+   bool renameMode = (GetKeyModifiers() == kModifier_Command);
+   if (storeMode || deleteMode || renameMode)
    {
       if (hover >= 0 && hover < mGrid->GetCols() * mGrid->GetRows())
       {
          ofVec2f pos = mGrid->GetCellPosition(hover % mGrid->GetCols(), hover / mGrid->GetCols()) + mGrid->GetPosition(true);
-         float xsize = float(mGrid->GetWidth()) / mGrid->GetCols();
-         float ysize = float(mGrid->GetHeight()) / mGrid->GetRows();
+         float squareSize = float(mGrid->GetHeight()) / mGrid->GetRows();
 
          ofPushStyle();
          ofSetColor(0, 0, 0);
          if (storeMode)
          {
             ofFill();
-            ofRect(pos.x + xsize / 2 - 1, pos.y + 3, 2, ysize - 6, 0);
-            ofRect(pos.x + 3, pos.y + ysize / 2 - 1, xsize - 6, 2, 0);
+            ofRect(pos.x + squareSize / 2 - 1, pos.y + 3, 2, squareSize - 6, 0);
+            ofRect(pos.x + 3, pos.y + squareSize / 2 - 1, squareSize - 6, 2, 0);
          }
          else if (deleteMode && !mSnapshotCollection[hover].mSnapshots.empty())
          {
-            ofLine(pos.x + 3, pos.y + 3, pos.x + xsize - 3, pos.y + ysize - 3);
-            ofLine(pos.x + xsize - 3, pos.y + 3, pos.x + 3, pos.y + ysize - 3);
+            ofLine(pos.x + 3, pos.y + 3, pos.x + squareSize - 3, pos.y + squareSize - 3);
+            ofLine(pos.x + squareSize - 3, pos.y + 3, pos.x + 3, pos.y + squareSize - 3);
+         }
+         else if (renameMode)
+         {
+            ofLine(pos.x + squareSize / 2, pos.y + 4, pos.x + squareSize / 2, pos.y + squareSize - 4);
+            ofLine(pos.x + squareSize / 2 - 3, pos.y + 3, pos.x + squareSize / 2 - 1, pos.y + 3);
+            ofLine(pos.x + squareSize / 2 + 1, pos.y + 3, pos.x + squareSize / 2 + 3, pos.y + 3);
+            ofLine(pos.x + squareSize / 2 - 3, pos.y + squareSize - 3, pos.x + squareSize / 2 - 1, pos.y + squareSize - 3);
+            ofLine(pos.x + squareSize / 2 + 1, pos.y + squareSize - 3, pos.x + squareSize / 2 + 3, pos.y + squareSize - 3);
          }
          ofPopStyle();
       }
@@ -173,32 +217,44 @@ void Snapshots::DrawModule()
          ofPopStyle();
       }
    }
+
+   if (mSnapshotRenameIndex != -1)
+   {
+      ofRectangle rect = mSnapshotLabelEntry->GetRect(K(local));
+      ofPushStyle();
+      ofSetColor(ofColor(40, 40, 40));
+      ofFill();
+      ofRect(rect);
+      ofPopStyle();
+   }
+   mSnapshotLabelEntry->Draw();
 }
 
 void Snapshots::DrawModuleUnclipped()
 {
-   int hover = mGrid->CurrentHover();
-   if (hover >= 0 && !mSnapshotCollection.empty())
+   if (mDisplayMode == DisplayMode::Grid)
    {
-      assert(hover >= 0 && hover < mSnapshotCollection.size());
+      int hover = mGrid->CurrentHover();
+      if (hover >= 0 && hover < mSnapshotCollection.size())
+      {
+         std::string tooltip = mSnapshotCollection[hover].mLabel;
+         ofVec2f pos = mGrid->GetCellPosition(hover % mGrid->GetCols(), hover / mGrid->GetCols()) + mGrid->GetPosition(true);
+         pos.x += (mGrid->GetWidth() / mGrid->GetCols()) + 3;
+         pos.y += (mGrid->GetHeight() / mGrid->GetRows()) / 2;
 
-      std::string tooltip = mSnapshotCollection[hover].mLabel;
-      ofVec2f pos = mGrid->GetCellPosition(hover % mGrid->GetCols(), hover / mGrid->GetCols()) + mGrid->GetPosition(true);
-      pos.x += (mGrid->GetWidth() / mGrid->GetCols()) + 3;
-      pos.y += (mGrid->GetHeight() / mGrid->GetRows()) / 2;
+         float width = GetStringWidth(tooltip);
 
-      float width = GetStringWidth(tooltip);
+         ofFill();
+         ofSetColor(50, 50, 50);
+         ofRect(pos.x, pos.y, width + 10, 15);
 
-      ofFill();
-      ofSetColor(50, 50, 50);
-      ofRect(pos.x, pos.y, width + 10, 15);
+         ofNoFill();
+         ofSetColor(255, 255, 255);
+         ofRect(pos.x, pos.y, width + 10, 15);
 
-      ofNoFill();
-      ofSetColor(255, 255, 255);
-      ofRect(pos.x, pos.y, width + 10, 15);
-
-      ofSetColor(255, 255, 255);
-      DrawTextNormal(tooltip, pos.x + 5, pos.y + 12);
+         ofSetColor(255, 255, 255);
+         DrawTextNormal(tooltip, pos.x + 5, pos.y + 12);
+      }
    }
 }
 
@@ -210,11 +266,11 @@ bool Snapshots::HasSnapshot(int index) const
 void Snapshots::UpdateGridValues()
 {
    mGrid->Clear();
-   assert(mSnapshotCollection.size() >= size_t(mGrid->GetRows()) * mGrid->GetCols());
    for (int i = 0; i < mGrid->GetRows() * mGrid->GetCols(); ++i)
    {
       float val = 0;
-      if (mSnapshotCollection[i].mSnapshots.empty() == false)
+      if (i < mSnapshotCollection.size() &&
+          mSnapshotCollection[i].mSnapshots.empty() == false)
          val = .5f;
       mGrid->SetVal(i % mGrid->GetCols(), i / mGrid->GetCols(), val);
    }
@@ -250,11 +306,28 @@ void Snapshots::OnClicked(float x, float y, bool right)
       int idx = cell.mCol + cell.mRow * mGrid->GetCols();
 
       if (GetKeyModifiers() == kModifier_Shift || mStoreMode)
-         StoreSnapshot(idx, false);
+      {
+         StoreSnapshot(idx, true);
+      }
       else if (GetKeyModifiers() == kModifier_Alt || mDeleteMode)
+      {
          DeleteSnapshot(idx);
+      }
+      else if (GetKeyModifiers() == kModifier_Command)
+      {
+         mSnapshotRenameIndex = idx;
+         if (idx >= 0 && idx < (int)mSnapshotCollection.size())
+         {
+            mSnapshotLabel = mSnapshotCollection[idx].mLabel;
+            mSnapshotLabelEntry->UpdateDisplayString();
+         }
+         mSnapshotLabelEntry->MakeActiveTextEntry(!K(setCaretToEnd));
+         mSnapshotLabelEntry->SelectAll();
+      }
       else
+      {
          SetSnapshot(idx, NextBufferTime(false));
+      }
 
       UpdateGridValues();
    }
@@ -272,7 +345,7 @@ void Snapshots::PlayNote(double time, int pitch, int velocity, int voiceIdx, Mod
    if (velocity > 0 && pitch < (int)mSnapshotCollection.size())
    {
       if (mStoreMode)
-         StoreSnapshot(pitch, false);
+         StoreSnapshot(pitch, true);
       else if (mDeleteMode)
          DeleteSnapshot(pitch);
       else
@@ -505,12 +578,13 @@ void Snapshots::StoreSnapshot(int idx, bool setAsCurrent)
 
 void Snapshots::DeleteSnapshot(int idx)
 {
-   assert(idx >= 0 && idx < mSnapshotCollection.size());
-
-   SnapshotCollection& coll = mSnapshotCollection[idx];
-   coll.mSnapshots.clear();
-   coll.mLabel = ofToString(idx);
-   mCurrentSnapshotSelector->SetLabel(coll.mLabel, idx);
+   if (idx >= 0 && idx < mSnapshotCollection.size())
+   {
+      SnapshotCollection& coll = mSnapshotCollection[idx];
+      coll.mSnapshots.clear();
+      coll.mLabel = "snapshot" + ofToString(idx);
+      mCurrentSnapshotSelector->SetLabel(coll.mLabel, idx);
+   }
 }
 
 bool Snapshots::OnPush2Control(Push2Control* push2, MidiMessageType type, int controlIndex, float midiValue)
@@ -535,7 +609,7 @@ bool Snapshots::OnPush2Control(Push2Control* push2, MidiMessageType type, int co
          else if (midiValue > 0 && index >= 0 && index < (int)mSnapshotCollection.size())
          {
             if (mStoreMode)
-               StoreSnapshot(index, false);
+               StoreSnapshot(index, true);
             else if (mDeleteMode)
                DeleteSnapshot(index);
             else
@@ -593,9 +667,23 @@ void Snapshots::UpdatePush2Leds(Push2Control* push2)
    }
 }
 
+void Snapshots::ResizeSnapshotCollection(int size)
+{
+   int oldSize = (int)mSnapshotCollection.size();
+   if (size != oldSize)
+   {
+      mSnapshotCollection.resize(size);
+      for (int i = oldSize; i < size; ++i)
+         mSnapshotCollection[i].mLabel = "snapshot" + ofToString(i);
+
+      if (mDisplayMode == DisplayMode::List)
+         mModuleSaveData.SetInt("num_list_snapshots", size);
+   }
+}
+
 namespace
 {
-   const float extraW = 10;
+   const float extraW = 9;
    const float extraH = 58;
    const float gridSquareDimension = 18;
    const int maxGridSide = 20;
@@ -608,26 +696,21 @@ void Snapshots::ButtonClicked(ClickButton* button, double time)
 
    if (button == mAddButton)
    {
-      for (size_t i = 0; i < mSnapshotCollection.size(); ++i)
+      for (size_t i = 0; i < mSnapshotCollection.size() + 1; ++i)
       {
+         if (i == mSnapshotCollection.size()) //we didn't find any
+            ResizeSnapshotCollection(i + 1);
          if (mSnapshotCollection[i].mSnapshots.empty())
          {
-            StoreSnapshot(i, false);
+            StoreSnapshot(i, true);
             mCurrentSnapshot = i;
-            UpdateGridValues();
+            if(mDisplayMode == DisplayMode::List)
+               UpdateListGrid();
+            if (mDisplayMode == DisplayMode::Grid)
+               UpdateGridValues();
             break;
          }
       }
-   }
-
-   if (button == mClearButton)
-   {
-      for (size_t i = 0; i < mSnapshotCollection.size(); ++i)
-      {
-         if (!mSnapshotCollection[i].mSnapshots.empty())
-            DeleteSnapshot(i);
-      }
-      UpdateGridValues();
    }
 }
 
@@ -638,7 +721,7 @@ void Snapshots::DropdownUpdated(DropdownList* list, int oldVal, double time)
       int newIdx = mCurrentSnapshot;
       mCurrentSnapshot = oldVal;
       if (mStoreMode)
-         StoreSnapshot(newIdx, false);
+         StoreSnapshot(newIdx, true);
       else if (mDeleteMode)
          DeleteSnapshot(newIdx);
       else
@@ -651,8 +734,15 @@ void Snapshots::TextEntryComplete(TextEntry* entry)
 {
    if (entry == mSnapshotLabelEntry)
    {
-      mSnapshotCollection[mCurrentSnapshot].mLabel = mSnapshotLabel;
-      mCurrentSnapshotSelector->SetLabel(mSnapshotLabel, mCurrentSnapshot);
+      int snapshotIndex = mCurrentSnapshot;
+      if (mSnapshotRenameIndex != -1)
+      {
+         snapshotIndex = mSnapshotRenameIndex;
+         mSnapshotRenameIndex = -1;
+      }
+
+      mSnapshotCollection[snapshotIndex].mLabel = mSnapshotLabel;
+      mCurrentSnapshotSelector->SetLabel(mSnapshotLabel, snapshotIndex);
    }
 }
 
@@ -664,47 +754,65 @@ void Snapshots::GetModuleDimensions(float& width, float& height)
 
 void Snapshots::Resize(float w, float h)
 {
-   SetGridSize(MAX(w - extraW, 120), MAX(h - extraH, gridSquareDimension));
+   SetGridSize(MAX(w - extraW, 137), MAX(h - extraH, gridSquareDimension));
 }
 
 void Snapshots::SetGridSize(float w, float h)
 {
+   assert(mDisplayMode == DisplayMode::Grid);
    mGrid->SetDimensions(w, h);
    int cols = MIN(w / gridSquareDimension, maxGridSide);
    int rows = MIN(h / gridSquareDimension, maxGridSide);
    mGrid->SetGrid(cols, rows);
-   int oldSize = (int)mSnapshotCollection.size();
-   if (oldSize < size_t(cols) * rows)
-   {
-      mSnapshotCollection.resize(size_t(cols) * rows);
-      for (int i = oldSize; i < (int)mSnapshotCollection.size(); ++i)
-         mSnapshotCollection[i].mLabel = ofToString(i);
-   }
+   ResizeSnapshotCollection(cols * rows);
    UpdateGridValues();
-}
-
-void Snapshots::SaveLayout(ofxJSONElement& moduleInfo)
-{
-   moduleInfo["gridwidth"] = mGrid->GetWidth();
-   moduleInfo["gridheight"] = mGrid->GetHeight();
 }
 
 void Snapshots::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadInt("defaultsnapshot", moduleInfo, -1, -1, 100, true);
-
-   mModuleSaveData.LoadFloat("gridwidth", moduleInfo, 120, 120, 1000);
-   mModuleSaveData.LoadFloat("gridheight", moduleInfo, 50, 15, 1000);
+   EnumMap map;
+   map["grid"] = (int)DisplayMode::Grid;
+   map["list"] = (int)DisplayMode::List;
+   mModuleSaveData.LoadEnum<DisplayMode>("display_mode", moduleInfo, (int)DisplayMode::List, nullptr, &map);
+   mModuleSaveData.LoadInt("num_list_snapshots", moduleInfo, 8, 0, 64, K(isTextField));
    mModuleSaveData.LoadBool("allow_set_on_audio_thread", moduleInfo, true);
    mModuleSaveData.LoadBool("auto_store_on_switch", moduleInfo, false);
+
+   //for rev < 4
+   mOldWidth = moduleInfo["gridwidth"].asFloat();
+   mOldHeight = moduleInfo["gridheight"].asFloat();
 
    SetUpFromSaveData();
 }
 
 void Snapshots::SetUpFromSaveData()
 {
-   SetGridSize(mModuleSaveData.GetFloat("gridwidth"), mModuleSaveData.GetFloat("gridheight"));
    mAllowSetOnAudioThread = mModuleSaveData.GetBool("allow_set_on_audio_thread");
+   mDisplayMode = mModuleSaveData.GetEnum<DisplayMode>("display_mode");
+   mAutoStoreOnSwitch = mModuleSaveData.GetBool("auto_store_on_switch");
+
+   if (mDisplayMode == DisplayMode::Grid)
+   {
+      // set up the grid
+      float w, h;
+      GetModuleDimensions(w, h);
+      Resize(w, h);
+   }
+
+   if (mDisplayMode == DisplayMode::List)
+   {
+      ResizeSnapshotCollection(mModuleSaveData.GetInt("num_list_snapshots"));
+      UpdateListGrid();
+   }
+}
+
+void Snapshots::UpdateListGrid()
+{
+   int numSnapshots = mSnapshotCollection.size();
+   mGrid->SetGrid(1, numSnapshots);
+   mGrid->SetDimensions(kListModeGridWidth, kListRowHeight * numSnapshots);
+   UpdateGridValues();
 }
 
 void Snapshots::SaveState(FileStreamOut& out)
@@ -752,6 +860,9 @@ void Snapshots::SaveState(FileStreamOut& out)
    }
 
    out << mCurrentSnapshot;
+
+   out << mGrid->GetWidth();
+   out << mGrid->GetHeight();
 }
 
 void Snapshots::LoadState(FileStreamIn& in, int rev)
@@ -796,7 +907,7 @@ void Snapshots::LoadState(FileStreamIn& in, int rev)
       }
       in >> mSnapshotCollection[i].mLabel;
       if (rev < 2 && mSnapshotCollection[i].mLabel.empty())
-         mSnapshotCollection[i].mLabel = ofToString(i);
+         mSnapshotCollection[i].mLabel = "snapshot" + ofToString(i);
       mCurrentSnapshotSelector->SetLabel(mSnapshotCollection[i].mLabel, i);
    }
 
@@ -835,6 +946,25 @@ void Snapshots::LoadState(FileStreamIn& in, int rev)
 
    if (rev >= 2)
       in >> mCurrentSnapshot;
+
+   if (rev < 4)
+   {
+      mDisplayMode = DisplayMode::Grid;
+      mModuleSaveData.SetEnum("display_mode", DisplayMode::Grid);
+   }
+
+   if (rev >= 4)
+   {
+      float w, h;
+      in >> w;
+      in >> h;
+      if (mDisplayMode == DisplayMode::Grid)
+         SetGridSize(w, h);
+   }
+   else
+   {
+      SetGridSize(mOldWidth, mOldHeight);
+   }
 }
 
 void Snapshots::UpdateOldControlName(std::string& oldName)
@@ -866,6 +996,20 @@ bool Snapshots::LoadOldControl(FileStreamIn& in, std::string& oldName)
          return true;
       }
    }
+   if (mLoadRev < 4)
+   {
+      if (oldName == "auto-store on switch")
+      {
+         //load from checkbox
+         int checkboxSliderRev;
+         in >> checkboxSliderRev;
+         float var;
+         in >> var;
+         mAutoStoreOnSwitch = var > 0.5f;
+         mModuleSaveData.SetBool("auto_store_on_switch", mAutoStoreOnSwitch);
+         return true;
+      }
+   }
    return false;
 }
 
@@ -873,6 +1017,7 @@ std::vector<IUIControl*> Snapshots::ControlsToNotSetDuringLoadState() const
 {
    std::vector<IUIControl*> ignore;
    ignore.push_back(mCurrentSnapshotSelector);
+   ignore.push_back(mSnapshotLabelEntry);
    return ignore;
 }
 

--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -704,7 +704,7 @@ void Snapshots::ButtonClicked(ClickButton* button, double time)
          {
             StoreSnapshot(i, true);
             mCurrentSnapshot = i;
-            if(mDisplayMode == DisplayMode::List)
+            if (mDisplayMode == DisplayMode::List)
                UpdateListGrid();
             if (mDisplayMode == DisplayMode::Grid)
                UpdateGridValues();

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -174,7 +174,7 @@ private:
    int mQueuedSnapshotIndex{ -1 };
    bool mAllowSetOnAudioThread{ false };
    TextEntry* mSnapshotLabelEntry{ nullptr };
-   std::string mSnapshotLabel{ };
+   std::string mSnapshotLabel{};
    int mLoadRev{ -1 };
    bool mStoreMode{ false };
    Checkbox* mStoreCheckbox{ nullptr };

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -53,7 +53,7 @@ public:
    //IDrawableModule
    void Init() override;
    void Poll() override;
-   bool IsResizable() const override { return true; }
+   bool IsResizable() const override { return mDisplayMode == DisplayMode::Grid; }
    void Resize(float w, float h) override;
 
    bool HasSnapshot(int index) const;
@@ -81,12 +81,11 @@ public:
    void TextEntryComplete(TextEntry* entry) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
-   void SaveLayout(ofxJSONElement& moduleInfo) override;
    void SetUpFromSaveData() override;
    void SaveState(FileStreamOut& out) override;
    void LoadState(FileStreamIn& in, int rev) override;
    bool LoadOldControl(FileStreamIn& in, std::string& oldName) override;
-   int GetModuleSaveStateRev() const override { return 3; }
+   int GetModuleSaveStateRev() const override { return 4; }
    std::vector<IUIControl*> ControlsToNotSetDuringLoadState() const override;
    void UpdateOldControlName(std::string& oldName) override;
 
@@ -103,6 +102,8 @@ private:
    bool IsConnectedToPath(std::string path) const;
    void RandomizeTargets();
    void RandomizeControl(IUIControl* control);
+   void UpdateListGrid();
+   void ResizeSnapshotCollection(int size);
 
    //IDrawableModule
    void DrawModule() override;
@@ -110,6 +111,12 @@ private:
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
+
+   enum class DisplayMode
+   {
+      Grid,
+      List
+   };
 
    struct Snapshot
    {
@@ -167,13 +174,15 @@ private:
    int mQueuedSnapshotIndex{ -1 };
    bool mAllowSetOnAudioThread{ false };
    TextEntry* mSnapshotLabelEntry{ nullptr };
-   std::string mSnapshotLabel;
+   std::string mSnapshotLabel{ };
    int mLoadRev{ -1 };
-   ClickButton* mClearButton{ nullptr };
    bool mStoreMode{ false };
    Checkbox* mStoreCheckbox{ nullptr };
    bool mDeleteMode{ false };
    Checkbox* mDeleteCheckbox{ nullptr };
    bool mAutoStoreOnSwitch{ false };
-   Checkbox* mAutoStoreOnSwitchCheckbox{ nullptr };
+   DisplayMode mDisplayMode{ DisplayMode::List };
+   int mSnapshotRenameIndex{ -1 };
+   float mOldWidth{ 0 };
+   float mOldHeight{ 0 };
 };

--- a/Source/TextEntry.h
+++ b/Source/TextEntry.h
@@ -70,6 +70,7 @@ public:
    const char* GetText() const { return mString; }
    TextEntryType GetTextEntryType() const { return mType; }
    void SetText(std::string text);
+   void SelectAll();
 
    void GetDimensions(float& width, float& height) override;
 
@@ -101,7 +102,6 @@ private:
    void AcceptEntry(bool pressedEnter) override;
    void CancelEntry() override;
    void MoveCaret(int pos, bool allowSelection = true);
-   void SelectAll();
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -66,15 +66,13 @@ radiosequencer~sequence to only enable one value at a time. patch it to the "ena
 
 
 
-snapshots~save and restore sets of values. connect the grey circle to modules to affect all controls on that module. connect the purple circle to a control to affect only that control. shift-click on the grid to store a preset to that square, and click on a grid square to load that preset.
+snapshots~save and restore sets of values. connect the grey circle to modules to affect all controls on that module. connect the purple circle to a control to affect only that control. shift-click on the grid to store a snapshot to that square, and click on a grid square to load that snapshot. alt/option-click to delete a snapshot, and ctrl/command-click to rename a snapshot.
 ~blend~length of time in milliseconds over which to blend snapshot values
 ~snapshot~jump to a snapshot
 ~random~randomize connected controls
 ~add~snapshot the currently connected controls to the next available snapshot slot
-~clear~clear all snapshots
 ~store~when clicking/selecting a snapshot, store into that slot (alternately: hold the shift key)
 ~delete~when clicking/selecting a snapshot, delete that slot (alternately: hold the alt/option key)
-~auto-store on switch~when switching to a new slot, automatically store state in the current slot
 ~snapshot label~assign a label to this snapshot
 
 


### PR DESCRIPTION
`snapshots` is a super powerful module for organizing ideas, so here are some improvements to encourage effective usage. the old "grid" mode is still useful, and can be accessed via the triangle menu.