### PR TITLE
fix issues related to saving a `seaofgrain` at one sample rate and loading it at another sample rate

### DIFF
--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -54,14 +54,14 @@ void Granulator::Reset()
    }
 }
 
-void Granulator::ProcessFrame(double time, ChannelBuffer* buffer, int bufferLength, double offset, float* output)
+void Granulator::ProcessFrame(double time, ChannelBuffer* buffer, int bufferLength, double offset, float speed, float* output)
 {
    if (time + gInvSampleRateMs >= mNextGrainSpawnMs)
    {
       double startFromMs = mNextGrainSpawnMs;
       if (startFromMs < time - 1000) //must have recently started processing, reset
          startFromMs = time;
-      SpawnGrain(mNextGrainSpawnMs, offset, buffer->NumActiveChannels() == 2 ? mWidth : 0);
+      SpawnGrain(mNextGrainSpawnMs, offset, buffer->NumActiveChannels() == 2 ? mWidth : 0, speed);
       mNextGrainSpawnMs = startFromMs + mGrainLengthMs * 1 / mGrainOverlap * ofRandom(1 - mSpacingRandomize / 2, 1 + mSpacingRandomize / 2);
    }
 
@@ -76,11 +76,11 @@ void Granulator::ProcessFrame(double time, ChannelBuffer* buffer, int bufferLeng
    }
 }
 
-void Granulator::SpawnGrain(double time, double offset, float width)
+void Granulator::SpawnGrain(double time, double offset, float width, float speed)
 {
    if (mLiveMode)
    {
-      float speedMult = 1 + mSpeedRandomize;
+      float speedMult = speed + mSpeedRandomize;
       if (mOctaves)
          speedMult *= 1.5f;
       float extraSpeed = MAX(0, speedMult * mSpeed - 1);
@@ -88,7 +88,7 @@ void Granulator::SpawnGrain(double time, double offset, float width)
       float extraSamples = extraMs / gInvSampleRateMs;
       offset -= extraSamples;
    }
-   float speedMult = 1 + ofRandom(-mSpeedRandomize, mSpeedRandomize);
+   float speedMult = speed + ofRandom(-mSpeedRandomize, mSpeedRandomize);
    float vol = 1;
    if (mOctaves)
    {

--- a/Source/Granulator.h
+++ b/Source/Granulator.h
@@ -57,7 +57,7 @@ class Granulator
 {
 public:
    Granulator();
-   void ProcessFrame(double time, ChannelBuffer* buffer, int bufferLength, double offset, float* output);
+   void ProcessFrame(double time, ChannelBuffer* buffer, int bufferLength, double offset, float speed, float* output);
    void Draw(float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength);
    void Reset();
    void ClearGrains();
@@ -73,7 +73,7 @@ public:
    float mWidth{ 1 };
 
 private:
-   void SpawnGrain(double time, double offset, float width);
+   void SpawnGrain(double time, double offset, float width, float speed);
 
    double mNextGrainSpawnMs{ 0 };
    int mNextGrainIdx{ 0 };

--- a/Source/LiveGranulator.cpp
+++ b/Source/LiveGranulator.cpp
@@ -121,7 +121,7 @@ void LiveGranulator::ProcessAudio(double time, ChannelBuffer* buffer)
       {
          float sample[ChannelBuffer::kMaxNumChannels];
          Clear(sample, ChannelBuffer::kMaxNumChannels);
-         mGranulator.ProcessFrame(time, mBuffer.GetRawBuffer(), mBufferLength, mBuffer.GetRawBufferOffset(0) - mFreezeExtraSamples - 1 + mPos, sample);
+         mGranulator.ProcessFrame(time, mBuffer.GetRawBuffer(), mBufferLength, mBuffer.GetRawBufferOffset(0) - mFreezeExtraSamples - 1 + mPos, 1.0f, sample);
          for (int ch = 0; ch < buffer->NumActiveChannels(); ++ch)
             buffer->GetChannel(ch)[i] = mDry * buffer->GetChannel(ch)[i] + sample[ch];
       }

--- a/Source/LooperGranulator.cpp
+++ b/Source/LooperGranulator.cpp
@@ -101,7 +101,7 @@ void LooperGranulator::ProcessFrame(double time, float bufferOffset, float* outp
    {
       int bufferLength;
       auto* buffer = mLooper->GetLoopBuffer(bufferLength);
-      mGranulator.ProcessFrame(time, buffer, bufferLength, bufferOffset, output);
+      mGranulator.ProcessFrame(time, buffer, bufferLength, bufferOffset, 1.0f, output);
    }
 }
 

--- a/Source/RollingBuffer.cpp
+++ b/Source/RollingBuffer.cpp
@@ -144,7 +144,7 @@ void RollingBuffer::Draw(int x, int y, int width, int height, int length /*= -1*
 
 namespace
 {
-   const int kSaveStateRev = 3;
+   const int kSaveStateRev = 4;
 }
 
 void RollingBuffer::SaveState(FileStreamOut& out)
@@ -153,6 +153,7 @@ void RollingBuffer::SaveState(FileStreamOut& out)
 
    out << mBuffer.NumActiveChannels();
    out << Size();
+   out << gSampleRate;
    for (int i = 0; i < mBuffer.NumActiveChannels(); ++i)
    {
       out << mOffsetToNow[i];
@@ -168,29 +169,55 @@ void RollingBuffer::LoadState(FileStreamIn& in)
    int channels = ChannelBuffer::kMaxNumChannels;
    if (rev >= 2)
       in >> channels;
+   mBuffer.SetNumActiveChannels(channels);
+
    int savedSize = Size();
    if (rev >= 3)
       in >> savedSize;
    if (rev < 3 && UserPrefs.oversampling.Get() > 1)
       savedSize = savedSize / UserPrefs.oversampling.Get();
-   mBuffer.SetNumActiveChannels(channels);
+
+   int savedSampleRate = gSampleRate;
+   if (rev >= 4)
+      in >> savedSampleRate;
+
    for (int i = 0; i < channels; ++i)
    {
       in >> mOffsetToNow[i];
       mOffsetToNow[i] %= Size();
-      if (savedSize <= Size())
+      if (savedSampleRate == gSampleRate)
       {
-         in.Read(mBuffer.GetChannel(i), savedSize);
+         if (savedSize <= Size())
+         {
+            in.Read(mBuffer.GetChannel(i), savedSize);
+         }
+         else
+         {
+            //saved with a longer buffer than we have... not sure what the right solution here is, but lets just fill the buffer over and over again until we consume all of the samples
+            int sizeLeft = savedSize;
+            while (sizeLeft > 0)
+            {
+               in.Read(mBuffer.GetChannel(i), MIN(sizeLeft, Size()));
+               sizeLeft -= Size();
+            }
+         }
       }
       else
       {
-         //saved with a longer buffer than we have... not sure what the right solution here is, but lets just fill the buffer over and over again until we consume all of the samples
-         int sizeLeft = savedSize;
-         while (sizeLeft > 0)
+         float sampleRateRatio = (float)savedSampleRate / gSampleRate;
+         mOffsetToNow[i] = int(mOffsetToNow[i] / sampleRateRatio);
+         float* sampleLoader = new float[savedSize];
+         in.Read(sampleLoader, savedSize);
+         float* destinationBuffer = mBuffer.GetChannel(i);
+         for (int j = 0; j < Size(); ++j)
          {
-            in.Read(mBuffer.GetChannel(i), MIN(sizeLeft, Size()));
-            sizeLeft -= Size();
+            float pos = j * sampleRateRatio;
+            int posA = MIN(int(pos), savedSize - 1);
+            int posB = MIN(posA + 1, savedSize - 1);
+            float alpha = pos - posA;
+            destinationBuffer[j] = sampleLoader[posA] * (1 - alpha) + sampleLoader[posB] * alpha;
          }
+         delete[] sampleLoader;
       }
    }
 }

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -99,6 +99,7 @@ private:
    void GetModuleDimensions(float& width, float& height) override;
    void OnClicked(float x, float y, bool right) override;
 
+   float GetSampleRateRatio() const;
    ChannelBuffer* GetSourceBuffer();
    float GetSourceStartSample();
    float GetSourceEndSample();


### PR DESCRIPTION
fixes #1704
