### PR TITLE
Minimap tweaks. Resolves: #1120. Resolves: #1119. 

### DIFF
--- a/Source/Minimap.cpp
+++ b/Source/Minimap.cpp
@@ -1,12 +1,15 @@
 #include "Minimap.h"
+
+#include "EffectChain.h"
 #include "ModularSynth.h"
 #include "OpenFrameworksPort.h"
+#include "Prefab.h"
+#include "TitleBar.h"
+#include "UserPrefs.h"
 
 namespace
 {
    const float kMaxLength = 150;
-   const float kMarginRight = 10;
-   const float kMarginTop = 45;
    const float kBookmarkSize = 15;
    const float kNumBookmarks = 9;
 }
@@ -119,22 +122,41 @@ ofVec2f Minimap::CoordsToViewport(ofRectangle& boundingBox, float x, float y)
 void Minimap::DrawModulesOnMinimap(ofRectangle& boundingBox)
 {
    std::vector<IDrawableModule*> modules;
+   std::vector<IDrawableModule*> second_pass_modules;
    TheSynth->GetRootContainer()->GetAllModules(modules);
 
    ofPushStyle();
-   for (int i = 0; i < modules.size(); ++i)
+   for (auto& module : modules)
    {
-      if (!modules[i]->IsShowing())
+      if (!module->IsShowing() ||
+          (dynamic_cast<IDrawableModule*>(module->GetParent()) && dynamic_cast<IDrawableModule*>(module->GetParent())->Minimized()))
       {
          continue;
       }
-      ofRectangle moduleRect = modules[i]->GetRect();
-      ofColor moduleColor(IDrawableModule::GetColor(modules[i]->GetModuleCategory()));
-      ofSetColor(moduleColor);
-      ofFill();
-      ofRect(CoordsToMinimap(boundingBox, moduleRect));
+      if (dynamic_cast<Prefab*>(module->GetParent()) != nullptr || dynamic_cast<EffectChain*>(module->GetParent()) != nullptr)
+      {
+         second_pass_modules.push_back(module);
+         continue;
+      }
+      if (dynamic_cast<EffectChain*>(module) != nullptr && !module->GetChildren().empty() && !module->Minimized())
+         for (auto& effect : module->GetChildren())
+            second_pass_modules.push_back(effect);
+      DrawModuleOnMinimap(boundingBox, module);
    }
+   for (auto& module : second_pass_modules)
+      DrawModuleOnMinimap(boundingBox, module);
    ofPopStyle();
+}
+
+void Minimap::DrawModuleOnMinimap(ofRectangle& boundingBox, IDrawableModule* module)
+{
+   ofRectangle moduleRect = module->GetRect();
+   ofColor moduleColor(IDrawableModule::GetColor(module->GetModuleCategory()));
+   if (!module->GetChildren().empty())
+      moduleColor.a = 127;
+   ofSetColor(moduleColor);
+   ofFill();
+   ofRect(CoordsToMinimap(boundingBox, moduleRect));
 }
 
 void Minimap::RectUnion(ofRectangle& target, ofRectangle& unionRect)
@@ -301,6 +323,25 @@ void Minimap::ForcePosition()
    float width, height, scale;
    scale = 1 / TheSynth->GetUIScale();
    GetDimensions(width, height);
-   mX = floor((ofGetWidth() * scale) - (width + kMarginRight));
-   mY = kMarginTop;
+   const int margin = static_cast<int>(UserPrefs.minimap_margin.Get());
+   switch (UserPrefs.minimap_corner.GetIndex())
+   {
+      default:
+      case static_cast<int>(MinimapCorner::TopRight):
+         mX = floor((ofGetWidth() * scale) - (width + margin));
+         mY = margin + TheTitleBar->GetRect().height;
+         break;
+      case static_cast<int>(MinimapCorner::TopLeft):
+         mX = margin;
+         mY = margin + TheTitleBar->GetRect().height;
+         break;
+      case static_cast<int>(MinimapCorner::BottomRight):
+         mX = floor((ofGetWidth() * scale) - (width + margin));
+         mY = floor((ofGetHeight() * scale) - (height + margin));
+         break;
+      case static_cast<int>(MinimapCorner::BottomLeft):
+         mX = margin;
+         mY = floor((ofGetHeight() * scale) - (height + margin));
+         break;
+   }
 }

--- a/Source/Minimap.h
+++ b/Source/Minimap.h
@@ -29,6 +29,14 @@
 #include "UIGrid.h"
 
 
+enum class MinimapCorner
+{
+   TopRight,
+   TopLeft,
+   BottomRight,
+   BottomLeft
+};
+
 class Minimap : public IDrawableModule
 {
 public:
@@ -49,6 +57,7 @@ private:
    void ComputeBoundingBox(ofRectangle& rect);
    ofRectangle CoordsToMinimap(ofRectangle& boundingBox, ofRectangle& source);
    void DrawModulesOnMinimap(ofRectangle& boundingBox);
+   void DrawModuleOnMinimap(ofRectangle& boundingBox, IDrawableModule* module);
    void RectUnion(ofRectangle& target, ofRectangle& unionRect);
    void OnClicked(float x, float y, bool right) override;
    void MouseReleased() override;

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -312,6 +312,8 @@ public:
    UserPrefBool autosave{ "autosave", false, UserPrefCategory::General };
    UserPrefBool show_tooltips_on_load{ "show_tooltips_on_load", true, UserPrefCategory::General };
    UserPrefBool show_minimap{ "show_minimap", false, UserPrefCategory::General };
+   UserPrefFloat minimap_margin{ "minimap_margin", 10, 0, 50, UserPrefCategory::General };
+   UserPrefDropdownString minimap_corner{ "minimap_corner", "Top right", 150, UserPrefCategory::General };
    UserPrefBool immediate_paste{ "immediate_paste", false, UserPrefCategory::General };
    UserPrefTextEntryFloat record_buffer_length_minutes{ "record_buffer_length_minutes", 30, 1, 120, 5, UserPrefCategory::General };
 #if !BESPOKE_LINUX
@@ -336,8 +338,7 @@ public:
    UserPrefFloat motion_trails{ "motion_trails", 1, 0, 2, UserPrefCategory::Graphics };
    UserPrefBool draw_module_highlights{ "draw_module_highlights", true, UserPrefCategory::Graphics };
    UserPrefTextEntryFloat mouse_offset_x{ "mouse_offset_x", 0, -100, 100, 5, UserPrefCategory::Graphics };
-   UserPrefTextEntryFloat mouse_offset_y
-   {
+   UserPrefTextEntryFloat mouse_offset_y{
       "mouse_offset_y",
 #if BESPOKE_MAC
       -4,

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -338,7 +338,8 @@ public:
    UserPrefFloat motion_trails{ "motion_trails", 1, 0, 2, UserPrefCategory::Graphics };
    UserPrefBool draw_module_highlights{ "draw_module_highlights", true, UserPrefCategory::Graphics };
    UserPrefTextEntryFloat mouse_offset_x{ "mouse_offset_x", 0, -100, 100, 5, UserPrefCategory::Graphics };
-   UserPrefTextEntryFloat mouse_offset_y{
+   UserPrefTextEntryFloat mouse_offset_y
+   {
       "mouse_offset_y",
 #if BESPOKE_MAC
       -4,

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -87,6 +87,18 @@ void UserPrefsEditor::CreateUIControls()
       if (UserPrefs.qwerty_to_pitch_mode.GetDropdown()->GetElement(i).mLabel == UserPrefs.qwerty_to_pitch_mode.Get())
          UserPrefs.qwerty_to_pitch_mode.GetIndex() = i;
    }
+
+   UserPrefs.minimap_corner.GetIndex() = 0;
+   UserPrefs.minimap_corner.GetDropdown()->AddLabel("Top right", (int)MinimapCorner::TopRight);
+   UserPrefs.minimap_corner.GetDropdown()->AddLabel("Top left", (int)MinimapCorner::TopLeft);
+   UserPrefs.minimap_corner.GetDropdown()->AddLabel("Bottom right", (int)MinimapCorner::BottomRight);
+   UserPrefs.minimap_corner.GetDropdown()->AddLabel("Bottom left", (int)MinimapCorner::BottomLeft);
+
+   for (int i = 0; i < UserPrefs.minimap_corner.GetDropdown()->GetNumValues(); ++i)
+   {
+      if (UserPrefs.minimap_corner.GetDropdown()->GetElement(i).mLabel == UserPrefs.minimap_corner.Get())
+         UserPrefs.minimap_corner.GetIndex() = i;
+   }
 }
 
 void UserPrefsEditor::Show()


### PR DESCRIPTION
- Fixed a bug where the `minimap` could be obscured by the titlebar menu. Resolves: #1120.
- Fixed several bugs in the rendering of child modules in the `minimap`. Resolves: #1119. 
- Added settings for `minimap` margin and corner.