### PR TITLE
Add a callback for sysex messages in scripts - improved

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -485,7 +485,7 @@ void MidiController::OnMidi(const MidiMessage& message)
    int is_sysex = message.isSysEx();
    if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !is_sysex))
       return;
-   if (is_sysex)
+   if (mEnabled && mSendSysex && is_sysex)
       for (auto* script : mScriptListeners)
          script->SysExReceived(message.getSysExData(), message.getSysExDataSize());
 
@@ -2420,6 +2420,7 @@ void MidiController::LoadLayout(const ofxJSONElement& moduleInfo)
    mModuleSaveData.LoadBool("twoway_on_change", moduleInfo, true);
    mModuleSaveData.LoadBool("resend_feedback_on_release", moduleInfo, false);
    mModuleSaveData.LoadBool("show_activity_ui_overlay", moduleInfo, true);
+   mModuleSaveData.LoadBool("send_sysex", moduleInfo, false);
 
    mConnectionsJson = moduleInfo["connections"];
 
@@ -2452,6 +2453,7 @@ void MidiController::SetUpFromSaveData()
    mSendTwoWayOnChange = mModuleSaveData.GetBool("twoway_on_change");
    mResendFeedbackOnRelease = mModuleSaveData.GetBool("resend_feedback_on_release");
    mShowActivityUIOverlay = mModuleSaveData.GetBool("show_activity_ui_overlay");
+   mSendSysex = mModuleSaveData.GetBool("send_sysex");
 
    BuildControllerList();
 

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -482,8 +482,13 @@ void MidiController::OnMidiPitchBend(MidiPitchBend& pitchBend)
 
 void MidiController::OnMidi(const MidiMessage& message)
 {
-   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !message.isSysEx()))
+   int is_sysex = message.isSysEx();
+   if (!mEnabled || (mChannelFilter != ChannelFilter::kAny && message.getChannel() != (int)mChannelFilter && !is_sysex))
       return;
+   if (is_sysex)
+      for (auto* script : mScriptListeners)
+         script->SysExReceived(message.getSysExData(), message.getSysExDataSize());
+
    mNoteOutput.SendMidi(message);
 }
 

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -434,6 +434,7 @@ private:
    int mMonomeDeviceIndex{ -1 };
    DropdownList* mMonomeDeviceDropdown{ nullptr };
    bool mShouldSendControllerInfoStrings{ false };
+   bool mSendSysex{ false };
 
    int mControllerIndex{ -1 };
    double mLastActivityTime{ -9999 };

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -895,7 +895,7 @@ void ScriptModule::oscMessageReceived(const OSCMessage& msg)
    RunCode(gTime, "on_osc(\"" + messageString + "\")");
 }
 
-void ScriptModule::SysExReceived(const uint8 * data, int data_size)
+void ScriptModule::SysExReceived(const uint8_t* data, int data_size)
 {
    // Avoid code injection by preventing the sysex payload to be interpreted as Python
    // - convert the sysex payload to hex

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -901,9 +901,8 @@ void ScriptModule::SysExReceived(const uint8 * data, int data_size)
    // - convert the sysex payload to hex
    // - use bytes.fromhex in Python to parse it
    std::ostringstream ss;
-   ss << std::setfill('0') << std::setw(2) << std::hex;
    for (size_t i = 0; i < data_size; i++)
-      ss << (int)data[i];
+      ss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(data[i]);
    mMidiMessageQueueMutex.lock();
    mMidiMessageQueue.push_back("on_sysex(bytes.fromhex('" + ss.str() + "'))");
    mMidiMessageQueueMutex.unlock();

--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -895,6 +895,20 @@ void ScriptModule::oscMessageReceived(const OSCMessage& msg)
    RunCode(gTime, "on_osc(\"" + messageString + "\")");
 }
 
+void ScriptModule::SysExReceived(const uint8 * data, int data_size)
+{
+   // Avoid code injection by preventing the sysex payload to be interpreted as Python
+   // - convert the sysex payload to hex
+   // - use bytes.fromhex in Python to parse it
+   std::ostringstream ss;
+   ss << std::setfill('0') << std::setw(2) << std::hex;
+   for (size_t i = 0; i < data_size; i++)
+      ss << (int)data[i];
+   mMidiMessageQueueMutex.lock();
+   mMidiMessageQueue.push_back("on_sysex(bytes.fromhex('" + ss.str() + "'))");
+   mMidiMessageQueueMutex.unlock();
+}
+
 void ScriptModule::MidiReceived(MidiMessageType messageType, int control, float value, int channel)
 {
    mMidiMessageQueueMutex.lock();

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -71,7 +71,7 @@ public:
    double GetScheduledTime(double delayMeasureTime);
    void SetNumNoteOutputs(int num);
    void ConnectOscInput(int port);
-   void SysExReceived(const uint8_t * data, int data_size);
+   void SysExReceived(const uint8_t* data, int data_size);
    void MidiReceived(MidiMessageType messageType, int control, float value, int channel);
    void OnModuleReferenceBound(IDrawableModule* target);
    void SetContext();

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -71,6 +71,7 @@ public:
    double GetScheduledTime(double delayMeasureTime);
    void SetNumNoteOutputs(int num);
    void ConnectOscInput(int port);
+   void SysExReceived(const uint8_t * data, int data_size);
    void MidiReceived(MidiMessageType messageType, int control, float value, int channel);
    void OnModuleReferenceBound(IDrawableModule* target);
    void SetContext();


### PR DESCRIPTION
Based on pull request https://github.com/BespokeSynth/BespokeSynth/pull/1472/ credits to [Étienne Noss](https://github.com/etene)

This allows python scripts to define a `on_sysex(data)` method that get called by the MidiController much like `on_midi`.

It's called for every sysex MIDI event and takes the raw payload as bytes.

I added these improvements:
- Fix exceptions when converting certain sysex payload data to hexstring by forcing static_cast to int
- Added send_sysex setting to make MidiController backwords compatible and avoid unhandled on_sysex events in existing python scripts

So the send_sysex option must be enabled first in the `midicontroller` triangle/settings, before the on_sysex event will be send to a script listener.

I have used the new on_sysex function, to parse synth program dumps send via sysex.

