### PR TITLE
Fix parsing of Python script files in CR+LF format

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -634,7 +634,9 @@ void ScriptModule::Poll()
       if (mLoadedScriptFiletime < scriptFile.getLastModificationTime())
       {
          std::unique_ptr<FileInputStream> input(scriptFile.createInputStream());
-         mCodeEntry->SetText(input->readString().toStdString());
+         std::string text = input->readString().toStdString();
+         ofStringReplace(text, "\r", "");
+         mCodeEntry->SetText(text);
          mCodeEntry->Publish();
          ExecuteCode();
          mLoadedScriptFiletime = scriptFile.getLastModificationTime();
@@ -988,7 +990,9 @@ void ScriptModule::ButtonClicked(ClickButton* button, double time)
 
          mLoadedScriptFiletime = resourceFile.getLastModificationTime();
 
-         mCodeEntry->SetText(input->readString().toStdString());
+         std::string text = input->readString().toStdString();
+         ofStringReplace(text, "\r", "");
+         mCodeEntry->SetText(text);
       }
    }
 


### PR DESCRIPTION
I noticed some weird behavior when importing Python script files in CRLF format.
A lot of Python scripts work fine, but when a multiline statement is used, it would result in syntax errors.
For instance: IF ELIF combinations will give errors.

Fixed for loading and hotloading a Python script.