### PR TITLE
fix `rhythmsequencer` crash when trying to set length above 8

### DIFF
--- a/Source/RhythmSequencer.cpp
+++ b/Source/RhythmSequencer.cpp
@@ -342,6 +342,8 @@ void RhythmSequencer::DropdownUpdated(DropdownList* list, int oldVal, double tim
 
 void RhythmSequencer::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 {
+   if (slider == mLengthSlider)
+      mLength = MIN(mLength, kMaxSteps);
 }
 
 void RhythmSequencer::LoadLayout(const ofxJSONElement& moduleInfo)


### PR DESCRIPTION
fixes #1492
