### PR TITLE
Midicontroller catchcontrol function to block sending of CC values until certain value is catched

### DIFF
--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -241,6 +241,8 @@ struct ControlLayoutElement
 
    float mLastValue{ 0 };
    float mLastActivityTime{ -9999 };
+   bool mCatchFlag{ false }; // Control set to catch mode?
+   float mCatchValue{ 0 }; // Control value must be matched ("catched") before midi CC is being passed on
 };
 
 struct GridLayout
@@ -322,6 +324,8 @@ public:
    void OnMidi(const juce::MidiMessage& message) override;
 
    void OnTransportAdvanced(float amount) override;
+
+   void OnCatchControl(int control, float value);
 
    //IKeyboardFocusListener
    void OnKeyPressed(int key, bool isRepeat) override;

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -508,7 +508,11 @@ PYBIND11_EMBEDDED_MODULE(midicontroller, m)
       .def("resync_controller_state", [](MidiController& midicontroller)
       {
          midicontroller.ResyncControllerState();
-      });
+      })
+      .def("set_catchcontrol", [](MidiController& midicontroller, int control, float value)
+      {
+         midicontroller.OnCatchControl(control, value);
+      }, "control"_a, "value"_a = 0);
 }
 
 PYBIND11_EMBEDDED_MODULE(linnstrument, m)

--- a/resource/python_stubs/midicontroller/__init__.pyi
+++ b/resource/python_stubs/midicontroller/__init__.pyi
@@ -41,3 +41,6 @@ class midicontroller:
    def resync_controller_state(this, ):
       pass
 
+   def set_catchcontrol(this, control, value):
+      pass
+

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -148,6 +148,7 @@ import midicontroller
          example: m.send_sysex(bytes([0, 32, 41, 2, 12, 14, 1]) 
       m.add_script_listener(script)
       m.resync_controller_state()
+      m.set_catchcontrol(control, value)
 
 
 import linnstrument


### PR DESCRIPTION
Work in progress. All comments welcome how to expand/improve this new feature.

I have added a feature to the midicontroller, to have the MIDI CC Control "catch" up with a certain value, before sending out new knob  / CC values.

Setting the catch control values is done using a new python midicontroller function called m.set_catchcontrol(control, value)

I use this to allow the midicontroller to modify different settings, like for instance synth patches, without jumping to the current knob value. Or controlling multiple devices, and loading the "catch" values, to avoid sudden jumps in values.

I will post a little video in Discord - Nerd Stuff.

Possible improvements:
- Currently only handles MIDI CC messages. Notes/Other messages required? Most midicontrollers work with CC I guess
- Implemented for knobs and sliders. Not sure if this is required for buttons, as the button state probably does not need to be "catched"
- Add handling of switching midicontroller pages, to support multiple sets of catch values?
- Other ways to set the catch value and activate it, besides the Python function?
  - Add to the layout json? But that would be a fixed setting. Probably requires more dynamic catch values.
  - Or make a preset / snapshot to save catch values. Currently the catch values are not saveable/snapshotable
  - Or add the catch value to the midi mapping config of a midicontroller control