### PR TITLE
Fix shift+drag not precise dragging on Int sliders. Resolves #1331

### DIFF
--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -1074,7 +1074,21 @@ bool IntSlider::MouseMoved(float x, float y)
 void IntSlider::SetValueForMouse(float x, float y)
 {
    int oldVal = *mVar;
-   *mVar = (int)round(ofMap(x + mX, mX + 1, mX + mWidth - 1, mMin, mMax));
+   float fX = x;
+   if (GetKeyModifiers() & kModifier_Shift)
+   {
+      if (mFineRefX == -999)
+      {
+         mFineRefX = x;
+      }
+      fX = mFineRefX + (fX - mFineRefX) / 10;
+   }
+   else
+   {
+      mFineRefX = -999;
+   }
+
+   *mVar = (int)round(ofMap(fX + mX, mX + 1, mX + mWidth - 1, mMin, mMax));
    *mVar = ofClamp(*mVar, mMin, mMax);
    if (oldVal != *mVar)
    {

--- a/Source/Slider.h
+++ b/Source/Slider.h
@@ -286,6 +286,7 @@ private:
    bool mMouseDown;
    int mOriginalValue;
    IIntSliderListener* mOwner;
+   int mFineRefX{ -999 };
 
    int mLastDisplayedValue;
    int mLastSetValue;


### PR DESCRIPTION
This was bugging me the other day and I saw an already open issue for it, so went ahead and adapted some of the logic already in use for the float slider. Resolves #1331 