### PR TITLE
Enhance python script functions me.get() and me.set() to search modules in prefab

### DIFF
--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -213,6 +213,18 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
          return 0.0f;
       })
       ///example: pulsewidth = me.get("oscillator~pulsewidth")
+      .def("get_path_prefix", [](ScriptModule& module)
+      {
+         std::string path = module.Path();
+         if (ofIsStringInString(path, "~"))
+         {
+            return path.substr(0, path.find('~') + 1);
+         }
+         else 
+         {
+            return std::string("");
+         }
+      })
       .def("adjust", [](ScriptModule& module, std::string path, float amount)
       {
          IUIControl* control = module.GetUIControl(path);

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -54,6 +54,8 @@ script-relative:
    me.schedule_set(delay, path, value)
    me.get(path)
       example: pulsewidth = me.get("oscillator~pulsewidth")
+   me.get_path_prefix(): returns prefix if script is run in prefab (example: prefab~), or return empty string if run on main screen
+      example: active = me.get(me.get_path_prefix() + 'notesequencer~enabled')
    me.adjust(path, amount)
    me.highlight_line(lineNum, scriptModuleIndex)
    me.output(obj)

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -51,11 +51,15 @@ script-relative:
       optional: pan = 0, output_index = 0
    me.set(path, value)
       example: me.set("oscillator~pw", .2)
+      note: if script runs in prefab module: tries to update module in prefab first. if no match: update module in main screen.
+      note: use # in path to force module search on main screen (skip search for prefab module)
+      example: me.set('#notesequencer~enabled', 1)
    me.schedule_set(delay, path, value)
-   me.get(path)
+   me.get(path):
       example: pulsewidth = me.get("oscillator~pulsewidth")
-   me.get_path_prefix(): returns prefix if script is run in prefab (example: prefab~), or return empty string if run on main screen
-      example: active = me.get(me.get_path_prefix() + 'notesequencer~enabled')
+      note: if script runs in prefab module: tries to find module in prefab first. if no match: find module in main screen.
+      note: use # in path to force module search on main screen (skip search for prefab module)
+      example: active = me.get('#notesequencer~enabled')
    me.adjust(path, amount)
    me.highlight_line(lineNum, scriptModuleIndex)
    me.output(obj)


### PR DESCRIPTION
There is no way to dynamically reference a module within a prefab from a python script in that same prefab, except by using a static path like `prefab~notesequencer~enabled`.

This PR enhances the functions `me.get()` and `me.set()` to search for modules in a prefab first, if the python script is running inside that prefab.
If the module is not found in the prefab, the functions will continue searching the module on the main screen.

This way, when a group of modules and the related python script, are moved to a prefab, the script will continue to work and will reference the modules inside the prefab, without any changes in the script.

Also duplicating a prefab, or loading a prefab from a saved preset, will keep working and will reference the new prefab path/name automatically.

In case a script in a prefab, wants to modify a module on the main screen directly, and there is a module with the same name inside that prefab, it's possible to prefix the path with `#`.
For example: modify the notesequencer on the main screen from a script in a prefab, which also contains a notesequencer:
```
me.set('#notesequencer~enabled', 1)
```

Breaking change:
Previously, if a script inside a prefab would modify a notesequencer on the main screen, it would use `me.get('notesequencer~enabled')`.
With this PR, if the script inside a prefab is run and in the prefab is a notesequencer as well, the module inside the prefab will now be modified when using `me.get('notesequencer~enabled')`.

I think this impact is very low and only changes behavior if a script is run within a prefab, and there are modules in and outside the prefab with the same name.

Note:
Existing scripts in a prefab would require a full path to a module inside that prefab, so including the prefab name: `prefab~notesequencer~enabled`
This PR will not break these scripts. Although adding the prefix again would result in an invalid path at first, `prefab~prefab~notesequencer~enabled`,
but the fallback check of the original path name, will then match the module in the prefab.


Note 2:
The first commit of this PR added a new function `me.get_path_prefix()` to get the current prefix.
This would require a lot of modifications of a script, if it is moved to a prefab.
For example:
```
pathprefix = me.get_path_prefix()
noteseq_active = me.get(pathprefix + 'notesequencer~enabled')
```

I have removed this new function again, in favor of modifying the `me.get()` and `me.set()` functions.

Concluding:
I hope this PR is accepted as it allows referencing modules inside of a prefab. Also the conversion of a group of modules and script into a prefab, is much more convenient.

I hope the breaking impact is considered acceptable. Only in a very specific case, the behavior is modified, as explained above.

