### PR TITLE
Fix python script functions me.get() and me.set() to use correct module paths in a prefab script

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -782,10 +782,27 @@ void ScriptModule::PrintText(std::string text)
 IUIControl* ScriptModule::GetUIControl(std::string path)
 {
    IUIControl* control;
-   if (ofIsStringInString(path, "~"))
-      control = TheSynth->FindUIControl(path);
-   else
-      control = TheSynth->FindUIControl(Path() + "~" + path);
+   std::string prefix = "";
+
+   if (path == "")
+      return nullptr;
+
+   //if path[0] == '$', skip prefix calculation
+   if (path[0] != '$')
+   {
+      //if path has two ~ chars: path is prefab full path: skip prefix calculation
+      if (std::count(path.begin(), path.end(), '~') < 2)
+      {
+         prefix = Path();
+         if (ofIsStringInString(prefix, "~"))
+            //script is in prefab: create prefix up to last ~ (also handles nested prefabs)
+            prefix = prefix.substr(0, prefix.rfind('~') + 1);
+         else
+            prefix = "";
+      }
+   }
+
+   control = TheSynth->FindUIControl(prefix + path);
 
    return control;
 }

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -213,6 +213,18 @@ PYBIND11_EMBEDDED_MODULE(scriptmodule, m)
          return 0.0f;
       })
       ///example: pulsewidth = me.get("oscillator~pulsewidth")
+      .def("get_path_prefix", [](ScriptModule& module)
+      {
+         std::string path = module.Path();
+         if (ofIsStringInString(path, "~"))
+         {
+            return path.substr(0, path.rfind('~') + 1);
+         }
+         else 
+         {
+            return std::string("");
+         }
+      })
       .def("adjust", [](ScriptModule& module, std::string path, float amount)
       {
          IUIControl* control = module.GetUIControl(path);

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -54,6 +54,8 @@ script-relative:
    me.schedule_set(delay, path, value)
    me.get(path)
       example: pulsewidth = me.get("oscillator~pulsewidth")
+   me.get_path_prefix(): returns prefix if script is run in prefab (example: prefab~), or return empty string if run on main screen
+      example: active = me.get(me.get_path_prefix() + 'notesequencer~enabled')
    me.adjust(path, amount)
    me.highlight_line(lineNum, scriptModuleIndex)
    me.output(obj)


### PR DESCRIPTION
The python script functions `me.get()` and `me.set()` reference the main screen module instead of the module within that same prefab.

I have investigated this further, and found the root cause of the issue is within the function ScriptModule::GetUIControl(std::string path)

2 bugs there:
- If path contains ~ the code assumes the path is a prefab path, but would also match `notesequencer~length` and no prefab prefix would be added. This was the root cause of the `me.get` issue.
- `Path()` was used to generate a prefix, but this will return `prefab~script`, so this generates an invalid path. This code was never hit, because there is always a ~ in the path, to reference controls on a module.

The fix now generates the correct path of the prefab, if script is run within a prefab. So references will be to modules within the prefab.

See attached savestate for proof of concept.
[me.get test.bsk.zip](https://github.com/user-attachments/files/18783916/me.get.test.bsk.zip)

Note: This replaces https://github.com/BespokeSynth/BespokeSynth/pull/1754 which will be removed.