### PR TITLE
fix to allow multiple python script modules to receive on_sysex events

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1305,6 +1305,7 @@ void ScriptModule::FixUpCode(std::string& code)
    ofStringReplace(code, "on_grid_button(", "on_grid_button__" + prefix + "(");
    ofStringReplace(code, "on_osc(", "on_osc__" + prefix + "(");
    ofStringReplace(code, "on_midi(", "on_midi__" + prefix + "(");
+   ofStringReplace(code, "on_sysex(", "on_sysex__" + prefix + "(");
    ofStringReplace(code, "this.", GetThisName() + ".");
    ofStringReplace(code, "me.", GetThisName() + ".");
 }


### PR DESCRIPTION
The on_sysex event was added in PR #1726. 

But the on_sysex event was only triggering in 1 python script.

Each event handler must have a unique name, to differentiate the `on_...` event handlers.
Fixed by adding on_sysex event to ScriptModule::FixUpCode, just like all other `on_...`. events, to generate unique function names.