### PR TITLE
save and load view/zoom locations in Python

### DIFF
--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -158,6 +158,14 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
       }
       return paths;
    });
+   m.def("location_recall", [](char location)
+   {
+      TheSynth->GetLocationZoomer()->MoveToLocation(location);
+   });
+   m.def("location_store", [](char location)
+   {
+      TheSynth->GetLocationZoomer()->WriteCurrentLocation(location);
+   });
 }
 
 PYBIND11_EMBEDDED_MODULE(scriptmodule, m)

--- a/resource/python_stubs/bespoke/__init__.pyi
+++ b/resource/python_stubs/bespoke/__init__.pyi
@@ -54,3 +54,9 @@ def random(seed, index):
 def get_modules():
    pass
 
+def location_recall(location):
+   pass
+
+def location_store(location):
+   pass
+

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -34,6 +34,10 @@ globals:
       optional: size=50, xPos = 150, yPos = 250, red = 1, green = 1, blue = 1
    bespoke.random(seed, index)
    bespoke.get_modules()
+   bespoke.location_recall(location): move to saved location (0-255). "1" - "9" match the minimap and function key shortcuts: SHIFT+"1" - "9"
+      example: bespoke.location_recall("1")
+      example: bespoke.location_recall(49)
+   bespoke.location_store(location)
 
 
 script-relative:


### PR DESCRIPTION
Two new Python functions are created:
- `bespoke.location_recall(location)`
- `bespoke.location_store(location)`

This allows to save and load view/zoom locations from a Python `script` module.
Or use a `midicontroller` or other triggers, to run a `script` module and use these 2 new functions.

They work similar to OscController "/bespoke/location/recall" and ".../store", so this allows locations in the range 0-255 (char), much more than the Functionkey Shortcut / Minimap range: "1" - "9" (49 - 57).