### PR TITLE
Fixed buffer overflow in NoteTable::PlayColumn causing unexpected crashes

### DIFF
--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -344,7 +344,7 @@ void NoteTable::PlayColumn(NoteMessage note)
    if (note.velocity == 0)
    {
       mLastColumnPlayTime[column] = -1;
-      for (int i = 0; i < 128; ++i)
+      for (int i = 0; i < mLastColumnNoteOnPitches.size(); ++i)
       {
          if (mLastColumnNoteOnPitches[column][i])
          {
@@ -362,7 +362,7 @@ void NoteTable::PlayColumn(NoteMessage note)
          int outputPitch = RowToPitch(row);
 
          // don't play notes > 127, and also to avoid bufferoverflow for mQueuedPitches and mPitchPlayTimes below
-         if (outputPitch > 127)
+         if (outputPitch >= mPitchPlayTimes.size() || outputPitch >= mQueuedPitches.size())
             continue;
 
          if (mQueuedPitches[outputPitch])

--- a/Source/NoteTable.cpp
+++ b/Source/NoteTable.cpp
@@ -361,6 +361,10 @@ void NoteTable::PlayColumn(NoteMessage note)
       {
          int outputPitch = RowToPitch(row);
 
+         // don't play notes > 127, and also to avoid bufferoverflow for mQueuedPitches and mPitchPlayTimes below
+         if (outputPitch > 127)
+            continue;
+
          if (mQueuedPitches[outputPitch])
          {
             mGrid->SetVal(column, row, 1);


### PR DESCRIPTION
When the `notetable` grid contains pitches > 127, several buffer overflows occur in NoteTable::PlayColumn.

Both mQueuedPitches and mPitchPlayTimes have a kMaxLength of 128, so pitches > 127 were causing buffer overflows.

To reproduce, create this config. No notes are required in the notetable, only pitches > 128/130.
![image](https://github.com/user-attachments/assets/19d9d8a3-a5cb-494d-97e4-1fd208b2a81c)
