### PR TITLE
add module.set_focus() to python script module

### DIFF
--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -824,6 +824,25 @@ PYBIND11_EMBEDDED_MODULE(module, m)
             float value = ofClamp(control->GetValue() + amount, min, max);
             control->SetValue(value, ScriptModule::sMostRecentRunTime);
          }
+      })
+      .def("set_focus", [](IDrawableModule& module, float zoom)
+      {
+         ofRectangle module_rect = module.GetRect();
+         if (zoom >= 0.1)
+            gDrawScale = ofClamp(zoom, 0.1, 8);
+         else if (fabs(zoom) < 0.1) // Close to 0
+         {
+            //calculate zoom to view the entire module
+            float margin = 60;
+            float w_ratio = ofGetWidth() / (module_rect.width + margin);
+            float h_ratio = ofGetHeight() / (module_rect.height + margin);
+            float ratio = (w_ratio < h_ratio) ? w_ratio : h_ratio;
+            gDrawScale = ofClamp(ratio, 0.1, 8);
+         }
+         // Move viewport to centered on the module
+         float w, h;
+         TheTitleBar->GetDimensions(w, h);
+         TheSynth->SetDrawOffset(ofVec2f(-module_rect.x + ofGetWidth() / gDrawScale / 2 - module_rect.width / 2, -module_rect.y + ofGetHeight() / gDrawScale / 2 - (module_rect.height - h / 2) / 2));
       });
 }
 

--- a/resource/python_stubs/module/__init__.pyi
+++ b/resource/python_stubs/module/__init__.pyi
@@ -49,3 +49,6 @@ class module:
    def adjust(this, path, amount):
       pass
 
+   def set_focus(this, zoom):
+      pass
+

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -223,3 +223,6 @@ import module
       m.set(path, value)
       m.get(path)
       m.adjust(path, amount)
+      m.set_focus(zoom)
+         description: zoom = 0: zoom module to full screen, zoom = 0.1 - 8: zoom to specified zoomlevel
+         example: ns = me.get("notesequencer"); ns.set_focus(2)


### PR DESCRIPTION
This adds a new Python function `module.set_focus(zoom)` to the `script` module.

Focus/zoom logic inspired (read: blatantly copied) from the `OSC controller` bespoke/module/focus function.

zoom = 0: zoom module to full screen
zoom = 0.1 - 8: zoom to specified zoomlevel

Code example:
```
ns = module.get("notesequencer")  
if ns is not None:
   ns.set_focus(0)
else:
   me.output('module not found')
```