### PR TITLE
small documentation update: add m.set_target(cableSourceIndex, targetPath) to scripting reference

### DIFF
--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -216,6 +216,7 @@ import module
       m.get_height()
       m.set_target(target)
       m.set_target(targetPath)
+      m.set_target(cableSourceIndex, targetPath)
       m.get_target()
       m.get_targets()
       m.set_name(name)


### PR DESCRIPTION
python script function `module.set_target` has been enhanced a while ago with extra parameter options.

this updates the documentation in the scripting_reference:
`m.set_target(cableSourceIndex, targetPath)`
