### PR TITLE
feat: add Launchpad X controller definition

### DIFF
--- a/resource/userdata_original/controllers/Launchpad X.json
+++ b/resource/userdata_original/controllers/Launchpad X.json
@@ -1,0 +1,46 @@
+{
+  "groups" : [
+     {
+        "rows": 8,
+        "cols": 8,
+        "position" : [ 0, 35 ],
+        "dimensions" : [28, 28],
+        "spacing" : [30, 30],
+        "controls" : [
+          81, 82, 83, 84, 85, 86, 87, 88,
+          71, 72, 73, 74, 75, 76, 77, 78,
+          61, 62, 63, 64, 65, 66, 67, 68,
+          51, 52, 53, 54, 55, 56, 57, 58,
+          41, 42, 43, 44, 45, 46, 47, 48,
+          31, 32, 33, 34, 35, 36, 37, 38,
+          21, 22, 23, 24, 25, 26, 27, 28,
+          11, 12, 13, 14, 15, 16, 17, 18
+        ],
+        "colors" : [ 0, 1, 3, 16, 48, 34, 35],
+        "messageType" : "note",
+        "drawType" : "button"
+     },
+     {
+       "rows": 8,
+       "cols": 1,
+       "position" : [ 250, 37 ],
+       "dimensions" : [25, 25],
+       "spacing" : [30, 30],
+       "controls" : [ 89, 79, 69, 59, 49, 39, 29, 19],
+       "colors" : [ 0, 1, 3, 16, 48, 34, 35],
+       "messageType" : "control",
+       "drawType" : "button"
+    },
+    {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 2, 0 ],
+      "dimensions" : [25, 25],
+      "spacing" : [30, 30],
+      "controls" : [91, 92, 93, 94, 95, 96, 97, 98],
+      "colors" : [ 0, 1, 3, 16, 48, 34, 35],
+      "messageType" : "control",
+      "drawType" : "button"
+   }
+  ]
+}


### PR DESCRIPTION
This is apparently the same mapping as the "Launchpad mk2" in PR #617, but I think it still warrants its own file, since it is a separate model.

The mapping is the one when the device is in "Programmer Mode", which needs to be enabled by sending some SysEx to the device, but this is out of the scope of this PR.