### PR TITLE
feat(SynthGlobals): make current slider value accessible as "x"

### DIFF
--- a/Source/SynthGlobals.cpp
+++ b/Source/SynthGlobals.cpp
@@ -11484,19 +11484,19 @@ bool EvaluateExpression(std::string expressionStr, float currentValue, float& ou
 {
    exprtk::symbol_table<float> symbolTable;
    exprtk::expression<float> expression;
-   symbolTable.add_variable("current_value", currentValue);
+   symbolTable.add_variable("x", currentValue);
    symbolTable.add_constants();
    expression.register_symbol_table(symbolTable);
 
    juce::String input = expressionStr;
    if (input.startsWith("+="))
-      input = input.replace("+=", "current_value+");
+      input = input.replace("+=", "x+");
    if (input.startsWith("*="))
-      input = input.replace("*=", "current_value*");
+      input = input.replace("*=", "x*");
    if (input.startsWith("/="))
-      input = input.replace("/=", "current_value/");
+      input = input.replace("/=", "x/");
    if (input.startsWith("-="))
-      input = input.replace("-=", "current_value-");
+      input = input.replace("-=", "x-");
 
    exprtk::parser<float> parser;
    bool expressionValid = parser.compile(input.toStdString(), expression);


### PR DESCRIPTION
It was previously accessible as `current_value`, but that's inconvenient to type.

`x` is what the `expression` modules use for their main input, so I figured it would be good to use it as the default here too. Another one I considered was `a`, just because it's a little faster to type on most keyboards, but I figured using `x` made more sense overall.