### PR TITLE
add grid control and xy offset sliders to the snapshots module

### DIFF
--- a/Source/Snapshots.cpp
+++ b/Source/Snapshots.cpp
@@ -58,6 +58,10 @@ void Snapshots::CreateUIControls()
    mAddButton = new ClickButton(this, "add", mCurrentSnapshotSelector, kAnchor_Right);
    mStoreCheckbox = new Checkbox(this, "store", mAddButton, kAnchor_Right, &mStoreMode);
    mDeleteCheckbox = new Checkbox(this, "delete", mStoreCheckbox, kAnchor_Right, &mDeleteMode);
+   mGridControlTarget = new GridControlTarget(this, "grid", 4, 4);
+   mGridControlTarget->PositionTo(mDeleteCheckbox, kAnchor_Right);
+   mGridControlOffsetXSlider = new IntSlider(this, "x offset", mStoreCheckbox, kAnchor_Below, 60, 15, &mGridControlOffsetX, 0, 16);
+   mGridControlOffsetYSlider = new IntSlider(this, "y offset", mGridControlOffsetXSlider, kAnchor_Right, 60, 15, &mGridControlOffsetY, 0, 16);
    mSnapshotLabelEntry = new TextEntry(this, "snapshot label", -1, -1, 12, &mSnapshotLabel);
 
    {
@@ -133,6 +137,12 @@ void Snapshots::DrawModule()
       mSnapshotLabelEntry->SetPosition(pos.x, pos.y);
       mStoreCheckbox->PositionTo(mGrid, kAnchor_Below);
       mDeleteCheckbox->PositionTo(mStoreCheckbox, kAnchor_Right_Padded);
+
+      mGridControlTarget->PositionTo(mDeleteCheckbox, kAnchor_Right);
+      mGridControlOffsetXSlider->SetShowing((mGridControlTarget->GetGridController() != nullptr && mGrid->GetCols() > mGridControlTarget->GetGridController()->NumCols()) || mPush2Connected);
+      mGridControlOffsetYSlider->SetShowing((mGridControlTarget->GetGridController() != nullptr && mGrid->GetRows() > mGridControlTarget->GetGridController()->NumRows()) || mPush2Connected);
+      mGridControlOffsetXSlider->PositionTo(mStoreCheckbox, kAnchor_Below);
+      mGridControlOffsetYSlider->PositionTo(mGridControlOffsetXSlider, kAnchor_Right);
    }
 
    if (mDisplayMode == DisplayMode::List)
@@ -143,6 +153,12 @@ void Snapshots::DrawModule()
 
       mStoreCheckbox->PositionTo(mGrid, kAnchor_Below);
       mDeleteCheckbox->PositionTo(mStoreCheckbox, kAnchor_Right_Padded);
+
+      mGridControlTarget->PositionTo(mDeleteCheckbox, kAnchor_Right);
+      mGridControlOffsetXSlider->SetShowing(false);
+      mGridControlOffsetYSlider->SetShowing((mGridControlTarget->GetGridController() != nullptr && kListRowHeight > mGridControlTarget->GetGridController()->NumRows()) || mPush2Connected);
+      mGridControlOffsetXSlider->PositionTo(mStoreCheckbox, kAnchor_Below);
+      mGridControlOffsetYSlider->PositionTo(mGridControlOffsetXSlider, kAnchor_Right);
    }
 
    mGrid->Draw();
@@ -152,6 +168,9 @@ void Snapshots::DrawModule()
    mAddButton->Draw();
    mStoreCheckbox->Draw();
    mDeleteCheckbox->Draw();
+   mGridControlTarget->Draw();
+   mGridControlOffsetXSlider->Draw();
+   mGridControlOffsetYSlider->Draw();
 
    if (mDisplayMode == DisplayMode::List)
    {
@@ -228,6 +247,30 @@ void Snapshots::DrawModule()
       ofPopStyle();
    }
    mSnapshotLabelEntry->Draw();
+
+   if (mGridControlTarget->GetGridController())
+   {
+      int controllerCols = 8;
+      int controllerRows = 8;
+      if (mGridControlTarget->GetGridController() != nullptr)
+      {
+         controllerCols = MIN(mGridControlTarget->GetGridController()->NumCols(), mGrid->GetCols());
+         controllerRows = MIN(mGridControlTarget->GetGridController()->NumRows(), mGrid->GetRows());
+      }
+
+      ofPushStyle();
+      ofNoFill();
+      ofSetLineWidth(4);
+      ofSetColor(255, 0, 0, 50);
+      float squareh = float(mGrid->GetHeight()) / mGrid->GetRows();
+      float squarew = float(mGrid->GetWidth()) / mGrid->GetCols();
+      ofRectangle gridRect = mGrid->GetRect(K(local));
+      ofRect(gridRect.x + squarew * mGridControlOffsetX,
+             gridRect.y + squareh * mGridControlOffsetY,
+             squarew * controllerCols,
+             squareh * controllerRows);
+      ofPopStyle();
+   }
 }
 
 void Snapshots::DrawModuleUnclipped()
@@ -274,6 +317,21 @@ void Snapshots::UpdateGridValues()
          val = .5f;
       mGrid->SetVal(i % mGrid->GetCols(), i / mGrid->GetCols(), val);
    }
+
+   if (mGridControlTarget->GetGridController())
+   {
+      int maxXOffset = mGrid->GetCols() - mGridControlTarget->GetGridController()->NumCols();
+      if (maxXOffset >= 0)
+         mGridControlOffsetXSlider->SetExtents(0, maxXOffset);
+      int maxYOffset = mGrid->GetRows() - mGridControlTarget->GetGridController()->NumRows();
+      if (maxYOffset >= 0)
+         mGridControlOffsetYSlider->SetExtents(0, maxYOffset);
+
+      mGridControlOffsetX = MAX(MIN(mGridControlOffsetX, maxXOffset), 0);
+      mGridControlOffsetY = MAX(MIN(mGridControlOffsetY, maxYOffset), 0);
+   }
+
+   UpdateGridControllerLights(true);
 }
 
 bool Snapshots::IsTargetingModule(IDrawableModule* module) const
@@ -603,8 +661,66 @@ void Snapshots::DeleteSnapshot(int idx)
    }
 }
 
+void Snapshots::UpdateGridControllerLights(bool force)
+{
+   if (mGridControlTarget->GetGridController())
+   {
+      for (int x = 0; x < mGridControlTarget->GetGridController()->NumCols(); ++x)
+      {
+         for (int y = 0; y < mGridControlTarget->GetGridController()->NumRows(); ++y)
+         {
+            int column = x + mGridControlOffsetX;
+            int row = y + mGridControlOffsetY;
+
+            GridColor color = GridColor::kGridColorOff;
+            if (column < mGrid->GetCols())
+            {
+               if (mGrid->GetVal(column, row) > 0)
+               {
+                  color = GridColor::kGridColor1Bright;
+               }
+
+               if (column == mCurrentSnapshot % mGrid->GetCols() && row == mCurrentSnapshot / mGrid->GetCols())
+               {
+                  if (mGrid->GetVal(column, row) > 0)
+                     color = GridColor::kGridColor3Bright;
+                  else
+                     color = GridColor::kGridColor2Bright;
+               }
+            }
+            mGridControlTarget->GetGridController()->SetLight(x, y, color, force);
+         }
+      }
+   }
+}
+
+void Snapshots::OnControllerPageSelected()
+{
+   UpdateGridControllerLights(true);
+}
+
+void Snapshots::OnGridButton(int x, int y, float velocity, IGridController* grid)
+{
+   int col = x + mGridControlOffsetX;
+   int row = y + mGridControlOffsetY;
+   if (grid == mGridControlTarget->GetGridController() && col >= 0 && col < mGrid->GetCols() && velocity > 0)
+   {
+      int btnIdx = row * mGrid->GetCols() + col;
+      if (mStoreMode)
+         StoreSnapshot(btnIdx, true);
+      else if (mDeleteMode)
+         DeleteSnapshot(btnIdx);
+      else
+         SetSnapshot(btnIdx, gTime);
+
+      UpdateGridValues();
+   }
+}
+
 bool Snapshots::OnPush2Control(Push2Control* push2, MidiMessageType type, int controlIndex, float midiValue)
 {
+   mPush2Connected = true;
+
    if (type == kMidiMessage_Note)
    {
       if (controlIndex >= 36 && controlIndex <= 99)
@@ -643,6 +759,8 @@ bool Snapshots::OnPush2Control(Push2Control* push2, MidiMessageType type, int co
 
 void Snapshots::UpdatePush2Leds(Push2Control* push2)
 {
+   mPush2Connected = true;
+
    for (int x = 0; x < 8; ++x)
    {
       for (int y = 0; y < 8; ++y)
@@ -730,6 +848,12 @@ void Snapshots::ButtonClicked(ClickButton* button, double time)
    }
 }
 
+void Snapshots::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
+{
+   if (slider == mGridControlOffsetXSlider || slider == mGridControlOffsetYSlider)
+      UpdateGridControllerLights(true);
+}
+
 void Snapshots::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
    if (list == mCurrentSnapshotSelector)
@@ -765,7 +889,7 @@ void Snapshots::TextEntryComplete(TextEntry* entry)
 void Snapshots::GetModuleDimensions(float& width, float& height)
 {
    width = mGrid->GetWidth() + extraW;
-   height = mGrid->GetHeight() + extraH;
+   height = mGrid->GetHeight() + extraH + ((mGridControlOffsetXSlider->IsShowing() || mGridControlOffsetYSlider->IsShowing()) ? 18 : 0);
 }
 
 void Snapshots::Resize(float w, float h)
@@ -828,6 +952,18 @@ void Snapshots::UpdateListGrid()
    int numSnapshots = (int)mSnapshotCollection.size();
    mGrid->SetGrid(1, numSnapshots);
    mGrid->SetDimensions(kListModeGridWidth, kListRowHeight * numSnapshots);
+
+   if (mGridControlTarget->GetGridController())
+   {
+      mGridControlOffsetXSlider->SetExtents(0, 0);
+      int maxYOffset = mGrid->GetRows() - mGridControlTarget->GetGridController()->NumRows();
+      if (maxYOffset >= 0)
+         mGridControlOffsetYSlider->SetExtents(0, maxYOffset);
+
+      mGridControlOffsetX = 0;
+      mGridControlOffsetY = MAX(MIN(mGridControlOffsetY, maxYOffset), 0);
+   }
+
    UpdateGridValues();
 }
 

--- a/Source/Snapshots.h
+++ b/Source/Snapshots.h
@@ -37,8 +37,10 @@
 #include "DropdownList.h"
 #include "TextEntry.h"
 #include "Push2Control.h"
+#include "GridController.h"
 
-class Snapshots : public IDrawableModule, public IButtonListener, public IAudioPoller, public IFloatSliderListener, public IDropdownListener, public INoteReceiver, public ITextEntryListener, public IPush2GridController
+
+class Snapshots : public IDrawableModule, public IButtonListener, public IAudioPoller, public IIntSliderListener, public IFloatSliderListener, public IDropdownListener, public INoteReceiver, public ITextEntryListener, public IPush2GridController, public IGridControllerListener
 {
 public:
    Snapshots();
@@ -70,12 +72,17 @@ public:
    void PlayNote(NoteMessage note) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
 
+   //IGridControllerListener
+   void OnControllerPageSelected() override;
+   void OnGridButton(int x, int y, float velocity, IGridController* grid) override;
+
    //IPush2GridController
    bool OnPush2Control(Push2Control* push2, MidiMessageType type, int controlIndex, float midiValue) override;
    void UpdatePush2Leds(Push2Control* push2) override;
 
    void ButtonClicked(ClickButton* button, double time) override;
    void CheckboxUpdated(Checkbox* checkbox, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override {}
    void DropdownUpdated(DropdownList* list, int oldVal, double time) override;
    void TextEntryComplete(TextEntry* entry) override;
@@ -111,6 +118,7 @@ private:
    void GetModuleDimensions(float& w, float& h) override;
    void OnClicked(float x, float y, bool right) override;
    bool MouseMoved(float x, float y) override;
+   void UpdateGridControllerLights(bool force);
 
    enum class DisplayMode
    {
@@ -193,4 +201,10 @@ private:
    int mSnapshotRenameIndex{ -1 };
    float mOldWidth{ 0 };
    float mOldHeight{ 0 };
+   bool mPush2Connected{ false };
+   GridControlTarget* mGridControlTarget{ nullptr };
+   int mGridControlOffsetX{ 0 };
+   int mGridControlOffsetY{ 0 };
+   IntSlider* mGridControlOffsetXSlider{ nullptr };
+   IntSlider* mGridControlOffsetYSlider{ nullptr };
 };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -74,6 +74,9 @@ snapshots~save and restore sets of values. connect the grey circle to modules to
 ~store~when clicking/selecting a snapshot, store into that slot (alternately: hold the shift key)
 ~delete~when clicking/selecting a snapshot, delete that slot (alternately: hold the alt/option key)
 ~snapshot label~assign a label to this snapshot
+~grid~patch a grid in here from a "midicontroller" module
+~x offset~x offset of attached grid controller
+~y offset~y offset of attached grid controller
 
 
 


### PR DESCRIPTION
This will allow a `midicontroller` with a grid, to easily select snapshots in the `snapshots` module.
X and Y offset sliders will only show when a grid is connected and snapshots cols and rows are larger than the midicontroller grid.

Inspiration (copied some grid handling code) from modules `notetable` and `notestepsequencer`.

![image](https://github.com/user-attachments/assets/ea1c9b2b-9234-4438-9322-62c96235c7d8)
