### PR TITLE
Fix `selector` not being able to select the last item on the list

### DIFF
--- a/Source/Selector.cpp
+++ b/Source/Selector.cpp
@@ -74,7 +74,7 @@ void Selector::SyncList()
 
 void Selector::PlayNote(NoteMessage note)
 {
-   int range = (int)mControlCables.size() - 1;
+   int range = (int)mControlCables.size();
    if (note.velocity > 0 && range > 0)
       SetIndex(note.pitch % range, note.time);
 }


### PR DESCRIPTION
This PR fixes a bug in `selector` which caused the inability to select the last item on the list (#1778).

Fixes #1778