### PR TITLE
Fix stuck notes on retrigger in `noteoctaver`

### DIFF
--- a/Source/NoteOctaver.cpp
+++ b/Source/NoteOctaver.cpp
@@ -94,7 +94,7 @@ void NoteOctaver::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
       {
          if (mInputNotes[pitch].mOn)
          {
-            PlayNoteOutput(NoteMessage(time + .01, pitch + oldVal, 0, mInputNotes[pitch].mVoiceIdx));
+            PlayNoteOutput(NoteMessage(time + .01, pitch + oldVal * TheScale->GetPitchesPerOctave(), 0, mInputNotes[pitch].mVoiceIdx));
             PlayNoteOutput(NoteMessage(time, pitch + mOctave * TheScale->GetPitchesPerOctave(), mInputNotes[pitch].mVelocity, mInputNotes[pitch].mVoiceIdx));
          }
       }


### PR DESCRIPTION
Fix the note off messages emitted by `noteoctaver` with `retrigger` option (#1332).

Fixes #1332.