### PR TITLE
fix nullptr dereference in GridModule::OnGridButton causing an application crash

### DIFF
--- a/Source/GridModule.cpp
+++ b/Source/GridModule.cpp
@@ -94,8 +94,11 @@ void GridModule::OnGridButton(int x, int y, float velocity, IGridController* gri
    if (y < GetRows() && x < GetCols())
    {
       for (auto listener : mScriptListeners)
-         listener->RunCode(gTime, "on_grid_button(" + ofToString(x) + ", " + ofToString(y) + ", " + ofToString(velocity) + ")");
-
+         // use callAsync as RunCode should only be called from main thread
+         juce::MessageManager::callAsync([listener, time = gTime, x, y, velocity]()
+                                         {
+                                            listener->RunCode(time, "on_grid_button(" + ofToString(x) + ", " + ofToString(y) + ", " + ofToString(velocity) + ")");
+                                         });
       if (mGridControllerOwner)
          mGridControllerOwner->OnGridButton(x, y, velocity, this);
    }


### PR DESCRIPTION
GridModule function OnGridButton can possibly be triggered from a Midicontroller MIDI event, which is not running in the main thread.
This caused an nullptr dereference in the pybind PyEval_GetGlobals function, causing an application crash.

To reproduce:
- connect an actual midi device to a `midicontroller` module (so not the pc keyboard midicontroller)
- connect the `midicontroller` grid to a `grid` module
- create a Python `script` with code:
```
import grid

g = grid.get("grid")
g.add_listener(me.me())

def on_grid_button(col, row, velocity):
   me.output(f"{col} {row} {velocity}")
```
This issue has also been mentioned previously on [discord](https://discord.com/channels/846834873254805554/887380244334514267/1296618020399222827).

Fixed by using `juce::MessageManager::callAsync` to execute RunCode 'on_grid_button' from the main thread.

Note:
I could have used this code:
`listener->ScheduleMethod("on_grid_button(" + ofToString(x) + ", " + ofToString(y) + ", " + ofToString(velocity) + ")", 0);`
but that caused timer circles to be displayed on the executed Python script lines, which are a bit confusing.


