### PR TITLE
Clamp `num_loopers` in `looperrecorder` between 1 and maximum allowed number of loopers

### DIFF
--- a/Source/LooperRecorder.cpp
+++ b/Source/LooperRecorder.cpp
@@ -895,7 +895,7 @@ void LooperRecorder::LoadLayout(const ofxJSONElement& moduleInfo)
 void LooperRecorder::SetUpFromSaveData()
 {
    SetTarget(TheSynth->FindModule(mModuleSaveData.GetString("target")));
-   mNumLoopers = mModuleSaveData.GetInt("num_loopers");
+   mNumLoopers = ofClamp(mModuleSaveData.GetInt("num_loopers"), 1, kMaxLoopers);
    mTemporarilySilenceAfterCommit = mModuleSaveData.GetBool("temp_silence_after_commit");
 }
 


### PR DESCRIPTION
This PR offsets #1783 by clamping `num_loopers` in `looperrecorder` between 1 and maximum allowed number of loopers.

Fixes #1783