### PR TITLE
Add Behringer BCR2000 controller definitions

### DIFF
--- a/resource/userdata_original/controllers/BCR2000.json
+++ b/resource/userdata_original/controllers/BCR2000.json
@@ -1,0 +1,69 @@
+{
+   "groups": [
+      {
+         "rows": 1,
+         "cols": 2,
+         "position": [ 0, 0 ],
+         "dimensions": [28, 28],
+         "spacing": [35, 30],
+         "controls": [109, 110],
+         "messageType": "control",
+         "drawType": "button"
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 50 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [33, 34, 35, 36, 37, 38, 39, 40],
+         "messageType": "control",
+         "drawType": "button",
+	 "no_grid" : true
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 80 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [1, 2, 3, 4, 5, 6, 7, 8],
+         "messageType": "control",
+         "drawType": "knob"
+      },
+      {
+         "rows": 2,
+         "cols": 8,
+         "position": [ 0, 125 ],
+         "dimensions": [25, 20],
+         "spacing": [30, 22],
+         "controls": [65, 66, 67, 68, 69, 70, 71, 72,
+                      73, 74, 75, 76, 77, 78, 79, 80],
+         "messageType": "control",
+         "drawType": "button"
+      },
+      {
+        "rows": 3,
+        "cols": 8,
+        "position": [ 0, 195  ],
+        "dimensions": [28, 28],
+        "spacing": [30, 40],
+        "controls": [81, 82, 83,  84,  85,  86,  87,  88,
+                     89, 90, 91,  92,  93,  94,  95,  96,
+                     97, 98, 99, 100, 101, 102, 103, 104],
+        "messageType": "control",
+        "drawType": "knob"
+     },
+     {
+      "rows": 2,
+      "cols": 2,
+      "position": [ 250, 260 ],
+      "dimensions": [25, 20],
+      "spacing": [30, 22],
+      "controls": [105, 106,
+                   107, 108],
+      "messageType": "control",
+      "drawType": "button"
+     }
+   ]
+}

--- a/resource/userdata_original/controllers/BCR2000_encoder_groups.json
+++ b/resource/userdata_original/controllers/BCR2000_encoder_groups.json
@@ -1,0 +1,137 @@
+{
+   "groups": [
+      {
+         "rows": 1,
+         "cols": 2,
+         "position": [ 0, 0 ],
+         "dimensions": [28, 28],
+         "spacing": [35, 30],
+         "controls": [109, 110],
+         "messageType": "control",
+         "drawType": "button"
+      },
+
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 50 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [33, 34, 35, 36, 37, 38, 39, 40],
+         "messageType": "control",
+         "drawType": "button",
+	 "no_grid" : true
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 80 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [1, 2, 3, 4, 5, 6, 7, 8],
+         "messageType": "control",
+         "drawType": "knob"
+      },
+
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 250, 50 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [41, 42, 43, 44, 45, 46, 47, 48],
+         "messageType": "control",
+         "drawType": "button",
+	 "no_grid" : true
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 250, 80 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [9, 10, 11, 12, 13, 14, 15, 16],
+         "messageType": "control",
+         "drawType": "knob"
+      },
+
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 120 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [49, 50, 51, 52, 53, 54, 55, 56],
+         "messageType": "control",
+         "drawType": "button",
+	 "no_grid" : true
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 0, 150 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [17, 18, 19, 20, 21, 22, 23, 24],
+         "messageType": "control",
+         "drawType": "knob"
+      },
+
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 250, 120 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [57, 58, 59, 60, 61, 62, 63, 64],
+         "messageType": "control",
+         "drawType": "button",
+	 "no_grid" : true
+      },
+      {
+         "rows": 1,
+         "cols": 8,
+         "position": [ 250, 150 ],
+         "dimensions": [28, 28],
+         "spacing": [30, 30],
+         "controls": [25, 26, 27, 28, 29, 30, 31, 32],
+         "messageType": "control",
+         "drawType": "knob"
+      },
+
+      {
+         "rows": 2,
+         "cols": 8,
+         "position": [ 0, 200 ],
+         "dimensions": [25, 20],
+         "spacing": [30, 22],
+         "controls": [65, 66, 67, 68, 69, 70, 71, 72,
+                      73, 74, 75, 76, 77, 78, 79, 80],
+         "messageType": "control",
+         "drawType": "button"
+      },
+      {
+        "rows": 3,
+        "cols": 8,
+        "position": [ 0, 265 ],
+        "dimensions": [28, 28],
+        "spacing": [30, 40],
+        "controls": [81, 82, 83,  84,  85,  86,  87,  88,
+                     89, 90, 91,  92,  93,  94,  95,  96,
+                     97, 98, 99, 100, 101, 102, 103, 104],
+        "messageType": "control",
+        "drawType": "knob"
+     },
+     {
+      "rows": 2,
+      "cols": 2,
+      "position": [ 250, 330 ],
+      "dimensions": [25, 20],
+      "spacing": [30, 22],
+      "controls": [105, 106,
+                   107, 108],
+      "messageType": "control",
+      "drawType": "button"
+     }
+   ]
+}


### PR DESCRIPTION
BCR2000.json

	Matches the layout of the front pannel controls that emit MIDI
	plus two foot switch inputs, factory default first preset, first
	encoder group only.

BCR2000_encoder_groups.json

	The same except for having four copies of the top row of
	encoders, selectable with the four encoder group buttons on the
	hardware.

If you are not using multiple encoder groups then the "BCR2000.json" 
layout is a bit more compact and visually analogous to the hardware.

In both layouts the button directly above each knob in the first row of
knobs represents the push function of that encoder. The other three rows
of encoders have no such function in the hardware.