### PR TITLE
Fix stereo output for `seaofgrain` when mono sample is used (#1642)

### DIFF
--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -261,6 +261,11 @@ float SeaOfGrain::GetSourceBufferOffset()
       return 0;
 }
 
+int SeaOfGrain::GetSampleNumChannels()
+{
+   return mSample->NumChannels();
+}
+
 void SeaOfGrain::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mLoading = true;
@@ -475,7 +480,7 @@ void SeaOfGrain::GrainMPEVoice::Process(ChannelBuffer* output, int bufferSize)
          float pos = (mPitch + pitchBend + MIN(.125f, mPlay) - mOwner->mKeyboardBasePitch) / mOwner->mKeyboardNumPitches;
          mGranulator.ProcessFrame(time, mOwner->GetSourceBuffer(), mOwner->GetSourceBuffer()->BufferSize(), ofLerp(mOwner->GetSourceStartSample(), mOwner->GetSourceEndSample(), pos) + mOwner->GetSourceBufferOffset(), speed, outSample);
          for (int ch = 0; ch < output->NumActiveChannels(); ++ch)
-            output->GetChannel(ch)[i] += outSample[ch] * sqrtf(mGain) * mADSR.Value(time);
+            output->GetChannel(ch)[i] += outSample[mOwner->GetSampleNumChannels() == 1 ? 0 : ch] * sqrtf(mGain) * mADSR.Value(time);
 
          time += gInvSampleRateMs;
          mPlay += .001f;
@@ -533,7 +538,7 @@ void SeaOfGrain::GrainManualVoice::Process(ChannelBuffer* output, int bufferSize
          Clear(outSample, ChannelBuffer::kMaxNumChannels);
          mGranulator.ProcessFrame(time, mOwner->GetSourceBuffer(), mOwner->GetSourceBuffer()->BufferSize(), ofLerp(mOwner->GetSourceStartSample(), mOwner->GetSourceEndSample(), mPosition) + mOwner->GetSourceBufferOffset(), speed, outSample);
          for (int ch = 0; ch < output->NumActiveChannels(); ++ch)
-            output->GetChannel(ch)[i] += outSample[ch] * mGain * (ch == 0 ? panLeft : panRight);
+            output->GetChannel(ch)[i] += outSample[mOwner->GetSampleNumChannels() == 1 ? 0 : ch] * mGain * (ch == 0 ? panLeft : panRight);
          time += gInvSampleRateMs;
       }
    }

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -104,6 +104,7 @@ private:
    float GetSourceStartSample();
    float GetSourceEndSample();
    float GetSourceBufferOffset();
+   int GetSampleNumChannels();
 
    struct GrainMPEVoice
    {


### PR DESCRIPTION
This PR fixes #1642 (only one output channel is written by `seaofgrain` on mono samples) by using the same sample channel for both left and right for mono samples. It seems that previously all samples were treated as stereo samples, resulting in the right channel being outputted as empty for mono samples.

Fixes #1642