### PR TITLE
Clamp set values to each TextEntry range

### DIFF
--- a/Source/TextEntry.cpp
+++ b/Source/TextEntry.cpp
@@ -563,13 +563,13 @@ void TextEntry::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
    if (mType == kTextEntry_Int)
    {
-      *mVarInt = std::round(value);
+      *mVarInt = ofClamp(std::round(value), mIntMin, mIntMax);
       UpdateDisplayString();
    }
 
    if (mType == kTextEntry_Float)
    {
-      *mVarFloat = value;
+      *mVarFloat = ofClamp(value, mFloatMin, mFloatMax);
       UpdateDisplayString();
    }
 }


### PR DESCRIPTION
Shenanigans that were permitted before this change include setting waveformviewer freq = 0 which crashed the GUI.