### PR TITLE
Fix multiple crashes when importing invalid cue points using the scripts `import_sampleplayer_cue` method. Resolves: #197.

### DIFF
--- a/Source/DrumPlayer.cpp
+++ b/Source/DrumPlayer.cpp
@@ -698,7 +698,7 @@ void DrumPlayer::SampleDropped(int x, int y, Sample* sample)
 
 void DrumPlayer::ImportSampleCuePoint(SamplePlayer* player, int sourceCueIndex, int destHitIndex)
 {
-   if (player != nullptr)
+   if (player != nullptr && player->validCuePoint(sourceCueIndex))
    {
       ChannelBuffer* data = player->GetCueSampleData(sourceCueIndex);
       Sample sample;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -941,6 +941,11 @@ void SamplePlayer::SetCuePoint(int pitch, float startSeconds, float lengthSecond
    }
 }
 
+bool SamplePlayer::validCuePoint(int cueIndex)
+{
+   return mSample != nullptr && cueIndex > 0 && cueIndex < mSampleCuePoints.size() - 1 && mSampleCuePoints[cueIndex].lengthSeconds > 0;
+}
+
 void SamplePlayer::DrawModule()
 {
    if (Minimized() || IsVisible() == false)

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -943,7 +943,7 @@ void SamplePlayer::SetCuePoint(int pitch, float startSeconds, float lengthSecond
 
 bool SamplePlayer::validCuePoint(int cueIndex)
 {
-   return mSample != nullptr && cueIndex > 0 && cueIndex < mSampleCuePoints.size() - 1 && mSampleCuePoints[cueIndex].lengthSeconds > 0;
+   return mSample != nullptr && cueIndex >= 0 && cueIndex < mSampleCuePoints.size() - 1 && mSampleCuePoints[cueIndex].lengthSeconds > 0;
 }
 
 void SamplePlayer::DrawModule()

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -78,6 +78,7 @@ public:
    }
 
    void SetCuePoint(int pitch, float startSeconds, float lengthSeconds, float speed);
+   bool validCuePoint(int cueIndex);
    void FillData(std::vector<float> data);
    ChannelBuffer* GetCueSampleData(int cueIndex);
    float GetLengthInSeconds() const;


### PR DESCRIPTION
Fix multiple crashes when importing invalid cue points using the scripts `import_sampleplayer_cue` method. Resolves: #197.