### PR TITLE
Make the `multitapdelay` UI more compact

### DIFF
--- a/Source/MultitapDelay.cpp
+++ b/Source/MultitapDelay.cpp
@@ -53,17 +53,22 @@ MultitapDelay::MultitapDelay()
 void MultitapDelay::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mDryAmountSlider = new FloatSlider(this, "dry", 5, 10, 150, 15, &mDryAmount, 0, 1);
-   mDisplayLengthSlider = new FloatSlider(this, "display length", mDryAmountSlider, kAnchor_Below, 150, 15, &mDisplayLength, .1f, mDelayBuffer.Size() / gSampleRate);
+
+   int tapBoxW = (mBufferW - 30) / 4;
+
+   mDryAmountSlider = new FloatSlider(this, "dry", 5, 10, tapBoxW, 15, &mDryAmount, 0, 1);
+   mDisplayLengthSlider = new FloatSlider(this, "display length", mDryAmountSlider, kAnchor_Below, tapBoxW, 15, &mDisplayLength, .1f, mDelayBuffer.Size() / gSampleRate);
    mDisplayLength = mDisplayLengthSlider->GetMax();
 
    for (int i = 0; i < mNumTaps; ++i)
    {
-      float y = mBufferY + mBufferH + 10 + i * 100;
-      mTaps[i].mDelayMsSlider = new FloatSlider(this, ("delay " + ofToString(i + 1)).c_str(), 10, y, 150, 15, &mTaps[i].mDelayMs, gBufferSize / gSampleRateMs, mDelayBuffer.Size() / gSampleRateMs);
-      mTaps[i].mGainSlider = new FloatSlider(this, ("gain " + ofToString(i + 1)).c_str(), mTaps[i].mDelayMsSlider, kAnchor_Below, 150, 15, &mTaps[i].mGain, 0, 1);
-      mTaps[i].mFeedbackSlider = new FloatSlider(this, ("feedback " + ofToString(i + 1)).c_str(), mTaps[i].mGainSlider, kAnchor_Below, 150, 15, &mTaps[i].mFeedback, 0, 1);
-      mTaps[i].mPanSlider = new FloatSlider(this, ("pan " + ofToString(i + 1)).c_str(), mTaps[i].mFeedbackSlider, kAnchor_Below, 150, 15, &mTaps[i].mPan, -1, 1);
+      int row = i / 4;
+      int column = i % 4;
+
+      mTaps[i].mDelayMsSlider = new FloatSlider(this, ("delay " + ofToString(i + 1)).c_str(), 5 + column * (tapBoxW + 10), mBufferY + mBufferH + 10 + row * 80, tapBoxW, 15, &mTaps[i].mDelayMs, gBufferSize / gSampleRateMs, mDelayBuffer.Size() / gSampleRateMs);
+      mTaps[i].mGainSlider = new FloatSlider(this, ("gain " + ofToString(i + 1)).c_str(), mTaps[i].mDelayMsSlider, kAnchor_Below, tapBoxW, 15, &mTaps[i].mGain, 0, 1);
+      mTaps[i].mFeedbackSlider = new FloatSlider(this, ("feedback " + ofToString(i + 1)).c_str(), mTaps[i].mGainSlider, kAnchor_Below, tapBoxW, 15, &mTaps[i].mFeedback, 0, 1);
+      mTaps[i].mPanSlider = new FloatSlider(this, ("pan " + ofToString(i + 1)).c_str(), mTaps[i].mFeedbackSlider, kAnchor_Below, tapBoxW, 15, &mTaps[i].mPan, -1, 1);
    }
 }
 
@@ -196,7 +201,7 @@ void MultitapDelay::CheckboxUpdated(Checkbox* checkbox, double time)
 void MultitapDelay::GetModuleDimensions(float& width, float& height)
 {
    width = mBufferW + 10;
-   height = mBufferY + mBufferH + 10 + 100 * mNumTaps;
+   height = mBufferY + mBufferH + 10 + 80 * ceil(mNumTaps / 4.0);
 }
 
 void MultitapDelay::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)


### PR DESCRIPTION
Currently the `multitapdelay` UI is not very compact: it lists tap sliders in one column, and with increasing the number of taps (currently by modifying variable `mNumTaps` in the code) new tap sliders appear below:
![Screenshot from 2025-06-11 16-29-26](https://github.com/user-attachments/assets/b5c15100-9676-42ce-a8c2-c1a9cdfef3ba)

This PR places 4 taps on a single row with the same width as the buffer display:
![Screenshot from 2025-06-11 16-32-20](https://github.com/user-attachments/assets/ffe390c0-dc67-488e-8f99-c2266936d501)

Should the number of taps increase, new rows are added below, again with four taps on each of them:
![Screenshot from 2025-06-11 16-33-38](https://github.com/user-attachments/assets/cbc723b9-7534-41f6-96d9-c7932dd1991b)