### PR TITLE
Fix `stereorotation` output: audio output has to be added to the buffer, not written over it

### DIFF
--- a/Source/StereoRotation.cpp
+++ b/Source/StereoRotation.cpp
@@ -67,13 +67,13 @@ void StereoRotation::Process(double time)
    {
       if (mEnabled)
       {
-         out->GetChannel(0)[i] = GetBuffer()->GetChannel(0)[i] * phaseCos - GetBuffer()->GetChannel(secondChannel)[i] * phaseSin;
-         out->GetChannel(1)[i] = GetBuffer()->GetChannel(0)[i] * phaseSin + GetBuffer()->GetChannel(secondChannel)[i] * phaseCos;
+         out->GetChannel(0)[i] += GetBuffer()->GetChannel(0)[i] * phaseCos - GetBuffer()->GetChannel(secondChannel)[i] * phaseSin;
+         out->GetChannel(1)[i] += GetBuffer()->GetChannel(0)[i] * phaseSin + GetBuffer()->GetChannel(secondChannel)[i] * phaseCos;
       }
       else
       {
-         out->GetChannel(0)[i] = GetBuffer()->GetChannel(0)[i];
-         out->GetChannel(1)[i] = GetBuffer()->GetChannel(secondChannel)[i];
+         out->GetChannel(0)[i] += GetBuffer()->GetChannel(0)[i];
+         out->GetChannel(1)[i] += GetBuffer()->GetChannel(secondChannel)[i];
       }
    }
 


### PR DESCRIPTION
I made a subtle mistake in `stereorotation` module, causing it to overwrite its siblings' contributions to the target buffer. I should have used `+=` instead of `=`.