### PR TITLE
`stereorotation` improvements

### DIFF
--- a/Source/StereoRotation.cpp
+++ b/Source/StereoRotation.cpp
@@ -59,14 +59,14 @@ void StereoRotation::Process(double time)
 
    SyncBuffers(2);
 
-   float phaseSin = sin(mPhase * 2 * PI);
-   float phaseCos = cos(mPhase * 2 * PI);
-
    int secondChannel = GetBuffer()->NumActiveChannels() - 1;
    for (int i = 0; i < bufferSize; ++i)
    {
       if (mEnabled)
       {
+         float phaseSin = sin(mPhase * 2 * PI);
+         float phaseCos = cos(mPhase * 2 * PI);
+
          out->GetChannel(0)[i] += GetBuffer()->GetChannel(0)[i] * phaseCos - GetBuffer()->GetChannel(secondChannel)[i] * phaseSin;
          out->GetChannel(1)[i] += GetBuffer()->GetChannel(0)[i] * phaseSin + GetBuffer()->GetChannel(secondChannel)[i] * phaseCos;
       }

--- a/Source/StereoRotation.cpp
+++ b/Source/StereoRotation.cpp
@@ -37,7 +37,7 @@ StereoRotation::StereoRotation()
 void StereoRotation::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
-   mPhaseSlider = new FloatSlider(this, "phase", 5, 2, 110, 15, &mPhase, 0, 1);
+   mPhaseSlider = new FloatSlider(this, "phase", 5, 2, 110, 15, &mPhase, -0.5, 0.5);
 }
 
 StereoRotation::~StereoRotation()

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2153,3 +2153,6 @@ acciaccatura~adds a quick grace note before playing the input pitch
 ~notemode~should the offset be in scale steps, or chromatically in semitones?
 ~hold ms~how long to hold offset pitch before transitioning to input pitch
 ~glide ms~how long to spend bending between offset pitch and input pitch after hold ms
+
+stereorotation~rotates the phase of input audio
+~phase~phase offset


### PR DESCRIPTION
This PR introduces improvements to `stereorotation`, mainly the ones [suggested](https://github.com/BespokeSynth/BespokeSynth/pull/1821#issuecomment-2969060210) by @PowerUser64:

1. Refresh the phase value not once per buffer, but per each value in the buffer. This removes clicks for the price of a more intensive calculation.
2. Change the phase slider interval from [0, 1] to a more natural [-0.5, 0.5]. I have checked, this does not affect old savestates as the sliders remember their intervals.
3. Add tooltips for the module.