### PR TITLE
Set the titlebar to be dark themed on windows

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -849,6 +849,7 @@ if (APPLE)
     endif()
 elseif (WIN32)
     target_compile_definitions(BespokeSynth PRIVATE BESPOKE_WINDOWS=1)
+    target_link_libraries(BespokeSynth PRIVATE "dwmapi.lib")
 
     IF (MINGW)
         target_link_libraries(BespokeSynth PRIVATE iphlpapi)

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -165,29 +165,9 @@ public:
 #if BESPOKE_WINDOWS
          auto hwnd = getPeer()->getNativeHandle();
 
-         char buffer[4];
-         DWORD bufferSize = sizeof(buffer);
-         auto result = RegGetValueW(
-         HKEY_CURRENT_USER,
-         L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-         L"AppsUseLightTheme",
-         RRF_RT_REG_DWORD,
-         nullptr,
-         buffer,
-         &bufferSize);
-
-         if (result == ERROR_SUCCESS)
-         {
-            // Windows registry values are in little endian
-            int i = int(buffer[3] << 24 |
-                        buffer[2] << 16 |
-                        buffer[1] << 8 |
-                        buffer[0]);
-
-            BOOL darkMode = i != 1;
-            DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
-            UpdateWindow((HWND)hwnd);
-         }
+         BOOL darkMode = Desktop::getInstance().isDarkModeActive();
+         DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+         UpdateWindow((HWND)hwnd);
 #endif
       }
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -186,6 +186,7 @@ public:
 
             BOOL darkMode = i != 1;
             DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+            UpdateWindow((HWND)hwnd);
          }
 #endif
       }

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -18,7 +18,6 @@
 #if BESPOKE_WINDOWS
 #include <dwmapi.h>
 #include <windows.h>
-#include <string>
 #endif
 
 using namespace juce;
@@ -166,37 +165,24 @@ public:
 #if BESPOKE_WINDOWS
          auto hwnd = getPeer()->getNativeHandle();
 
-         char themeBuffer[4];
-         DWORD themeBufferSize = sizeof(themeBuffer);
-         auto themeResult = RegGetValueW(
+         char buffer[4];
+         DWORD bufferSize = sizeof(buffer);
+         auto result = RegGetValueW(
          HKEY_CURRENT_USER,
          L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
          L"AppsUseLightTheme",
          RRF_RT_REG_DWORD,
          nullptr,
-         themeBuffer,
-         &themeBufferSize);
+         buffer,
+         &bufferSize);
 
-         WCHAR versionBuffer[512];
-         DWORD versionBufferSize = sizeof(versionBuffer);
-         auto versionResult = RegGetValueW(
-         HKEY_LOCAL_MACHINE,
-         L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-         L"CurrentBuildNumber",
-         RRF_RT_ANY,
-         nullptr,
-         versionBuffer,
-         &versionBufferSize);
-
-         int versionNumber = versionResult == ERROR_SUCCESS ? std::stoi(versionBuffer) : 0;
-
-         if (themeResult == ERROR_SUCCESS && versionNumber > 2200)
+         if (result == ERROR_SUCCESS)
          {
             // Windows registry values are in little endian
-            int i = int(themeBuffer[3] << 24 |
-                        themeBuffer[2] << 16 |
-                        themeBuffer[1] << 8 |
-                        themeBuffer[0]);
+            int i = int(buffer[3] << 24 |
+                        buffer[2] << 16 |
+                        buffer[1] << 8 |
+                        buffer[0]);
 
             BOOL darkMode = i != 1;
             DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -17,6 +17,7 @@
 
 #if BESPOKE_WINDOWS
 #include <dwmapi.h>
+#include <windows.h>
 #endif
 
 using namespace juce;
@@ -164,8 +165,25 @@ public:
 #if BESPOKE_WINDOWS
          auto hwnd = getPeer()->getNativeHandle();
 
-         BOOL USE_DARK_MODE = true;
-         auto result = DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &USE_DARK_MODE, sizeof(USE_DARK_MODE));
+         char buffer[4];
+         DWORD bufferSize = sizeof(buffer);
+         auto result = RegGetValueW(
+         HKEY_CURRENT_USER,
+         L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+         L"AppsUseLightTheme",
+         RRF_RT_REG_DWORD,
+         nullptr,
+         buffer,
+         &bufferSize);
+
+         // Win32 registry values are in little endian
+         int i = int(buffer[3] << 24 |
+                     buffer[2] << 16 |
+                     buffer[1] << 8 |
+                     buffer[0]);
+
+         BOOL darkMode = i != 1;
+         DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
 #endif
       }
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -18,6 +18,7 @@
 #if BESPOKE_WINDOWS
 #include <dwmapi.h>
 #include <windows.h>
+#include <string>
 #endif
 
 using namespace juce;
@@ -165,24 +166,37 @@ public:
 #if BESPOKE_WINDOWS
          auto hwnd = getPeer()->getNativeHandle();
 
-         char buffer[4];
-         DWORD bufferSize = sizeof(buffer);
-         auto result = RegGetValueW(
+         char themeBuffer[4];
+         DWORD themeBufferSize = sizeof(themeBuffer);
+         auto themeResult = RegGetValueW(
          HKEY_CURRENT_USER,
          L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
          L"AppsUseLightTheme",
          RRF_RT_REG_DWORD,
          nullptr,
-         buffer,
-         &bufferSize);
+         themeBuffer,
+         &themeBufferSize);
 
-         if (result == ERROR_SUCCESS)
+         WCHAR versionBuffer[512];
+         DWORD versionBufferSize = sizeof(versionBuffer);
+         auto versionResult = RegGetValueW(
+         HKEY_LOCAL_MACHINE,
+         L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+         L"CurrentBuildNumber",
+         RRF_RT_ANY,
+         nullptr,
+         versionBuffer,
+         &versionBufferSize);
+
+         int versionNumber = versionResult == ERROR_SUCCESS ? std::stoi(versionBuffer) : 0;
+
+         if (themeResult == ERROR_SUCCESS && versionNumber > 2200)
          {
             // Windows registry values are in little endian
-            int i = int(buffer[3] << 24 |
-                        buffer[2] << 16 |
-                        buffer[1] << 8 |
-                        buffer[0]);
+            int i = int(themeBuffer[3] << 24 |
+                        themeBuffer[2] << 16 |
+                        themeBuffer[1] << 8 |
+                        themeBuffer[0]);
 
             BOOL darkMode = i != 1;
             DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -106,6 +106,14 @@ public:
 
       appProperties = std::make_unique<juce::ApplicationProperties>();
       appProperties->setStorageParameters(options);
+
+#if BESPOKE_WINDOWS
+      HWND hwnd = (HWND)this->mainWindow.get()->getWindowHandle();
+
+      BOOL darkMode = Desktop::getInstance().isDarkModeActive();
+      DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+      UpdateWindow(hwnd);
+#endif
    }
 
    // Prints an error for arguments that expected an argument but were not given one
@@ -161,14 +169,6 @@ public:
 
          centreWithSize(getWidth(), getHeight());
          setVisible(true);
-
-#if BESPOKE_WINDOWS
-         auto hwnd = getPeer()->getNativeHandle();
-
-         BOOL darkMode = Desktop::getInstance().isDarkModeActive();
-         DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
-         UpdateWindow((HWND)hwnd);
-#endif
       }
 
       void closeButtonPressed() override

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -176,14 +176,17 @@ public:
          buffer,
          &bufferSize);
 
-         // Win32 registry values are in little endian
-         int i = int(buffer[3] << 24 |
-                     buffer[2] << 16 |
-                     buffer[1] << 8 |
-                     buffer[0]);
+         if (result == ERROR_SUCCESS)
+         {
+            // Windows registry values are in little endian
+            int i = int(buffer[3] << 24 |
+                        buffer[2] << 16 |
+                        buffer[1] << 8 |
+                        buffer[0]);
 
-         BOOL darkMode = i != 1;
-         DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+            BOOL darkMode = i != 1;
+            DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+         }
 #endif
       }
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -15,6 +15,10 @@
 
 #include "VersionInfo.h"
 
+#if BESPOKE_WINDOWS
+#include <dwmapi.h>
+#endif
+
 using namespace juce;
 
 Component* createMainContentComponent();
@@ -156,6 +160,13 @@ public:
 
          centreWithSize(getWidth(), getHeight());
          setVisible(true);
+
+#if BESPOKE_WINDOWS
+         auto hwnd = getPeer()->getNativeHandle();
+
+         BOOL USE_DARK_MODE = true;
+         auto result = DwmSetWindowAttribute((HWND)hwnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &USE_DARK_MODE, sizeof(USE_DARK_MODE));
+#endif
       }
 
       void closeButtonPressed() override


### PR DESCRIPTION
This PR changes the titlebar on Windows 11 (and some supported versions of 10 I'm pretty sure) to have a dark theme, to better match the rest of the application.

Before:
![before](https://github.com/user-attachments/assets/d289130a-a426-4b89-81c8-64fb9cbc3add)

After:
![after](https://github.com/user-attachments/assets/b539fa44-1545-497d-96d5-3905fb2a06f1)

This is my first time contributing to anything so please let me know if I've done anything wrong!