### PR TITLE
Plugin parameters tweaks and fixes. Resolves: #1691.

### DIFF
--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -593,6 +593,8 @@ void VSTPlugin::CreateParameterSliders()
          RemoveUIControl(slider.mRemoveButton);
          slider.mSlider->Delete();
          slider.mRemoveButton->Delete();
+         slider.mSlider = nullptr;
+         slider.mRemoveButton = nullptr;
       }
    }
    mParameterSliders.clear();
@@ -1237,6 +1239,11 @@ void VSTPlugin::ButtonClicked(ClickButton* button, double time)
 
    if (button == mLoadParameterButton)
    {
+      if (GetKeyModifiers() & kModifier_Command)
+      {
+         CreateParameterSliders();
+         return;
+      }
       mWantLoadParameters = true;
       return;
    }

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -640,6 +640,8 @@ void VSTPlugin::CreateParameterSliders()
          mParameterSliders[i].mInSelectorList = false;
       }
    }
+   // Move output cables
+   RecreateUIOutputCables();
 }
 
 void VSTPlugin::Poll()
@@ -698,9 +700,6 @@ void VSTPlugin::Poll()
          if (mWindow == nullptr)
             mWindow = std::unique_ptr<VSTWindow>(VSTWindow::CreateVSTWindow(this, VSTWindow::Normal));
          mWindow->ShowWindow();
-
-         //if (mWindow->GetNSViewComponent())
-         //   mWindowOverlay = new NSWindowOverlay(mWindow->GetNSViewComponent()->getView());
       }
    }
 
@@ -757,6 +756,8 @@ void VSTPlugin::Poll()
                      mParameterSliders[index].MakeSlider();
                }
             }
+            // Move output cables
+            RecreateUIOutputCables();
          }
       }
    }
@@ -973,7 +974,10 @@ void VSTPlugin::Process(double time)
          int numMonoSamples = buffer.getNumSamples();
          for (int sampleIndex = 0; sampleIndex < numMonoSamples; ++sampleIndex)
          {
-            AllChannelsBuffer->GetChannel(sourceChannel)[sampleIndex] += buffer.getSample(sourceChannel, sampleIndex) * mVol;
+            auto temp_buffer = AllChannelsBuffer->GetChannel(sourceChannel);
+            if (temp_buffer == nullptr)
+               continue;
+            temp_buffer[sampleIndex] += buffer.getSample(sourceChannel, sampleIndex) * mVol;
          }
 
          // Copy the outputs from the single buffer into our multiple output buffers
@@ -1171,6 +1175,8 @@ void VSTPlugin::DropdownUpdated(DropdownList* list, int oldVal, double time)
       mParameterSliders[mShowParameterIndex].mInSelectorList = true;
       mShowParameterIndex = -1;
       mTemporarilyDisplayedParamIndex = -1;
+      // Move output cables
+      RecreateUIOutputCables();
    }
 }
 

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -181,6 +181,7 @@ private:
    int mModwheelCC{ 1 }; //or 74 in Multidimensional Polyphonic Expression (MPE) spec
    std::string mOldVstPath{ "" }; //for loading save files that predate pluginId-style saving
    int mParameterVersion{ 1 };
+   int mLastNumChannels{ -1 };
 
    // juce supports a max of 16 stereo output channels
    static const int maxStereoOutputChannels{ 16 };

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -141,6 +141,8 @@ private:
    std::atomic<bool> mWantsPanic{ false };
    std::atomic<bool> mWantsAddExtraOutput{ false };
    std::atomic<bool> mWantsRemoveExtraOutput{ false };
+   std::atomic<bool> mWantRemoveSlider{ false };
+   std::atomic<int> mWantRemoveSliderIndex{ -1 };
 
    bool mPluginReady{ false };
    std::unique_ptr<juce::AudioProcessor> mPlugin;
@@ -164,6 +166,7 @@ private:
       VSTPlugin* mOwner{ nullptr };
       float mValue{ 0 };
       FloatSlider* mSlider{ nullptr };
+      ClickButton* mRemoveButton{ nullptr };
       juce::AudioProcessorParameter* mParameter{ nullptr };
       bool mShowing{ false };
       bool mInSelectorList{ true };

--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -135,12 +135,14 @@ private:
    ClickButton* mSavePresetFileButton{ nullptr };
    std::vector<std::string> mPresetFilePaths;
    ClickButton* mOpenEditorButton{ nullptr };
+   ClickButton* mLoadParameterButton{ nullptr };
    ClickButton* mPanicButton{ nullptr };
    ClickButton* mAddExtraOutputButton{ nullptr };
    ClickButton* mRemoveExtraOutputButton{ nullptr };
    std::atomic<bool> mWantsPanic{ false };
    std::atomic<bool> mWantsAddExtraOutput{ false };
    std::atomic<bool> mWantsRemoveExtraOutput{ false };
+   std::atomic<bool> mWantLoadParameters{ false };
    std::atomic<bool> mWantRemoveSlider{ false };
    std::atomic<int> mWantRemoveSliderIndex{ -1 };
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1925,6 +1925,7 @@ plugin~a hosted plugin instance, such as a VST
 ~program change~send a program change message to the plugin instance
 ~open~show the plugin window
 ~show parameter~select parameters to display them, so they can be adjusted from within bespoke's interface. if a plugin has more than 100 parameters, this list will initially be empty. in that case, to make a parameter appear in this list, wiggle or change it within the plugin's interface.
+~load parameter~This shows the number of parameters exposed by the plugin. If you click here, up to a 100 parameters are attempted to be added to the parameter dropdown list. If you hold `shift` while clicking, the parameter sliders will be added as well.
 ~preset~choose from saved plugin presets
 ~save as~save the current plugin settings as a preset to load again later
 ~panic~send "all notes off" and "all sounds off" to this plugin in order to silence it immediately

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1925,7 +1925,7 @@ plugin~a hosted plugin instance, such as a VST
 ~program change~send a program change message to the plugin instance
 ~open~show the plugin window
 ~show parameter~select parameters to display them, so they can be adjusted from within bespoke's interface. if a plugin has more than 100 parameters, this list will initially be empty. in that case, to make a parameter appear in this list, wiggle or change it within the plugin's interface.
-~load parameter~This shows the number of parameters exposed by the plugin. If you click here, up to a 100 parameters are attempted to be added to the parameter dropdown list. If you hold `shift` while clicking, the parameter sliders will be added as well.
+~load parameter~This shows the number of parameters exposed by the plugin. If you click here, up to a 100 parameters are attempted to be added to the parameter dropdown list. If you hold `shift` while clicking, the parameter sliders will be added as well. If you hold `control` the parameter list will be reset and recreated as if the plugin was spawned new.
 ~preset~choose from saved plugin presets
 ~save as~save the current plugin settings as a preset to load again later
 ~panic~send "all notes off" and "all sounds off" to this plugin in order to silence it immediately

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1924,13 +1924,13 @@ plugin~a hosted plugin instance, such as a VST
 ~vol~adjust the output volume
 ~program change~send a program change message to the plugin instance
 ~open~show the plugin window
-~show parameter~select parameters to display them, so they can be adjusted from within bespoke's interface. if a plugin has more than 20 parameters, this list will initially be empty. in that case, to make a parameter appear in this list, wiggle it within the plugin's interface.
+~show parameter~select parameters to display them, so they can be adjusted from within bespoke's interface. if a plugin has more than 100 parameters, this list will initially be empty. in that case, to make a parameter appear in this list, wiggle or change it within the plugin's interface.
 ~preset~choose from saved plugin presets
 ~save as~save the current plugin settings as a preset to load again later
 ~panic~send "all notes off" and "all sounds off" to this plugin in order to silence it immediately
-~+~Manually add a new Stereo output from the plugin
-~ - ~Remove the last manually added Stereo output from the plugin
-
+~ + ~Manually add a new Stereo output from the plugin
+~  -  ~Remove the last manually added Stereo output from the plugin
+~ X ~Remove the parameter and all modulation connected to it
 
 
 transport~controls tempo and current time position


### PR DESCRIPTION
- Fix a rare crash.
- Fixed a few places the output cable sources weren't being updated.
- Fixed a bug where the buffers would always be recreated instead of only when needed in the plugin module.
- Stop processing of audio when a plugins output isn't connected.
- Made it so that wiggled/changed parameters are kept in the DropDownList for the session instead of only keeping the last one.
- Added the ability to remove parameter sliders from the plugin module.
- Rearranged UI elements to better suit the new features.
- Added a hidden button over the parameter count in the plugin module that allows one to load parameters in bundles of a 100. Resolves: #1691.
- Added a way to reset the parameter dropdown list and sliders to a state as if the plugin module was newly spawned.

