### PR TITLE
Change the default of level meters in the `gain` module to disabled. Resolves: #1755.

### DIFF
--- a/Source/Amplifier.cpp
+++ b/Source/Amplifier.cpp
@@ -116,7 +116,7 @@ void Amplifier::DrawModule()
 void Amplifier::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadString("target", moduleInfo);
-   mModuleSaveData.LoadBool("show_level_meter", moduleInfo, true);
+   mModuleSaveData.LoadBool("show_level_meter", moduleInfo, false);
 
    SetUpFromSaveData();
 }


### PR DESCRIPTION
Change the default of level meters in the `gain` module to disabled. 
This not only increases performance but also makes older savestates and prefabs less affected by overlapping modules. Resolves: #1755.