### PR TITLE
Fix `envelope` output when connected to anything other than a FloatSlider. Resolves: #1514.

### DIFF
--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -126,7 +126,7 @@ float EnvelopeModulator::Value(int samplesIn /*= 0*/)
    ComputeSliders(samplesIn);
    if (GetSliderTarget())
       return ofClamp(Interp(mAdsr.Value(gTime + samplesIn * gInvSampleRateMs), GetMin(), GetMax()), GetSliderTarget()->GetMin(), GetSliderTarget()->GetMax());
-   return 0;
+   return ofClamp(Interp(mAdsr.Value(gTime + samplesIn * gInvSampleRateMs), GetMin(), GetMax()), GetMin(), GetMax());
 }
 
 void EnvelopeModulator::PostRepatch(PatchCableSource* cableSource, bool fromUserClick)


### PR DESCRIPTION
Fix `envelope` output when connected to anything other than a FloatSlider. Resolves: #1514.