### PR TITLE
Fix the loading of MIDI files in the `notecanvas` module. Resolves: #1475.

### DIFF
--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -577,7 +577,6 @@ void NoteCanvas::LoadMidi()
       MidiFile midifile;
       if (midifile.readFrom(inputStream))
       {
-         midifile.convertTimestampTicksToSeconds();
          int ticksPerQuarterNote = midifile.getTimeFormat();
          int trackToGet = 0;
          if (midifile.getNumTracks() > 1)


### PR DESCRIPTION
Fix the loading of MIDI files in the `notecanvas` module. Resolves: #1475.