### PR TITLE
Adjust buffersize in the looper to make it less likely to access beyond the buffer. Resolves: #1500.

### DIFF
--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -50,9 +50,14 @@ Looper::Looper()
 : IAudioProcessor(gBufferSize)
 , mWorkBuffer(gBufferSize)
 {
-   //TODO(Ryan) buffer sizes
-   mBuffer = new ChannelBuffer(MAX_BUFFER_SIZE);
-   mUndoBuffer = new ChannelBuffer(MAX_BUFFER_SIZE);
+   //TODO(Ryan) buffer sizes.
+   //    (Noxy) The buffersize is dependant on the tempo which can be altered realtime and is not update in the
+   //           looper. For now I have this "workaround" which is more correct provided one does not lower the
+   //           tempo with a spawned in looper.
+   const auto sampsPerBar = abs(static_cast<int>(TheTransport->MsPerBar() / 1000 * gSampleRate));
+   const auto samplesNeeded = sampsPerBar * kMaxNumBars * 2 /* channels? */;
+   mBuffer = new ChannelBuffer(samplesNeeded);
+   mUndoBuffer = new ChannelBuffer(samplesNeeded);
    Clear();
 
    mMuteRamp.SetValue(1);
@@ -886,7 +891,7 @@ void Looper::BakeVolume()
 
 void Looper::UpdateNumBars(int oldNumBars)
 {
-   assert(mNumBars > 0);
+   assert(mNumBars > 0 && mNumBars <= kMaxNumBars);
    int sampsPerBar = abs(int(TheTransport->MsPerBar() / 1000 * gSampleRate));
    SetLoopLength(MIN(sampsPerBar * mNumBars, MAX_BUFFER_SIZE - 1));
    while (mLoopPos > sampsPerBar)


### PR DESCRIPTION
Adjust buffersize in the looper to make it less likely to access beyond the buffer. 

The only instance where this will still happen is if the tempo is lowered and then the number of bars is increased.
Adjusting the buffer sizes in realtime is likely not a good idea.

Resolves: #1500.