### PR TITLE
fixed crash when extending looper length beyond the max buffer size #1500

### DIFF
--- a/Source/Looper.cpp
+++ b/Source/Looper.cpp
@@ -899,7 +899,10 @@ void Looper::UpdateNumBars(int oldNumBars)
       for (int i = 1; i < mNumBars / oldNumBars; ++i)
       {
          for (int ch = 0; ch < mBuffer->NumActiveChannels(); ++ch)
-            BufferCopy(mBuffer->GetChannel(ch) + oldLoopLength * i, mBuffer->GetChannel(ch), oldLoopLength);
+         {
+            if (oldLoopLength * i + oldLoopLength < MAX_BUFFER_SIZE)
+               BufferCopy(mBuffer->GetChannel(ch) + oldLoopLength * i, mBuffer->GetChannel(ch), oldLoopLength);
+         }
       }
    }
 }


### PR DESCRIPTION
fixes #1500 