### PR TITLE
double the length of the buffer used by looper

### DIFF
--- a/Source/SynthGlobals.h
+++ b/Source/SynthGlobals.h
@@ -57,7 +57,7 @@ void* operator new[](std::size_t size, const char* file, int line) throw(std::ba
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
-#define MAX_BUFFER_SIZE 30 * gSampleRate
+#define MAX_BUFFER_SIZE 60 * gSampleRate
 #define MAX_TEXTENTRY_LENGTH 1024
 
 #ifndef M_PI


### PR DESCRIPTION
allows for longer loops, like the usage in #1500
