### PR TITLE
Fixed a bug where the `ramper` would not handle a resetting transport. Resolves: #1471.

### DIFF
--- a/Source/Ramper.cpp
+++ b/Source/Ramper.cpp
@@ -78,9 +78,8 @@ void Ramper::OnTransportAdvanced(float amount)
       mRamping = false;
    if (mRamping)
    {
-      float curMeasure = TheTransport->GetMeasure(gTime) + TheTransport->GetMeasurePos(gTime);
-      float measureProgress = curMeasure - mStartMeasure;
-      float length = TheTransport->GetDuration(mLength) / TheTransport->MsPerBar();
+      float measureProgress = gTime - mStartTime;
+      float length = TheTransport->GetDuration(mLength);
       float progress = measureProgress / length;
       if (progress >= 0 && progress < 1)
       {
@@ -153,7 +152,7 @@ void Ramper::Go(double time)
    if (mUIControls[0] != nullptr)
    {
       mStartValue = mUIControls[0]->GetValue();
-      mStartMeasure = TheTransport->GetMeasureTime(time);
+      mStartTime = time;
       mRamping = true;
    }
 }

--- a/Source/Ramper.h
+++ b/Source/Ramper.h
@@ -87,7 +87,7 @@ private:
    ClickButton* mTriggerButton{ nullptr };
    FloatSlider* mTargetValueSlider{ nullptr };
    float mTargetValue{ 0 };
-   float mStartMeasure{ 0 };
+   float mStartTime{ 0 };
    float mStartValue{ 0 };
    bool mRamping{ false };
 };


### PR DESCRIPTION
Fixed a bug where the `ramper` would not handle a resetting transport. Resolves: #1471.

This would be very apparent when using the `songbuilder` module since it resets the transport a lot.