### PR TITLE
Added the function `bespoke.get_controls` to the `script` module. Resolves: #1425.

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -1108,22 +1108,29 @@ void ScriptModule::OnCodeUpdated()
    {
       std::vector<std::string> lines = mCodeEntry->GetLines(false);
 
-      for (size_t i = 0; i < mBoundModuleConnections.size(); ++i)
+      for (auto mBoundModuleConnection = mBoundModuleConnections.begin(); mBoundModuleConnection != mBoundModuleConnections.end(); ++mBoundModuleConnection)
       {
-         if (mBoundModuleConnections[i].mLineText != lines[mBoundModuleConnections[i].mLineIndex])
+         if (mBoundModuleConnection->mLineIndex >= lines.size())
+         {
+            mBoundModuleConnection = mBoundModuleConnections.erase(mBoundModuleConnection);
+            if (mBoundModuleConnection == mBoundModuleConnections.end())
+               break;
+            continue;
+         }
+         if (mBoundModuleConnection->mLineText != lines[mBoundModuleConnection->mLineIndex])
          {
             bool found = false;
             for (int j = 0; j < (int)lines.size(); ++j)
             {
-               if (lines[j] == mBoundModuleConnections[i].mLineText)
+               if (lines[j] == mBoundModuleConnection->mLineText)
                {
                   found = true;
-                  mBoundModuleConnections[i].mLineIndex = j;
+                  mBoundModuleConnection->mLineIndex = j;
                }
             }
 
             if (!found)
-               mBoundModuleConnections[i].mTarget = nullptr;
+               mBoundModuleConnection->mTarget = nullptr;
          }
       }
    }

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -159,6 +159,19 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
       }
       return paths;
    });
+   m.def("get_controls", [](std::string path)
+   {
+      const auto module = TheSynth->FindModule(std::move(path));
+      std::vector<std::string> paths;
+      if (module == nullptr)
+         return paths;
+      for (auto* control : module->GetUIControls())
+      {
+         if (control && control->IsShowing())
+            paths.push_back(control->Path());
+      }
+      return paths;
+   });
    m.def("location_recall", [](char location)
    {
       TheSynth->GetLocationZoomer()->MoveToLocation(location);

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -34,6 +34,8 @@ globals:
       optional: size=50, xPos = 150, yPos = 250, red = 1, green = 1, blue = 1
    bespoke.random(seed, index)
    bespoke.get_modules()
+   bespoke.get_controls(path)
+      example: bespoke.set_background_text('"' + '"\n"'.join(bespoke.get_controls("transport")) + '"', 14, 0, 50, 1, 1, 1)
    bespoke.location_recall(location): move to saved location (0-255). "1" - "9" match the minimap and function key shortcuts: SHIFT+"1" - "9"
       example: bespoke.location_recall("1")
       example: bespoke.location_recall(49)


### PR DESCRIPTION
Added the function `bespoke.get_controls` to the `script` module. Resolves: #1425.
Fixed a crash when clearing or editing the `script` module when previously bound lines would disappear.