### PR TITLE
Make it so the `comment` module does not use the moduleSaveData. Resolves: #1031.

### DIFF
--- a/Source/CommentDisplay.cpp
+++ b/Source/CommentDisplay.cpp
@@ -65,17 +65,13 @@ void CommentDisplay::TextEntryComplete(TextEntry* entry)
 
 void CommentDisplay::LoadLayout(const ofxJSONElement& moduleInfo)
 {
-   mModuleSaveData.LoadString("comment", moduleInfo, "insert comment here");
-
    SetUpFromSaveData();
 }
 
 void CommentDisplay::SetUpFromSaveData()
 {
-   mComment = mModuleSaveData.GetString("comment");
 }
 
 void CommentDisplay::SaveLayout(ofxJSONElement& moduleInfo)
 {
-   moduleInfo["comment"] = mComment;
 }

--- a/Source/CommentDisplay.h
+++ b/Source/CommentDisplay.h
@@ -54,6 +54,6 @@ private:
    void DrawModule() override;
    void GetModuleDimensions(float& width, float& height) override;
 
-   std::string mComment{};
+   std::string mComment{ "insert comment here" };
    TextEntry* mCommentEntry{ nullptr };
 };


### PR DESCRIPTION
Make it so the `comment` module does not use the moduleSaveData. Resolves: #1031.

This might not load comments in really old savestates but this works for all the `example_*` savestates which are the oldest I have (iirc these are pre 1.0).