### PR TITLE
Fix issues with playing samples at negative speed

### DIFF
--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -209,10 +209,12 @@ bool Sample::ConsumeData(double time, ChannelBuffer* out, int size, bool replace
    if (mStopPoint != -1)
       end = mStopPoint;
 
+   if (mLooping && mOffset < 0)
+      mOffset += mNumSamples;
    if (mLooping && mOffset >= mNumSamples)
       mOffset -= mNumSamples;
 
-   if (mOffset >= end || std::isnan(mOffset))
+   if (mOffset < 0 || mOffset >= end || std::isnan(mOffset))
    {
       mPlayMutex.unlock();
       return false;

--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -526,6 +526,8 @@ void SamplePlayer::ButtonClicked(ClickButton* button, double time)
       {
          mCuePointSpeed = 1;
          mStopOnNoteOff = false;
+         if (mSpeed < 0)
+            mSample->SetPlayPosition(mSample->LengthInSamples() - 1);
          mPlay = true;
          mAdsr.Clear();
          mAdsr.Start(time * gInvSampleRateMs, 1);


### PR DESCRIPTION
This PR tackles #1317 by making sure the play offset of a sample (`mOffset`) never becomes negative. When looping mode is on in `sampleplayer`, negative offset is augmented by sample length, what fixes the playhead position in `sampleplayer`'s display. If looping mode is off, negative offset is a sign to stop playing. Fixes #1317.

In addition, this PR makes the play button in `sampleplayer` move the offset to the end of the sample on negative speeds.

Other modules using `Sample` deserve better testing to make sure they do not rely on sample offset becoming negative.