### PR TITLE
Implement "reset on load" mode for `pulselimit`

### DIFF
--- a/Source/PulseLimit.cpp
+++ b/Source/PulseLimit.cpp
@@ -84,6 +84,7 @@ void PulseLimit::ButtonClicked(ClickButton* button, double time)
 void PulseLimit::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadString("target", moduleInfo);
+   mModuleSaveData.LoadBool("reset_on_load", moduleInfo, false);
 
    SetUpFromSaveData();
 }
@@ -91,6 +92,7 @@ void PulseLimit::LoadLayout(const ofxJSONElement& moduleInfo)
 void PulseLimit::SetUpFromSaveData()
 {
    SetUpPatchCables(mModuleSaveData.GetString("target"));
+   mResetOnLoad = mModuleSaveData.GetBool("reset_on_load");
 }
 
 void PulseLimit::SaveState(FileStreamOut& out)
@@ -107,4 +109,6 @@ void PulseLimit::LoadState(FileStreamIn& in, int rev)
    IDrawableModule::LoadState(in, rev);
 
    in >> mCount;
+   if (mResetOnLoad)
+      mCount = 0;
 }

--- a/Source/PulseLimit.h
+++ b/Source/PulseLimit.h
@@ -73,6 +73,7 @@ private:
    int mCount{ 0 };
    TextEntry* mLimitEntry{ nullptr };
    ClickButton* mResetButton{ nullptr };
+   bool mResetOnLoad{ false };
 
    float mWidth{ 200 };
    float mHeight{ 20 };


### PR DESCRIPTION
This PR introduces `reset_on_load` boolean value in triangle menu of `pulselimit`, allowing to use it as "loadpulse". Enabling `reset_on_load` (off by default) makes it reset module's internal pulse counter to 0 every time a savestate containing it is loaded.

Creating as draft PR first as I need to test the backwards compatibility.