### PR TITLE
Bump `cmake_minimum_required` to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0091 NEW)
 
 # Global build parameters. Optional features are configurable via additional


### PR DESCRIPTION
Newer CMake versions have retired compatibility with versions < 3.5. Thus this now fails Mac builds in the pipelines. This PR bumps `cmake_minimum_required` to 3.5.