### PR TITLE
Fix visualization of `stereorotation` output for mono input

### DIFF
--- a/Source/StereoRotation.cpp
+++ b/Source/StereoRotation.cpp
@@ -77,8 +77,8 @@ void StereoRotation::Process(double time)
       }
    }
 
-   for (int ch = 0; ch < GetBuffer()->NumActiveChannels(); ++ch)
-      GetVizBuffer()->WriteChunk(GetBuffer()->GetChannel(ch), bufferSize, ch);
+   for (int ch = 0; ch < 2; ++ch)
+      GetVizBuffer()->WriteChunk(out->GetChannel(ch), bufferSize, ch);
 
    GetBuffer()->Reset();
 }


### PR DESCRIPTION
This PR fixes the visualization of `stereorotation` output for mono input. Previously it only showed visualization for the first channel, the second one was always flat.