### PR TITLE
Do not process empty `sampler` on note input

### DIFF
--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -87,7 +87,7 @@ void Sampler::Process(double time)
 
    IAudioReceiver* target = GetTarget();
 
-   if (!mEnabled || target == nullptr)
+   if (!mEnabled || target == nullptr || !mSample.LengthInSamples())
       return;
 
    mNoteInputBuffer.Process(time);


### PR DESCRIPTION
Empty `sampler` crashes upon receiving notes (see #1901). This PR skips processing of empty `sampler` by ensuring `mSample.LengthInSamples() > 0`. My only concern is whether there is a situation in recording mode when the sample is still of 0 length. I did some testing and did not run into any site effects.

Fixes #1901