### PR TITLE
Ignore `PlayNote()` if `sampler` is empty

### DIFF
--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -141,7 +141,7 @@ void Sampler::Process(double time)
 
 void Sampler::PlayNote(NoteMessage note)
 {
-   if (!mEnabled)
+   if (!mEnabled || !mSample.LengthInSamples())
       return;
 
    if (!NoteInputBuffer::IsTimeWithinFrame(note.time) && GetTarget())


### PR DESCRIPTION
#1901 is still around, even post-#1093, but now the crash is not instant - one has to send multiple notes to empty `sampler` to experience the crash.