### PR TITLE
Add `justfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ There are a few useful options to the *first* cmake command which many folks cho
 The directory name `ignore/build` is arbitrary. Bespoke is set up to `.gitignore` everything in the `ignore` directory but you
 can use any directory name you want for a build or have multiple builds also.
 
+For building on Linux, you can also use [`just`](https://github.com/casey/just) to build by running `just build`. Use `just list` to see other options available with `just`.
+
 To be able to build you will need a few things, depending on your OS
 
 * All systems require an install of git

--- a/justfile
+++ b/justfile
@@ -1,0 +1,76 @@
+# This is a set of scripts for interacting with Bespoke's cmake build system.
+
+# Default value for CMAKE_BUILD_TYPE
+default_build_type := "Debug"
+# Tell cmake to use parallel execution of <number of cpu cores> minus this number
+parallel_build_ignore_cpus := "2"
+
+# Compile (default)
+[positional-arguments]
+build type=default_build_type:
+   #!/bin/sh
+
+   # Check if we haven't configured yet
+   if ! [ -d "./ignore/build" ]; then
+      # run configure step
+      just _echo_do just configure "$1"
+   fi
+
+   # build with parallelism based on the number of cpu cores
+   just _echo_do cmake --build ignore/build --parallel="$(nproc --ignore='{{parallel_build_ignore_cpus}}')"
+
+
+# Configure build system (Release or Debug, default is Debug)
+[positional-arguments]
+configure type=default_build_type *cmake_args:
+   #!/bin/sh
+
+   # Find the vst2 sdk in ./ignore/VST_SDK/VST2_SDK or wherever the VST2_SDK_HOME variable points
+   VST2_SDK_HOME="${VST2_SDK_HOME:-"$(pwd)"/ignore/VST_SDK/VST2_SDK}"
+   if [ -d "$VST2_SDK_HOME" ]; then
+      set -- "$1" -DBESPOKE_VST2_SDK_LOCATION="$VST2_SDK_HOME" "${@:2}"
+   fi
+
+   just _echo_do cmake -B ignore/build -GNinja -DCMAKE_BUILD_TYPE="$1" "${@:2}"
+
+
+# Run
+[positional-arguments]
+run type=default_build_type *bespoke_args:
+   #!/bin/sh
+
+   # Check if we haven't compiled yet
+   bespoke_exe=./ignore/build/Source/BespokeSynth_artefacts/"$1"/BespokeSynth
+   if ! [ -f "$bespoke_exe" ]; then
+      just _echo_do just bulid
+   fi
+
+   # Run the program
+   shift
+   just _echo_do "$bespoke_exe" "$@"
+
+
+# Clean the build files
+clean:
+   rm -r ignore/build
+
+
+##
+## Utilities
+##
+
+# List available actions
+list:
+   @just --list --unsorted
+   @echo
+   @echo "Place your VST2 SDK at ./ignore/VST_SDK/VST2_SDK or set the VST2_SDK_HOME environment variable to enable using the VST2 SDK"
+
+
+# Simple utility to print out what's being executed before running it, matching just's default format
+[positional-arguments]
+_echo_do *exec:
+   #!/bin/bash
+   echo -en '\e[1m' >&2 # style: bold
+   echo -n "$@"     >&2
+   echo -e '\e[0m'  >&2 # style: reset
+   "$@"


### PR DESCRIPTION
This PR adds a `justfile`, which is used by the [`just`](https://github.com/casey/just) cli utility to run scripts. This makes it simpler to develop from the command line by shortening some common build commands. Commands like `just build` or `just run` can be used from anywhere inside repository to compile or run it.

The gist is:

- `just configure` = `cmake -B ignore/build -GNinja -DCMAKE_BUILD_TYPE="$1" "${@:2}"`
- `just build` = `cmake --build ignore/build --parallel="$(nproc --ignore=2)"` (depends on `configure`)
- `just run` = `./ignore/build/Source/BespokeSynth_artefacts/"$1"/BespokeSynth` (depends on `build`)
- `just clean` = `rm -r ignore/build`

... and running `just` (on its own) will run the `build` command. All commands are based on the readme.

_"Why?"_ Fair question. If no one cares to have this, feel free to close this PR. The main purpose of this is to make Bespoke's build system a little nicer to interface with from the command line, although I realize not everyone develops from their terminal. I initially made this for myself because I got tired of retrieving cmake commands from my shell history, and figured I'd contribute it so others can benefit from it.