### PR TITLE
doc(taskfile): add build automation tools and instructions in README,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,47 @@ To be able to build you will need a few things, depending on your OS
 * On Linux you probably already have everything (gcc, git, etc...), but you will need to install required packages. The full list we
   install on a fresh ubuntu 20 box are listed in the azure-pipelines.yml
     * Some distributions may have slightly different package names like for instance Debian bookworm: You need to replace `alsa` and `alsa-tools` with `alsa-utils`
+
+### Using Go Task for Build Automation
+
+BespokeSynth has a [Go Task](https://taskfile.dev) Taskfile.yml as a cross-platform build automation tool. This makes it easy to configure, build, and run BespokeSynth with a single command.
+
+```sh
+task           # Configure and build BespokeSynth (default)
+task run       # Run the built BespokeSynth executable
+task clean     # Remove build artifacts
+task install   # Install build prerequisites for your platform
+```
+
+Task will automatically detect your platform (Windows, macOS, Linux, or WSL) and use the appropriate build directory and commands.
+
+For more details, see the `Taskfile.yml` in the repository root.
+
+---
+
+### One-Step Build Scripts: ensure_task
+
+For convenience, you can use the provided scripts to automatically install Go Task (if needed) and build BespokeSynth in a single step:
+
+- **Windows:** `ensure_task.bat`
+- **Linux/macOS/WSL:** `ensure_task.sh`
+
+#### Usage
+
+**On Windows (cmd.exe):**
+
+```cmd
+ensure_task.bat [task arguments]
+```
+
+**On Linux/macOS/WSL (bash):**
+
+```sh
+./ensure_task.sh [task arguments]
+```
+
+- If Go Task is not found, the script will attempt to install it using your system's package manager or by downloading a release.
+- Any arguments you provide will be passed directly to `task` (e.g., `run`, `clean`, etc.).
+- By default, running the script with no arguments will perform the default build.
+
+See the script files for more details or to customize the installation logic for your environment.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,193 @@
+version: "3"
+
+vars:
+  BUILD_DIR: '{{default "ignore/build" .BUILD_DIR}}'
+  CONFIG: '{{default "Release" .CONFIG}}'
+  # For Windows MSVC generator:
+  VS_GEN: 'Visual Studio 17 2022'
+  VS_ARCH: 'x64'
+
+tasks:
+
+  default:
+    desc: Build BespokeSynth (configure + compile)
+    deps: [submodules]
+    cmds:
+      - task: configure
+      - task: build
+
+  submodules:
+    desc: Init / update git submodules recursively
+    cmds:
+      - git submodule update --init --recursive
+
+  # -------------------------------
+  # Install: meta helpers
+  # -------------------------------
+  install:
+    desc: Install build prerequisites (chooses a platform task)
+    cmds:
+      - task: install:windows
+      - task: install:wsl
+      - task: install:linux
+      - task: install:mac
+    silent: true
+
+  install:windows:
+    desc: Install tools on Windows (requires admin shell for winget/choco)
+    platforms: [windows]
+    cmds:
+      - cmd: winget install -e --id Kitware.CMake
+        ignore_error: true
+      - cmd: winget install -e --id Git.Git
+        ignore_error: true
+      - cmd: winget install -e --id Python.Python.3.12
+        ignore_error: true
+      - echo Ensure VS 2022 with "Desktop development with C++" workload is installed.
+
+  # WSL detection: run only if /proc/version mentions Microsoft or WSL env is present
+  install:wsl:
+    desc: Install deps for WSL (Ubuntu). Skips if not WSL.
+    platforms: [linux]
+    cmds:
+      - sudo apt update
+      - sudo apt install -y build-essential cmake ninja-build pkg-config git python3-dev python3-venv python3-pip
+      - sudo apt install -y libasound2-dev libjack-jackd2-dev \
+          libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxext-dev libxi-dev \
+          libxcomposite-dev libxrender-dev libglu1-mesa-dev mesa-common-dev
+      - sudo apt install -y libfreetype6-dev libcurl4-openssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev
+      - |
+        if [ -f /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc ] && \
+           [ ! -f /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc ]; then
+          echo "Creating pkg-config alias for webkit2gtk-4.0 -> 4.1"
+          sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
+                     /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
+        fi
+      - 'echo "Note: WSL is OK for compiling, but audio/MIDI support is limited."'
+
+  install:linux:
+    desc: Install deps for native Linux (Ubuntu/Debian). Skips under WSL.
+    platforms: [linux]
+    status:
+      - 'grep -qiE "(microsoft|wsl)" /proc/version && exit 1 || exit 0'
+    cmds:
+      - sudo apt update
+      - sudo apt install -y build-essential cmake ninja-build pkg-config git python3-dev python3-venv python3-pip
+      - sudo apt install -y libasound2-dev libjack-jackd2-dev \
+          libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxext-dev libxi-dev \
+          libxcomposite-dev libxrender-dev libglu1-mesa-dev mesa-common-dev
+      - sudo apt install -y libfreetype6-dev libcurl4-openssl-dev libgtk-3-dev
+      - |
+        if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then
+          sudo apt install -y libwebkit2gtk-4.1-dev
+          if [ -f /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc ] && \
+             [ ! -f /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc ]; then
+            sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
+                       /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
+          fi
+        else
+          # On some distros it may still be 4.0
+          sudo apt install -y libwebkit2gtk-4.0-dev || true
+        fi
+
+  install:mac:
+    desc: Install deps on macOS (Homebrew)
+    platforms: [darwin]
+    cmds:
+      - xcode-select --install || true
+      - brew update
+      - brew install cmake pkg-config python freetype curl
+      # JUCE uses native frameworks on macOS; GTK/WebKit not required here.
+
+  # -------------------------------
+  # Configure / Build
+  # -------------------------------
+  configure:
+    desc: Configure CMake (platform-aware)
+    deps: [submodules]
+    cmds:
+      - task: configure:windows
+      - task: configure:posix
+    silent: true
+
+  configure:windows:
+    desc: Configure for MSVC (Windows)
+    platforms: [windows]
+    cmds:
+      - mkdir -Force "{{.BUILD_DIR}}" 2>$null || true
+      - >
+        cmake -S . -B "{{.BUILD_DIR}}"
+        -G "{{.VS_GEN}}" -A "{{.VS_ARCH}}"
+        -DCMAKE_BUILD_TYPE={{.CONFIG}}
+
+  configure:posix:
+    desc: Configure for POSIX (Linux/macOS/WSL)
+    platforms: [linux, darwin]
+    cmds:
+      - mkdir -p "{{.BUILD_DIR}}"
+      - cmake -S . -B "{{.BUILD_DIR}}" -DCMAKE_BUILD_TYPE={{.CONFIG}}
+
+  build:
+    desc: Compile BespokeSynth
+    cmds:
+      - task: build:windows
+      - task: build:posix
+    silent: true
+
+  build:windows:
+    desc: Build with MSVC
+    platforms: [windows]
+    cmds:
+      - cmake --build "{{.BUILD_DIR}}" --config {{.CONFIG}} --parallel
+
+  build:posix:
+    desc: Build with Makefiles/Ninja on POSIX
+    platforms: [linux, darwin]
+    cmds:
+      - cmake --build "{{.BUILD_DIR}}" --parallel
+
+  clean:
+    desc: Remove build directory
+    cmds:
+      - task: clean:windows
+      - task: clean:posix
+    silent: true
+
+  clean:windows:
+    platforms: [windows]
+    cmds:
+      - powershell -Command "Remove-Item -Recurse -Force '{{.BUILD_DIR}}' -ErrorAction SilentlyContinue"
+
+  clean:posix:
+    platforms: [linux, darwin]
+    cmds:
+      - rm -rf "{{.BUILD_DIR}}"
+
+  # -------------------------------
+  # Run helpers
+  # -------------------------------
+  run:
+    desc: Run BespokeSynth (platform-aware)
+    cmds:
+      - task: run:windows
+      - task: run:posix
+    silent: true
+
+  run:windows:
+    platforms: [windows]
+    cmds:
+      - |
+        .\\ignore\\build\\Source\\BespokeSynth_artefacts\\Release\\BespokeSynth.exe
+
+  run:posix:
+    platforms: [linux, darwin]
+    cmds:
+      - |
+        BIN="{{.BUILD_DIR}}/Bespoke/BespokeSynth"
+        [ -x "$BIN" ] || BIN="{{.BUILD_DIR}}/BespokeSynth"
+        if [ -x "$BIN" ]; then
+          "$BIN"
+        else
+          echo "Executable not found. Did the build succeed?"
+          exit 1
+        fi

--- a/ensure_task.bat
+++ b/ensure_task.bat
@@ -1,0 +1,70 @@
+@echo off
+rem ensure_task.bat
+rem - checks for `task` in PATH and installs it if possible
+rem - then runs `task` to build BespokeSynth
+
+setlocal
+
+echo === ensure_task.bat ===
+
+rem Optional argument: pass "force" or "rebuild" to force a full rebuild
+rem If any arguments are provided, they will be passed to task as arguments.
+set "TASK_ARGS=%*"
+
+echo Checking for 'task' on PATH...
+where task >nul 2>&1
+if %ERRORLEVEL%==0 goto :TASK_FOUND
+
+echo 'task' not found. Attempting to install automatically.
+
+rem Prefer winget, then choco, then scoop. If none available, download a specific release.
+where winget >nul 2>&1
+if %ERRORLEVEL%==0 (
+  echo Installing go-task via winget...
+  winget install --silent --accept-source-agreements --accept-package-agreements --id go.task || echo winget install failed
+) else (
+  where choco >nul 2>&1
+  if %ERRORLEVEL%==0 (
+    echo Installing go-task via chocolatey...
+    choco install go-task -y || echo choco install failed
+  ) else (
+    where scoop >nul 2>&1
+    if %ERRORLEVEL%==0 (
+      echo Installing go-task via scoop...
+      scoop install go-task || echo scoop install failed
+    ) else (
+      echo No package manager found; downloading go-task v3.44.0 and extracting to %USERPROFILE%\bin
+      if not exist "%USERPROFILE%\bin" mkdir "%USERPROFILE%\bin"
+      powershell -NoProfile -Command "try { $u='https://github.com/go-task/task/releases/download/v3.44.0/task_windows_amd64.zip'; $out=Join-Path $env:USERPROFILE 'task.zip'; Invoke-WebRequest -Uri $u -OutFile $out -UseBasicParsing; Expand-Archive -Path $out -DestinationPath (Join-Path $env:USERPROFILE 'bin') -Force; Remove-Item $out -Force } catch { Write-Error $_; exit 1 }"
+      if %ERRORLEVEL% neq 0 (
+        echo Failed to download or extract task. Please install go-task manually from https://github.com/go-task/task/releases
+        pause
+        exit /b 1
+      )
+      rem Add to PATH for this session
+      set "PATH=%USERPROFILE%\bin;%PATH%"
+    )
+  )
+)
+
+goto :TASK_INST_DONE
+
+:TASK_FOUND
+echo Found 'task' in PATH.
+task --version 2>nul || echo (unable to run task --version)
+
+:TASK_INST_DONE
+
+rem verify installation
+where task >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+  echo 'task' still not found after attempted installs. Please install it manually and re-run this script.
+  pause
+  exit /b 1
+)
+
+echo 'task' is available:
+task --version
+
+echo Running build with task...
+task %TASK_ARGS%

--- a/ensure_task.sh
+++ b/ensure_task.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ensure_task.sh
+# - checks for `task` in PATH and installs it if possible
+# - then runs `task` to build BespokeSynth
+
+set -e
+
+echo "=== ensure_task.sh ==="
+
+# Optional argument: pass "force" or "rebuild" to force a full rebuild
+# If any arguments are provided, they will be passed to task as arguments.
+TASK_ARGS=("$@")
+
+echo "Checking for 'task' on PATH..."
+if command -v task >/dev/null 2>&1; then
+  echo "Found 'task' in PATH."
+  task --version || echo "(unable to run task --version)"
+else
+  echo "'task' not found. Attempting to install automatically."
+  if command -v brew >/dev/null 2>&1; then
+    echo "Installing go-task via Homebrew..."
+    brew install go-task/tap/go-task || echo "brew install failed"
+  elif command -v apt-get >/dev/null 2>&1; then
+    echo "Installing go-task via apt..."
+    sudo apt-get update && sudo apt-get install -y go-task || echo "apt install failed"
+  else
+    echo "No supported package manager found; downloading go-task v3.44.0 to ~/bin"
+    mkdir -p "$HOME/bin"
+    curl -L -o "$HOME/bin/task.tar.gz" "https://github.com/go-task/task/releases/download/v3.44.0/task_linux_amd64.tar.gz"
+    tar -xzf "$HOME/bin/task.tar.gz" -C "$HOME/bin" task
+    chmod +x "$HOME/bin/task"
+    export PATH="$HOME/bin:$PATH"
+  fi
+fi
+
+echo "Verifying installation..."
+if ! command -v task >/dev/null 2>&1; then
+  echo "'task' still not found after attempted installs. Please install it manually from https://github.com/go-task/task/releases and re-run this script."
+  exit 1
+fi
+
+echo "'task' is available:"
+task --version
+
+echo "Running build with task..."
+task "${TASK_ARGS[@]}"


### PR DESCRIPTION
… include ensure_task scripts and Taskfile.yml

similar to https://github.com/BespokeSynth/BespokeSynth/pull/1922

I plan to improve this more; possibly make the install actually copy to a public path instead of installing the prereqs.

I don't know if this needs to go upstream or not; i find it useful and thought I'd share.
--dave 