### PR TITLE
Fix bar counting in the SongBuilder when transport is off.

### DIFF
--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -302,7 +302,10 @@ void SongBuilder::OnTimeEvent(double time)
 
    if (mSequenceStepIndex != -1)
    {
-      if (TheTransport->GetMeasure(time + TheTransport->GetListenerInfo(this)->mOffsetInfo.mOffset) >= mSequencerStepLength[mSequenceStepIndex] && !mSequencePaused)
+      int sequencerMeasure = GetSequencerMeasure();
+      int currentMeasure = TheTransport->GetMeasure(time + TheTransport->GetListenerInfo(this)->mOffsetInfo.mOffset);
+
+      if (currentMeasure >= sequencerMeasure && !mSequencePaused)
       {
          if (mLoopSequence && mSequenceStepIndex == mSequenceLoopEndIndex && mSequenceLoopEndIndex >= mSequenceLoopStartIndex)
             mSequenceStepIndex = mSequenceLoopStartIndex;
@@ -339,6 +342,26 @@ void SongBuilder::OnTimeEvent(double time)
       mWantResetClock = false;
       mJustResetClock = true;
    }
+}
+
+int SongBuilder::GetSequencerMeasure()
+{
+   int sequencerMeasure = 0;
+   
+   if (mResetOnSceneChange || mLegacyTransportResetBehavior)
+   {
+      sequencerMeasure = mSequencerStepLength[mSequenceStepIndex];
+   }
+   else
+   {
+      // Calculate the current steps' ending measurement.
+      for (int i = 0; i <= mSequenceStepIndex; i++)
+      {
+         sequencerMeasure += mSequencerStepLength[i];
+      }
+   }
+
+   return sequencerMeasure;
 }
 
 void SongBuilder::OnPulse(double time, float velocity, int flags)
@@ -832,6 +855,7 @@ void SongBuilder::IntSliderUpdated(IntSlider* slider, int oldVal, double time)
 void SongBuilder::LoadLayout(const ofxJSONElement& moduleInfo)
 {
    mModuleSaveData.LoadBool("reset_transport_every_sequencer_scene", moduleInfo, true);
+   mModuleSaveData.LoadBool("legacy_transport_reset_behavior", moduleInfo, true);
 
    if (IsSpawningOnTheFly(moduleInfo))
    {
@@ -854,6 +878,7 @@ void SongBuilder::LoadLayout(const ofxJSONElement& moduleInfo)
 void SongBuilder::SetUpFromSaveData()
 {
    mResetOnSceneChange = mModuleSaveData.GetBool("reset_transport_every_sequencer_scene");
+   mLegacyTransportResetBehavior = mModuleSaveData.GetBool("legacy_transport_reset_behavior");
 }
 
 void SongBuilder::SaveState(FileStreamOut& out)

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -347,7 +347,6 @@ void SongBuilder::OnTimeEvent(double time)
 int SongBuilder::GetSequencerMeasure()
 {
    int sequencerMeasure = 0;
-   
    if (mResetOnSceneChange || mLegacyTransportResetBehavior)
    {
       sequencerMeasure = mSequencerStepLength[mSequenceStepIndex];

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -98,6 +98,7 @@ private:
    bool ShowSongSequencer() const { return mUseSequencer; }
    void RefreshSequencerDropdowns();
    void PlaySequence(double time, int startIndex);
+   int GetSequencerMeasure();
 
    enum class ContextMenuItems
    {
@@ -203,6 +204,7 @@ private:
    bool mUseSequencer{ false };
    Checkbox* mUseSequencerCheckbox{ nullptr };
    bool mResetOnSceneChange{ true };
+   bool mLegacyTransportResetBehavior { true };
    bool mActivateFirstSceneOnStop{ true };
    Checkbox* mActivateFirstSceneOnStopCheckbox{ nullptr };
    NoteInterval mChangeQuantizeInterval{ NoteInterval::kInterval_1n };

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -204,7 +204,7 @@ private:
    bool mUseSequencer{ false };
    Checkbox* mUseSequencerCheckbox{ nullptr };
    bool mResetOnSceneChange{ true };
-   bool mLegacyTransportResetBehavior { true };
+   bool mLegacyTransportResetBehavior{ true };
    bool mActivateFirstSceneOnStop{ true };
    Checkbox* mActivateFirstSceneOnStopCheckbox{ nullptr };
    NoteInterval mChangeQuantizeInterval{ NoteInterval::kInterval_1n };


### PR DESCRIPTION
Fix for issue #1639 

Added a new switch in the SongBuilder settings to be able to turn this fix on or off. 
This is on by default, so it won't break old projects. Turn it off to be able to enter bar values as when transport reset is off.

I don't know if this is a good way to do this, but is seemed like a logical place to put it, as it works together with the switch above it.

<img width="538" height="229" alt="image" src="https://github.com/user-attachments/assets/fdd9ed81-fbe8-49bc-a406-4a49dc0c5448" />

This project demonstrates the fix in the 2nd SongBuilder:

[songbuilder-transport-bug-v2.zip](https://github.com/user-attachments/files/23508612/songbuilder-transport-bug-v2.zip)

I'm not used to C++ development, so feel free to let me know if I did something incorrect here. 😉
