### PR TITLE
Fix octave up/down keybind in `notecanvas` to respect PPO

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -29,6 +29,7 @@
 #include "FileStream.h"
 #include "ModularSynth.h"
 #include "PatchCableSource.h"
+#include "Scale.h"
 #include "Snapshots.h"
 
 Canvas::Canvas(IDrawableModule* parent, int x, int y, int w, int h, float length, int rows, int cols, CreateCanvasElementFn elementCreator)
@@ -567,7 +568,7 @@ void Canvas::KeyPressed(int key, bool isRepeat)
          int direction = (key == OF_KEY_UP) ? -1 : 1;
 
          if (GetKeyModifiers() == kModifier_Shift)
-            direction *= 12; //octave
+            direction *= TheScale->GetPitchesPerOctave();
 
          for (auto* element : mElements)
          {

--- a/Source/NoteCanvas.cpp
+++ b/Source/NoteCanvas.cpp
@@ -409,7 +409,7 @@ bool NoteCanvas::OnAbletonGridControl(IAbletonGridDevice* abletonGrid, int contr
                   if (mGridKeyboardInterface != nullptr)
                      newPitch = mGridKeyboardInterface->TransposePitchInScale(element->GetPitch(), direction, octaveShift);
                   else
-                     newPitch = element->GetPitch() + direction * (octaveShift ? 12 : 1);
+                     newPitch = element->GetPitch() + direction * (octaveShift ? TheScale->GetPitchesPerOctave() : 1);
                   element->SetPitch(std::clamp(newPitch, 0, 127));
                }
 


### PR DESCRIPTION
Currently the octave up/down transpose keybind in `NoteCanvas.cpp` and `Canvas.cpp` is hardcoded to shift selected notes by 12 steps.

This PR makes it so that the notes get transposed by the active scale's `PitchesPerOctave` instead, so that the keybind works correctly in microtonal tunings.