### PR TITLE
Support for 16, 24 & 32 bit WAV export.

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -3533,7 +3533,7 @@ void ModularSynth::SaveOutput()
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);
    bool b1{ false };
-   auto writer = std::unique_ptr<juce::AudioFormatWriter>(wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0));
+   auto writer = std::unique_ptr<juce::AudioFormatWriter>(wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.wav_bit_depth.Get(), b1, 0));
 
    int samplesRemaining = mRecordingLength;
    const int chunkSize = 256;

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -3533,7 +3533,7 @@ void ModularSynth::SaveOutput()
    auto outputTo = outputFile.createOutputStream();
    assert(outputTo != nullptr);
    bool b1{ false };
-   auto writer = std::unique_ptr<juce::AudioFormatWriter>(wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.wav_bit_depth.Get(), b1, 0));
+   auto writer = std::unique_ptr<juce::AudioFormatWriter>(wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.output_wav_bit_depth.Get(), b1, 0));
 
    int samplesRemaining = mRecordingLength;
    const int chunkSize = 256;

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -29,6 +29,7 @@
 #include "ModularSynth.h"
 #include "ChannelBuffer.h"
 #include <memory>
+#include "UserPrefs.h"
 
 #include "juce_audio_formats/juce_audio_formats.h"
 
@@ -169,7 +170,7 @@ bool Sample::WriteDataToFile(const std::string& path, float** data, int numSampl
    assert(outputTo != nullptr);
    bool b1{ false };
    auto writer = std::unique_ptr<juce::AudioFormatWriter>(
-   wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, 16, b1, 0));
+   wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.wav_bit_depth.Get(), b1, 0));
    writer->writeFromFloatArrays(data, channels, numSamples);
 
    return true;

--- a/Source/Sample.cpp
+++ b/Source/Sample.cpp
@@ -170,7 +170,7 @@ bool Sample::WriteDataToFile(const std::string& path, float** data, int numSampl
    assert(outputTo != nullptr);
    bool b1{ false };
    auto writer = std::unique_ptr<juce::AudioFormatWriter>(
-   wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.wav_bit_depth.Get(), b1, 0));
+   wavFormat->createWriterFor(outputTo.release(), gSampleRate, channels, UserPrefs.output_wav_bit_depth.Get(), b1, 0));
    writer->writeFromFloatArrays(data, channels, numSamples);
 
    return true;

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -296,6 +296,7 @@ public:
    UserPrefDropdownInt samplerate{ "samplerate", 48000, 100, UserPrefCategory::General };
    UserPrefDropdownInt buffersize{ "buffersize", 256, 100, UserPrefCategory::General };
    UserPrefDropdownInt oversampling{ "oversampling", 1, 100, UserPrefCategory::General };
+   UserPrefDropdownInt wav_bit_depth{ "wav_bit_depth", 16, 100, UserPrefCategory::General };
    UserPrefTextEntryInt width{ "width", 1700, 100, 10000, 5, UserPrefCategory::General };
    UserPrefTextEntryInt height{ "height", 1100, 100, 10000, 5, UserPrefCategory::General };
    UserPrefBool set_manual_window_position{ "set_manual_window_position", false, UserPrefCategory::General };

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -296,7 +296,7 @@ public:
    UserPrefDropdownInt samplerate{ "samplerate", 48000, 100, UserPrefCategory::General };
    UserPrefDropdownInt buffersize{ "buffersize", 256, 100, UserPrefCategory::General };
    UserPrefDropdownInt oversampling{ "oversampling", 1, 100, UserPrefCategory::General };
-   UserPrefDropdownInt wav_bit_depth{ "wav_bit_depth", 16, 100, UserPrefCategory::General };
+   UserPrefDropdownInt output_wav_bit_depth{ "output_wav_bit_depth", 16, 100, UserPrefCategory::General };
    UserPrefTextEntryInt width{ "width", 1700, 100, 10000, 5, UserPrefCategory::General };
    UserPrefTextEntryInt height{ "height", 1100, 100, 10000, 5, UserPrefCategory::General };
    UserPrefBool set_manual_window_position{ "set_manual_window_position", false, UserPrefCategory::General };

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -69,6 +69,14 @@ void UserPrefsEditor::CreateUIControls()
          UserPrefs.oversampling.GetIndex() = oversample;
    }
 
+   std::array<int, 3> bitDepths = { 16, 24, 32 };
+   for (auto& bitDepth : bitDepths)
+   {
+      UserPrefs.wav_bit_depth.GetDropdown()->AddLabel(ofToString(bitDepth), bitDepth);
+      if (UserPrefs.wav_bit_depth.Get() == bitDepth)
+         UserPrefs.wav_bit_depth.GetIndex() = bitDepth;
+   }
+
    UserPrefs.cable_drop_behavior.GetIndex() = 0;
    UserPrefs.cable_drop_behavior.GetDropdown()->AddLabel("show quickspawn", (int)CableDropBehavior::ShowQuickspawn);
    UserPrefs.cable_drop_behavior.GetDropdown()->AddLabel("do nothing", (int)CableDropBehavior::DoNothing);
@@ -479,6 +487,12 @@ void UserPrefsEditor::DropdownUpdated(DropdownList* list, int oldVal, double tim
    if (list == UserPrefs.audio_input_device.GetDropdown())
    {
       UpdateDropdowns({ UserPrefs.samplerate.GetDropdown(), UserPrefs.buffersize.GetDropdown() });
+   }
+
+   // Update the wav_bit_depth value when the dropdown selection changes
+   if (list == UserPrefs.wav_bit_depth.GetDropdown())
+   {
+      UserPrefs.wav_bit_depth.Get() = ofToInt(UserPrefs.wav_bit_depth.GetDropdown()->GetLabel(UserPrefs.wav_bit_depth.GetIndex()));
    }
 }
 

--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -72,9 +72,9 @@ void UserPrefsEditor::CreateUIControls()
    std::array<int, 3> bitDepths = { 16, 24, 32 };
    for (auto& bitDepth : bitDepths)
    {
-      UserPrefs.wav_bit_depth.GetDropdown()->AddLabel(ofToString(bitDepth), bitDepth);
-      if (UserPrefs.wav_bit_depth.Get() == bitDepth)
-         UserPrefs.wav_bit_depth.GetIndex() = bitDepth;
+      UserPrefs.output_wav_bit_depth.GetDropdown()->AddLabel(ofToString(bitDepth), bitDepth);
+      if (UserPrefs.output_wav_bit_depth.Get() == bitDepth)
+         UserPrefs.output_wav_bit_depth.GetIndex() = bitDepth;
    }
 
    UserPrefs.cable_drop_behavior.GetIndex() = 0;
@@ -489,10 +489,10 @@ void UserPrefsEditor::DropdownUpdated(DropdownList* list, int oldVal, double tim
       UpdateDropdowns({ UserPrefs.samplerate.GetDropdown(), UserPrefs.buffersize.GetDropdown() });
    }
 
-   // Update the wav_bit_depth value when the dropdown selection changes
-   if (list == UserPrefs.wav_bit_depth.GetDropdown())
+   // Update the output_wav_bit_depth value when the dropdown selection changes
+   if (list == UserPrefs.output_wav_bit_depth.GetDropdown())
    {
-      UserPrefs.wav_bit_depth.Get() = ofToInt(UserPrefs.wav_bit_depth.GetDropdown()->GetLabel(UserPrefs.wav_bit_depth.GetIndex()));
+      UserPrefs.output_wav_bit_depth.Get() = ofToInt(UserPrefs.output_wav_bit_depth.GetDropdown()->GetLabel(UserPrefs.output_wav_bit_depth.GetIndex()));
    }
 }
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2016,6 +2016,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~samplerate~what sample rate to use with your audio device (requires restart)
 ~buffersize~what buffer size to use with your audio device. lower values use require more CPU power, higher values add more latency. (requires restart)
 ~oversampling~global oversampling multiplier. uses additional CPU for higher-resolution audio processing. (requires restart)
+~wav_bit_depth~Bit depth to use when exporting audio to WAV files
 ~width~width of bespoke's window on startup
 ~height~height of bespoke's window on startup
 ~set_manual_window_position~should we force bespoke to a specific position on startup

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2016,7 +2016,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~samplerate~what sample rate to use with your audio device (requires restart)
 ~buffersize~what buffer size to use with your audio device. lower values use require more CPU power, higher values add more latency. (requires restart)
 ~oversampling~global oversampling multiplier. uses additional CPU for higher-resolution audio processing. (requires restart)
-~wav_bit_depth~Bit depth to use when exporting audio to WAV files
+~output_wav_bit_depth~bit depth to use when exporting audio to WAV files
 ~width~width of bespoke's window on startup
 ~height~height of bespoke's window on startup
 ~set_manual_window_position~should we force bespoke to a specific position on startup


### PR DESCRIPTION
This satisfies feature request 474 except the limiter part, which isn't necessary IMO.
https://github.com/BespokeSynth/BespokeSynth/issues/474

Add a user preference settings to set the WAV export bit depth. 
Works for the global export audio button and the multitrack recorder. 
Changing the setting works for the next export without restarting Bespoke.

Screenshot of the setting dropdown:

<img width="352" height="123" alt="image" src="https://github.com/user-attachments/assets/0aa4c2ba-35de-40b2-a92f-3b4817807a3a" />

