### PR TITLE
Add midicontroller layouts for Novation Launchkey Mini 25 Mk4 and pads

### DIFF
--- a/resource/userdata_original/controllers/Launchkey Mini MK4 25 MIDI PADS.json
+++ b/resource/userdata_original/controllers/Launchkey Mini MK4 25 MIDI PADS.json
@@ -1,0 +1,17 @@
+{
+    "channelfilter": 10,
+    "groups" : [
+       {
+          "rows": 2,
+          "cols": 8,
+          "position" : [ 0, 0 ],
+          "dimensions" : [28, 28],
+          "spacing" : [32, 32],
+          "controls" : [ 40, 41, 42, 43, 48, 49, 50, 51, 36, 37, 38, 39, 44, 45, 46, 47],
+          "colors" : [ 0, 127],
+          "messageType" : "note",
+          "drawType" : "button"
+       }
+    ]
+ }
+ 

--- a/resource/userdata_original/controllers/Launchkey Mini MK4 25 MIDI.json
+++ b/resource/userdata_original/controllers/Launchkey Mini MK4 25 MIDI.json
@@ -1,0 +1,72 @@
+{
+    "channelfilter": 1,
+    "groups" : [
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 0, 0 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "messageType" : "pitchbend",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 1,
+            "cols": 1,
+            "position" : [ 30, 0 ],
+            "dimensions" : [28, 80],
+            "spacing" : [30],
+            "controls" : [1],
+            "messageType" : "control",
+            "drawType" : "slider"
+        },
+        {
+            "rows": 2,
+            "cols": 8,
+            "position" : [ 80, 0 ],
+            "dimensions" : [25, 25],
+            "spacing" : [30, 30],
+            "controls" : [
+				21, 22, 23, 24, 25, 26, 27, 28,
+				31, 32, 33, 34, 35, 36, 37, 38,
+			],
+            "messageType" : "control",
+            "drawType" : "knob"
+        },
+		{
+			"rows": 5,
+			"cols": 24,
+			"position" : [0, 100],
+			"dimensions" : [14, 28],
+			"spacing" : [15, 30],
+			"controls" : [
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+				12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+				24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+				36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+				48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+				60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
+				72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,
+				84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+				96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+				108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119
+			],
+			"messageType" : "note",
+			"drawType" : "button",
+			"no_grid": true
+		},
+		{
+			"rows": 1,
+			"cols": 8,
+			"position" : [0, 250],
+			"dimensions" : [14, 28],
+			"spacing" : [15, 30],
+			"controls" : [
+				120, 121, 122, 123, 124, 125, 126, 127
+			],
+			"messageType" : "note",
+			"drawType" : "button",
+			"no_grid": true
+		}
+    ]
+ }


### PR DESCRIPTION
Adds controller layout files for the Novation LaunchKey Mini 25 Mk4.

<img width="888" height="497" alt="image" src="https://github.com/user-attachments/assets/a7c648e1-4f43-4662-b709-28534518dac5" />

<img width="705" height="465" alt="image" src="https://github.com/user-attachments/assets/710703dd-9fb1-481d-870f-ba25fa6ca7dd" />

I erred on the side of representing the signals that the keyboard can send rather than exactly representing the physical layout (with default config, the keyboard has octave switching and a second set of mappings for the knobs)
