### PR TITLE
Fix incompatibiliy with JUCE version >=8.0.11

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -89,7 +89,11 @@ ModularSynth::ModularSynth()
    mAudioPluginFormatManager = std::make_unique<juce::AudioPluginFormatManager>();
    mKnownPluginList = std::make_unique<juce::KnownPluginList>();
 
+#if JUCE_VERSION < ((8 << 16) + (0 << 8) + 11) // member-function replaced in 8.0.11
    mAudioPluginFormatManager->addDefaultFormats();
+#else
+   juce::addDefaultFormatsToManager(*mAudioPluginFormatManager);
+#endif
 }
 
 ModularSynth::~ModularSynth()

--- a/Source/VSTScanner.cpp
+++ b/Source/VSTScanner.cpp
@@ -245,7 +245,11 @@ void PluginListWindow::closeButtonPressed()
 
 PluginScannerSubprocess::PluginScannerSubprocess()
 {
+#if JUCE_VERSION < ((8 << 16) + (0 << 8) + 11) // member-function replaced in 8.0.11
    formatManager.addDefaultFormats();
+#else
+   juce::addDefaultFormatsToManager(formatManager);
+#endif
 }
 
 void PluginScannerSubprocess::handleMessageFromCoordinator(const juce::MemoryBlock& mb)


### PR DESCRIPTION
JUCE 8.0.11 removed the `AudioPluginFormatManager` member function `addDefaultFormats` and replaced it with the non-member functions `addDefaultFormatsToManager` / `addHeadlessDefaultFormatsToManager`. See https://github.com/juce-framework/JUCE/commit/426b74fcf7ea155e54c2628aea51a3a38d632aed (breaking change is documented for 8.0.9 , but appears first in git tag 8.0.11)

Use `addDefaultFormatsToManager` when `JUCE_VERSION` is greater than or equal to 8.0.11.

Fixes https://github.com/BespokeSynth/BespokeSynth/issues/1944