### PR TITLE
Implement free LFO interval mode in `tremolo`

### DIFF
--- a/Source/TremoloEffect.cpp
+++ b/Source/TremoloEffect.cpp
@@ -42,11 +42,13 @@ void TremoloEffect::CreateUIControls()
    FLOATSLIDER(mAmountSlider, "amount", &mAmount, 0, 1);
    FLOATSLIDER(mOffsetSlider, "offset", &mOffset, 0, 1);
    FLOATSLIDER(mDutySlider, "duty", &mDuty, 0, 1);
+   FLOATSLIDER(mFreeRateSlider, "free rate", &mFreeRate, 0, 20);
    DROPDOWN(mIntervalSelector, "interval", (int*)(&mInterval), 45);
    UIBLOCK_SHIFTRIGHT();
    DROPDOWN(mOscSelector, "osc", (int*)(&mOscType), 45);
    ENDUIBLOCK(mWidth, mHeight);
 
+   mIntervalSelector->AddLabel("free", kInterval_Free);
    mIntervalSelector->AddLabel("1n", kInterval_1n);
    mIntervalSelector->AddLabel("2n", kInterval_2n);
    mIntervalSelector->AddLabel("4n", kInterval_4n);
@@ -103,6 +105,9 @@ void TremoloEffect::DrawModule()
    mOffsetSlider->Draw();
    mOscSelector->Draw();
    mDutySlider->Draw();
+   mFreeRateSlider->Draw();
+
+   mFreeRateSlider->SetShowing(mInterval == kInterval_Free);
 
    ofPushStyle();
    ofSetColor(0, 200, 0, gModuleDrawAlpha * .3f);
@@ -135,7 +140,7 @@ void TremoloEffect::FloatSliderUpdated(FloatSlider* slider, float oldVal, double
    if (slider == mOffsetSlider)
       mLFO.SetOffset(mOffset);
    if (slider == mDutySlider)
-   {
       mLFO.SetPulseWidth(mDuty);
-   }
+   if (slider == mFreeRateSlider)
+      mLFO.SetFreeRate(mFreeRate);
 }

--- a/Source/TremoloEffect.cpp
+++ b/Source/TremoloEffect.cpp
@@ -64,6 +64,9 @@ void TremoloEffect::CreateUIControls()
    mOscSelector->AddLabel("-saw", kOsc_NegSaw);
    mOscSelector->AddLabel("squ", kOsc_Square);
    mOscSelector->AddLabel("tri", kOsc_Tri);
+
+   mFreeRateSlider->SetMode(FloatSlider::kBezier);
+   mFreeRateSlider->SetBezierControl(1);
 }
 
 void TremoloEffect::ProcessAudio(double time, ChannelBuffer* buffer)

--- a/Source/TremoloEffect.h
+++ b/Source/TremoloEffect.h
@@ -63,6 +63,8 @@ private:
    FloatSlider* mAmountSlider{ nullptr };
    float mOffset{ 0 };
    FloatSlider* mOffsetSlider{ nullptr };
+   float mFreeRate{ 1 };
+   FloatSlider* mFreeRateSlider{ nullptr };
 
    LFO mLFO;
    NoteInterval mInterval{ NoteInterval::kInterval_16n };


### PR DESCRIPTION
This PR implements "free" mode in `tremolo`, allowing to use different intervals than the built-in multiples and fractions of `1n`.