### PR TITLE
Prevent exceeding the maximum number of steps in `notestepper`

### DIFF
--- a/Source/NoteStepper.cpp
+++ b/Source/NoteStepper.cpp
@@ -89,6 +89,10 @@ void NoteStepper::PlayNote(NoteMessage note)
       if (note.time > mLastNoteOnTime + 10 || !mAllowChords) //slop, to make a chord count as a single step
          mCurrentDestinationIndex = (mCurrentDestinationIndex + 1) % mLength;
 
+      //prevent exceeding maximum number of destinations even if user sets a large step number
+      if (mCurrentDestinationIndex >= kMaxDestinations)
+         return;
+
       selectedDestination = mCurrentDestinationIndex;
       mLastNoteOnTime = note.time;
 


### PR DESCRIPTION
Fixes #1971 by not sending the notes to nonexistent cables (ones with indices larger than the maximum number of cables).

Fixes #1971