### PR TITLE
add reset preset button, fix preset loading (#1973)

### DIFF
--- a/Source/VSTPlugin.h
+++ b/Source/VSTPlugin.h
@@ -132,7 +132,9 @@ private:
    int mPresetFileIndex{ -1 };
    DropdownList* mPresetFileSelector{ nullptr };
    bool mPresetFileUpdateQueued{ false };
+   int mPresetFileLoadCountdown{ 0 };
    ClickButton* mSavePresetFileButton{ nullptr };
+   ClickButton* mResetPresetButton{ nullptr };
    std::vector<std::string> mPresetFilePaths;
    std::string mLastLoadedPresetFilePath{};
    ClickButton* mOpenEditorButton{ nullptr };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1936,6 +1936,7 @@ plugin~a hosted plugin instance, such as a VST
 ~load parameter~This shows the number of parameters exposed by the plugin. If you click here, up to a 100 parameters are attempted to be added to the parameter dropdown list. If you hold `shift` while clicking, the parameter sliders will be added as well. If you hold `control` the parameter list will be reset and recreated as if the plugin was spawned new.
 ~preset~choose from saved plugin presets
 ~save as~save the current plugin settings as a preset to load again later
+~reset~reload the currently selected preset from disk, resetting all parameters to their original saved values
 ~panic~send "all notes off" and "all sounds off" to this plugin in order to silence it immediately
 ~ + ~Manually add a new Stereo output from the plugin
 ~  -  ~Remove the last manually added Stereo output from the plugin


### PR DESCRIPTION
This commit adds reset button with tooltip to plugin's control and also fixes #1973.
<img width="1027" height="337" alt="image" src="https://github.com/user-attachments/assets/d4163db5-2775-43b1-926c-6b7bcdf09468" />

Pressing the button resets the state of plugin to the saved state of the preset.

I've tried approach without `mPresetFileLoadCountdown = 2` first, but UI was lagging "one action behind" - reset needed to be pressed twice for UI sliders to reflect values of the preset.

Without `mPresetFileLoadCountdown = 2` and loading Preset A and Preset B repeatedly (see https://github.com/BespokeSynth/BespokeSynth/issues/1973), the UI sliders' state was like this:

Preset A: Parameters at 0
Preset B: Parameters at 0.5

- action 1 - load Preset A - parameter's unchanged
- action 2 - load Preset B - parameter's changed to the value of Preset A, plugin correctly set to values of Preset B
- action 3 - load Preset A - parameter's changed to the value of Preset B, plugin correctly set to values of Preset A

So this fix is mostly about keeping Bespoke's UI in sync with preset/plugin values on preset change / reset.
