### PR TITLE
Fix `audiorouter` crashes when nonexistent output cable is selected

### DIFF
--- a/Source/AudioRouter.cpp
+++ b/Source/AudioRouter.cpp
@@ -140,8 +140,8 @@ void AudioRouter::GetModuleDimensions(float& width, float& height)
 void AudioRouter::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mRouteSelector)
-   {
-   }
+      if (mRouteIndex >= mDestinationCables.size())
+         mRouteIndex = mDestinationCables.size() - 1;
 }
 
 void AudioRouter::LoadLayout(const ofxJSONElement& moduleInfo)

--- a/Source/AudioRouter.cpp
+++ b/Source/AudioRouter.cpp
@@ -140,8 +140,10 @@ void AudioRouter::GetModuleDimensions(float& width, float& height)
 void AudioRouter::RadioButtonUpdated(RadioButton* radio, int oldVal, double time)
 {
    if (radio == mRouteSelector)
+   {
       if (mRouteIndex >= mDestinationCables.size())
          mRouteIndex = mDestinationCables.size() - 1;
+   }
 }
 
 void AudioRouter::LoadLayout(const ofxJSONElement& moduleInfo)


### PR DESCRIPTION
`audiorouter` crashes when nonexistent output cable is selected via its radio button. This can happen, for example, when `audiorouter` has 2 output cables, but a value of 2 is sent via `valuesetter` or any other method. This PR adds a safeguard against the exceeding of cable count by selecting the last cable if the received value is larger than the number of cables.