### PR TITLE
fix grid keyboard chord mode cutting notes and releasing wrong chords

### DIFF
--- a/Source/LaunchpadKeyboard.cpp
+++ b/Source/LaunchpadKeyboard.cpp
@@ -247,27 +247,53 @@ void LaunchpadKeyboard::OnGridButton(int x, int y, float velocity, IGridControll
    {
       if (bOn)
       {
+         // Build new chord pitch set
+         bool newChordPitches[128] = {};
+         for (int i = 0; i < (int)mChords[x].size(); ++i)
+            newChordPitches[TheScale->MakeDiatonic(pitch + mChords[x][i])] = true;
+
+         // Note-off only for pitches in OLD chord but NOT in new chord.
+         // Shared pitches continue sustaining — avoids timing issues where
+         // note-off/note-on for the same pitch don't retrigger properly.
+         for (int i = 0; i < 128; ++i)
+         {
+            if (mActiveChordPitches[i] && !newChordPitches[i])
+               PlayKeyboardNote(time, i, 0);
+         }
+
+         // Note-on only for pitches in NEW chord but NOT in old chord
+         for (int i = 0; i < 128; ++i)
+         {
+            if (newChordPitches[i] && !mActiveChordPitches[i])
+               PlayKeyboardNote(time, i, 127 * velocity);
+         }
+
+         // Update tracking
+         for (int i = 0; i < 128; ++i)
+            mActiveChordPitches[i] = newChordPitches[i];
+         mActiveChordX = x;
+         mActiveChordY = y;
          for (int i = 0; i < 128; ++i)
             mCurrentNotes[i] = 0;
          PressedNoteFor(x, y, (int)127 * velocity);
-         mNoteOutput.Flush(time);
-         for (int i = 0; i < mChords[x].size(); ++i)
-            PlayKeyboardNote(time, TheScale->MakeDiatonic(pitch + mChords[x][i]), 127 * velocity);
       }
       else
       {
-         int currentPitch = -1;
-         for (int i = 0; i < 128; ++i)
-         {
-            if (mCurrentNotes[i] > 0)
-               currentPitch = i;
-         }
-
-         if (GridToPitch(x, y) == currentPitch)
+         // Only release if this is the button that activated the current chord.
+         // GridToPitch() only uses Y in chord mode, so buttons on the same row
+         // share the same root pitch — we must check the exact (x,y) position.
+         if (x == mActiveChordX && y == mActiveChordY)
          {
             for (int i = 0; i < 128; ++i)
+            {
+               if (mActiveChordPitches[i])
+                  PlayKeyboardNote(time, i, 0);
+            }
+            mActiveChordPitches.fill(false);
+            mActiveChordX = -1;
+            mActiveChordY = -1;
+            for (int i = 0; i < 128; ++i)
                mCurrentNotes[i] = 0;
-            mNoteOutput.Flush(time);
          }
       }
    }
@@ -930,6 +956,18 @@ void LaunchpadKeyboard::Exit()
 
 void LaunchpadKeyboard::DropdownUpdated(DropdownList* list, int oldVal, double time)
 {
+   if (list == mLayoutDropdown)
+   {
+      // Release any held chord notes when switching layout modes
+      for (int i = 0; i < 128; ++i)
+      {
+         if (mActiveChordPitches[i])
+            PlayKeyboardNote(NextBufferTime(false), i, 0);
+      }
+      mActiveChordPitches.fill(false);
+      mActiveChordX = -1;
+      mActiveChordY = -1;
+   }
    UpdateLights();
 }
 

--- a/Source/LaunchpadKeyboard.h
+++ b/Source/LaunchpadKeyboard.h
@@ -147,6 +147,9 @@ private:
    int mRootNote{ 4 }; // 4 = E
 
    std::array<int, 128> mCurrentNotes{};
+   std::array<bool, 128> mActiveChordPitches{}; // tracks all pitches in the currently playing chord
+   int mActiveChordX{ -1 }; // grid X of the active chord button
+   int mActiveChordY{ -1 }; // grid Y of the active chord button
    std::array<bool, 128> mPreviewNotes{};
    int mOctave{ 3 };
    IntSlider* mOctaveSlider{ nullptr };


### PR DESCRIPTION
Three issues fixed:
1. Replace Flush() with selective note-off/on — Flush() sends a second note-off 150ms later (sEventEarlyMs) which killed retriggered notes. Now only sends note-off for pitches removed from the chord; shared pitches sustain uninterrupted.
2. Track active chord button by exact (x, y) position — GridToPitch() ignores X in chord mode, so buttons on the same row shared the same root pitch, causing one button's release to kill another's chord.
3. Release held chord notes when switching layout modes to prevent stuck notes.


https://github.com/user-attachments/assets/e31c1537-6703-4b13-9574-bd0e2df84612


https://github.com/user-attachments/assets/25f64aa6-fef5-4f85-844a-8e70295d2bcf

