### PR TITLE
Fix/midicontroller flickering

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2796,7 +2796,8 @@ void UIControlConnection::Poll()
       else if (mUIControl != nullptr)
       {
          StringCopy(mUIControlPathInput, mUIControl->Path().c_str(), MAX_TEXTENTRY_LENGTH);
-         if (mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable)
+         if ((mPageless || mPage == mUIOwner->GetPage()) &&
+             mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable)
             mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable->SetTarget(mUIControl);
       }
       if (mUIControlPathEntry != nullptr)

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -2809,7 +2809,8 @@ void UIControlConnection::Poll()
          mUIControlPathEntry->SetInErrorMode(true);
       if (PatchCable::sActivePatchCable == nullptr)
       {
-         if (mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable)
+         if ((mPageless || mPage == mUIOwner->GetPage()) &&
+             mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable)
             mUIOwner->GetLayoutControl(mControl, mMessageType).mControlCable->ClearPatchCables();
       }
    }


### PR DESCRIPTION
## Summary

  - Fix MidiController patch cable flickering and instability when switching pages
  - Add missing page guards in `UIControlConnection::Poll()` so inactive page connections don't interfere with the active page's shared layout cables

  ## Details

  Layout cables in MidiController are shared across pages (indexed by MIDI control number + message type). `UIControlConnection::Poll()` iterates ALL connections regardless of page, but two
  operations were missing page checks:

  1. **`SetTarget()`** — connections from inactive pages were overriding the cable target every frame, causing cables to flicker between page 0 and page 1 targets
  2. **`ClearPatchCables()`** — connections on inactive pages with broken control paths could clear cables that the active page was using

  Both fixes add the same `(mPageless || mPage == mUIOwner->GetPage())` guard already used consistently everywhere else in MidiController (input processing, two-way feedback,
  `GetConnectionForControl()`, `PostRepatch()`).

  ## Test plan

  - [ ] Create a MidiController, connect a MIDI device
  - [ ] On page 0, bind several CC controls to UI targets
  - [ ] Switch to page 1 — verify page 0 cables don't flash/flicker
  - [ ] Bind controls on page 1 to different targets using the same CC numbers
  - [ ] Switch between pages — cables should cleanly switch without flickering
  - [ ] Verify pageless connections still work on all pages



Before:
https://github.com/user-attachments/assets/fa019e34-9635-476b-a257-dada891dad1f

After:
https://github.com/user-attachments/assets/7ed90efd-adea-4b40-b810-333e64869a8c



