### PR TITLE
Add Launchpad Pro controller mapping

### DIFF
--- a/resource/userdata_original/controllers/Launchpad Pro.json
+++ b/resource/userdata_original/controllers/Launchpad Pro.json
@@ -1,0 +1,87 @@
+{
+  "groups" : [
+     {
+        "rows": 1,
+        "cols": 1,
+        "position" : [ 0, 0 ],
+        "dimensions" : [25, 25],
+        "spacing" : [30, 30],
+        "controls" : [90],
+        "messageType" : "control",
+        "drawType" : "button"
+     },
+     {
+        "rows": 8,
+        "cols": 8,
+        "position" : [ 35, 35 ],
+        "dimensions" : [28, 28],
+        "spacing" : [30, 30],
+        "controls" : [ 81, 82, 83, 84, 85, 86, 87, 88,
+                       71, 72, 73, 74, 75, 76, 77, 78,
+                       61, 62, 63, 64, 65, 66, 67, 68,
+                       51, 52, 53, 54, 55, 56, 57, 58,
+                       41, 42, 43, 44, 45, 46, 47, 48,
+                       31, 32, 33, 34, 35, 36, 37, 38,
+                       21, 22, 23, 24, 25, 26, 27, 28,
+                       11, 12, 13, 14, 15, 16, 17, 18],
+        "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+        "messageType" : "note",
+        "drawType" : "button"
+     },
+     {
+       "rows": 8,
+       "cols": 1,
+       "position" : [ 0, 37 ],
+       "dimensions" : [25, 25],
+       "spacing" : [30, 30],
+       "controls" : [80,70,60,50,40,30,20,10],
+       "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+       "messageType" : "control",
+       "drawType" : "button"
+    },
+     {
+       "rows": 8,
+       "cols": 1,
+       "position" : [ 280, 37 ],
+       "dimensions" : [25, 25],
+       "spacing" : [30, 30],
+       "controls" : [89,79,69,59,49,39,29,19],
+       "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+       "messageType" : "control",
+       "drawType" : "button"
+    },
+    {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 37, 0 ],
+      "dimensions" : [25, 25],
+      "spacing" : [30, 30],
+      "controls" : [91,92,93,94,95,96,97,98],
+      "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+      "messageType" : "control",
+      "drawType" : "button"
+   },
+    {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 37, 280 ],
+      "dimensions" : [25, 25],
+      "spacing" : [30, 30],
+      "controls" : [101,102,103,104,105,106,107,108],
+      "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+      "messageType" : "control",
+      "drawType" : "button"
+   },
+    {
+      "rows": 1,
+      "cols": 8,
+      "position" : [ 37, 315 ],
+      "dimensions" : [25, 25],
+      "spacing" : [30, 30],
+      "controls" : [1,2,3,4,5,6,7,8],
+      "colors" : [ 0, 52, 53, 20, 21, 8, 9],
+      "messageType" : "control",
+      "drawType" : "button"
+   }
+  ]
+}


### PR DESCRIPTION
This adds a controller mapping for the Launchpad Pro controller.

Attached is a screenshot.

<img width="607" height="434" alt="image" src="https://github.com/user-attachments/assets/a379e04b-f7ab-4ea9-a844-e38718a78e06" />
