### PR TITLE
QoL - multipage dropdown opens on active value's page

### DIFF
--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -393,7 +393,17 @@ void DropdownList::OnClicked(float x, float y, bool right)
    mTotalColumns = 1 + ((int)mElements.size() - 1) / mMaxPerColumn;
    int maxDisplayColumns = std::max(1, int((ofGetWidth() / GetModuleParent()->GetOwningContainer()->GetDrawScale()) / mMaxItemWidth));
    mDisplayColumns = std::min(mTotalColumns, maxDisplayColumns);
-   mCurrentPagedColumn = 0;
+
+   int selectedIndex = FindItemIndex(*mVar);
+   if (selectedIndex >= 0 && selectedIndex < (int)mElements.size() && mMaxPerColumn > 0)
+   {
+      int column = selectedIndex / mMaxPerColumn;
+      mCurrentPagedColumn = (column / mDisplayColumns) * mDisplayColumns;
+   }
+   else
+   {
+      mCurrentPagedColumn = 0;
+   }
 
    bool paged = (mDisplayColumns < mTotalColumns);
 


### PR DESCRIPTION
Small QoL improvement for all dropdowns - if the list of options is paged, the page of the currently selected option is opened. 

<img width="1035" height="502" alt="image" src="https://github.com/user-attachments/assets/9dd671a8-1565-43fb-a6f2-19f79166090a" />
