### PR TITLE
add per-value LED feedback colors for midicontroller connections

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -275,6 +275,20 @@ void MidiController::AddControlConnection(const ofxJSONElement& connection)
       if (!connection["14bit"].isNull())
          controlConnection->m14BitMode = connection["14bit"].asBool();
 
+      if (!connection["feedback_values"].isNull() && connection["feedback_values"].isArray())
+      {
+         std::string display;
+         for (int j = 0; j < (int)connection["feedback_values"].size(); ++j)
+         {
+            int val = connection["feedback_values"][j].asInt();
+            controlConnection->mFeedbackValues.push_back(val);
+            if (j > 0)
+               display += ",";
+            display += ofToString(val);
+         }
+         StringCopy(controlConnection->mFeedbackValuesInput, display.c_str(), MAX_TEXTENTRY_LENGTH);
+      }
+
       controlConnection->SetUIControl(path);
 
       //controlConnection->CreateUIControls(this, mConnections.size()); //do this on the first draw instead, to avoid a long init time when setting up a bunch of minimized controllers
@@ -921,19 +935,30 @@ void MidiController::Poll()
             else if (connection->mType == kControlType_SetValue)
             {
                float realValue = uicontrol->GetValue();
-               bool valuesAreEqual = fabsf(realValue - connection->mValue) < .0001f;
                int outVal = 0;
-               if ((!uicontrol->IsBitmask() && valuesAreEqual) ||
-                   (uicontrol->IsBitmask() && ((int)realValue & (1 << (int)connection->mValue))))
+               if (!connection->mFeedbackValues.empty())
                {
-                  if (connection->mBlink == false)
-                     outVal = connection->mMidiOnValue;
-                  else
-                     outVal = mBlink ? connection->mMidiOnValue : connection->mMidiOffValue;
+                  int idx = (int)roundf(realValue);
+                  if (idx >= 0 && idx < (int)connection->mFeedbackValues.size())
+                     outVal = connection->mFeedbackValues[idx];
+                  else if (idx >= (int)connection->mFeedbackValues.size())
+                     outVal = connection->mFeedbackValues.back();
                }
                else
                {
-                  outVal = connection->mMidiOffValue;
+                  bool valuesAreEqual = fabsf(realValue - connection->mValue) < .0001f;
+                  if ((!uicontrol->IsBitmask() && valuesAreEqual) ||
+                      (uicontrol->IsBitmask() && ((int)realValue & (1 << (int)connection->mValue))))
+                  {
+                     if (connection->mBlink == false)
+                        outVal = connection->mMidiOnValue;
+                     else
+                        outVal = mBlink ? connection->mMidiOnValue : connection->mMidiOffValue;
+                  }
+                  else
+                  {
+                     outVal = connection->mMidiOffValue;
+                  }
                }
                if (messageType == kMidiMessage_Note)
                   SendNote(mControllerPage, control, outVal, true, connection->mChannel);
@@ -2093,6 +2118,16 @@ void MidiController::TextEntryComplete(TextEntry* entry)
             }
          }
       }
+      if (entry == connection->mFeedbackValuesEntry)
+      {
+         connection->mFeedbackValues.clear();
+         std::vector<std::string> tokens = ofSplitString(connection->mFeedbackValuesInput, ",", true, true);
+         for (const auto& token : tokens)
+         {
+            if (!token.empty())
+               connection->mFeedbackValues.push_back(ofToInt(token));
+         }
+      }
    }
 
    if (entry == mOscInPortEntry)
@@ -2563,6 +2598,12 @@ void MidiController::SaveLayout(ofxJSONElement& moduleInfo)
          mConnectionsJson[i]["feedbackcontrol"] = connection->mFeedbackControl;
       if (connection->m14BitMode)
          mConnectionsJson[i]["14bit"] = connection->m14BitMode;
+      if (!connection->mFeedbackValues.empty())
+      {
+         mConnectionsJson[i]["feedback_values"].resize(0);
+         for (int val : connection->mFeedbackValues)
+            mConnectionsJson[i]["feedback_values"].append(val);
+      }
 
       ++i;
    }
@@ -2703,7 +2744,9 @@ void UIControlConnection::CreateUIControls(int index)
    mBlinkCheckbox = new Checkbox(mUIOwner, "blink", mScaleOutputCheckbox, kAnchor_Right, &mBlink);
    mPagelessCheckbox = new Checkbox(mUIOwner, "pageless", mBlinkCheckbox, kAnchor_Right, &mPageless);
    m14BitModeCheckbox = new Checkbox(mUIOwner, "14bit", mPagelessCheckbox, kAnchor_Right, &m14BitMode);
-   mRemoveButton = new ClickButton(mUIOwner, " x ", mPagelessCheckbox, kAnchor_Right);
+   mFeedbackValuesEntry = new TextEntry(mUIOwner, "fbvals", -1, -1, 15, mFeedbackValuesInput);
+   mFeedbackValuesEntry->PositionTo(m14BitModeCheckbox, kAnchor_Right);
+   mRemoveButton = new ClickButton(mUIOwner, " x ", mFeedbackValuesEntry, kAnchor_Right);
    mCopyButton = new ClickButton(mUIOwner, "copy", mRemoveButton, kAnchor_Right);
    ++sControlID;
 
@@ -2722,6 +2765,7 @@ void UIControlConnection::CreateUIControls(int index)
    mEditorControls.push_back(mFeedbackDropdown);
    mEditorControls.push_back(mPagelessCheckbox);
    mEditorControls.push_back(m14BitModeCheckbox);
+   mEditorControls.push_back(mFeedbackValuesEntry);
    mEditorControls.push_back(mRemoveButton);
    mEditorControls.push_back(mCopyButton);
 
@@ -2827,6 +2871,7 @@ void UIControlConnection::PreDraw()
    mValueEntry->SetShowing((mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease) && mIncrementAmount == 0);
    m14BitModeCheckbox->SetShowing(mMessageType == kMidiMessage_Control && mControl >= 32);
    mIncrementalEntry->SetShowing(mType == kControlType_Slider || mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease);
+   mFeedbackValuesEntry->SetShowing((mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease) && mIncrementAmount != 0);
 }
 
 void UIControlConnection::DrawList(int index)
@@ -2840,6 +2885,7 @@ void UIControlConnection::DrawList(int index)
    mMidiOnEntry->DrawLabel(false);
    mIncrementalEntry->DrawLabel(false);
    mFeedbackDropdown->DrawLabel(false);
+   mFeedbackValuesEntry->DrawLabel(false);
 
    if (mControl < 32)
       m14BitModeCheckbox->SetShowing(false);
@@ -2885,6 +2931,7 @@ void UIControlConnection::DrawLayout()
    mMidiOnEntry->DrawLabel(true);
    mIncrementalEntry->DrawLabel(true);
    mFeedbackDropdown->DrawLabel(true);
+   mFeedbackValuesEntry->DrawLabel(true);
 
    mMessageTypeDropdown->SetPosition(kLayoutControlsX + 5, kLayoutControlsY + 3);
    mControlEntry->PositionTo(mMessageTypeDropdown, kAnchor_Right_Padded);
@@ -2901,7 +2948,8 @@ void UIControlConnection::DrawLayout()
    mFeedbackDropdown->PositionTo(mTwoWayCheckbox, kAnchor_Right_Padded);
    mPagelessCheckbox->PositionTo(mTwoWayCheckbox, kAnchor_Below);
    m14BitModeCheckbox->PositionTo(mPagelessCheckbox, kAnchor_Right);
-   mRemoveButton->PositionTo(mPagelessCheckbox, kAnchor_Below);
+   mFeedbackValuesEntry->PositionTo(mPagelessCheckbox, kAnchor_Below);
+   mRemoveButton->PositionTo(mFeedbackValuesEntry, kAnchor_Below);
    mCopyButton->SetShowing(false);
 
    if (mControl < 32)

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -936,13 +936,20 @@ void MidiController::Poll()
             {
                float realValue = uicontrol->GetValue();
                int outVal = 0;
-               if (!connection->mFeedbackValues.empty())
+               if (connection->mIncrementAmount != 0)
                {
-                  int idx = (int)roundf(realValue);
-                  if (idx >= 0 && idx < (int)connection->mFeedbackValues.size())
-                     outVal = connection->mFeedbackValues[idx];
-                  else if (idx >= (int)connection->mFeedbackValues.size())
-                     outVal = connection->mFeedbackValues.back();
+                  if (!connection->mFeedbackValues.empty())
+                  {
+                     int idx = (int)roundf(realValue);
+                     if (idx >= 0 && idx < (int)connection->mFeedbackValues.size())
+                        outVal = connection->mFeedbackValues[idx];
+                     else if (idx >= (int)connection->mFeedbackValues.size())
+                        outVal = connection->mFeedbackValues.back();
+                  }
+                  else
+                  {
+                     outVal = 0;
+                  }
                }
                else
                {
@@ -2744,10 +2751,10 @@ void UIControlConnection::CreateUIControls(int index)
    mBlinkCheckbox = new Checkbox(mUIOwner, "blink", mScaleOutputCheckbox, kAnchor_Right, &mBlink);
    mPagelessCheckbox = new Checkbox(mUIOwner, "pageless", mBlinkCheckbox, kAnchor_Right, &mPageless);
    m14BitModeCheckbox = new Checkbox(mUIOwner, "14bit", mPagelessCheckbox, kAnchor_Right, &m14BitMode);
-   mFeedbackValuesEntry = new TextEntry(mUIOwner, "fbvals", -1, -1, 15, mFeedbackValuesInput);
-   mFeedbackValuesEntry->PositionTo(m14BitModeCheckbox, kAnchor_Right);
-   mRemoveButton = new ClickButton(mUIOwner, " x ", mFeedbackValuesEntry, kAnchor_Right);
+   mRemoveButton = new ClickButton(mUIOwner, " x ", m14BitModeCheckbox, kAnchor_Right);
    mCopyButton = new ClickButton(mUIOwner, "copy", mRemoveButton, kAnchor_Right);
+   mFeedbackValuesEntry = new TextEntry(mUIOwner, "fbvals", -1, -1, 15, mFeedbackValuesInput);
+   mFeedbackValuesEntry->PositionTo(mFeedbackDropdown, kAnchor_Right);
    ++sControlID;
 
    mEditorControls.push_back(mMessageTypeDropdown);
@@ -2765,9 +2772,9 @@ void UIControlConnection::CreateUIControls(int index)
    mEditorControls.push_back(mFeedbackDropdown);
    mEditorControls.push_back(mPagelessCheckbox);
    mEditorControls.push_back(m14BitModeCheckbox);
-   mEditorControls.push_back(mFeedbackValuesEntry);
    mEditorControls.push_back(mRemoveButton);
    mEditorControls.push_back(mCopyButton);
+   mEditorControls.push_back(mFeedbackValuesEntry);
 
    for (auto iter = mEditorControls.begin(); iter != mEditorControls.end(); ++iter)
    {
@@ -2871,7 +2878,13 @@ void UIControlConnection::PreDraw()
    mValueEntry->SetShowing((mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease) && mIncrementAmount == 0);
    m14BitModeCheckbox->SetShowing(mMessageType == kMidiMessage_Control && mControl >= 32);
    mIncrementalEntry->SetShowing(mType == kControlType_Slider || mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease);
-   mFeedbackValuesEntry->SetShowing((mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease) && mIncrementAmount != 0);
+
+   bool showIndividualFeedbackValues = (mType == kControlType_SetValue || mType == kControlType_SetValueOnRelease) && mIncrementAmount != 0;
+   mMidiOffEntry->SetShowing(!showIndividualFeedbackValues);
+   mMidiOnEntry->SetShowing(!showIndividualFeedbackValues);
+   mScaleOutputCheckbox->SetShowing(!showIndividualFeedbackValues);
+   mBlinkCheckbox->SetShowing(!showIndividualFeedbackValues);
+   mFeedbackValuesEntry->SetShowing(showIndividualFeedbackValues);
 }
 
 void UIControlConnection::DrawList(int index)
@@ -2896,6 +2909,8 @@ void UIControlConnection::DrawList(int index)
    for (auto iter = mEditorControls.begin(); iter != mEditorControls.end(); ++iter)
    {
       (*iter)->SetPosition(x, y);
+      if (*iter == mFeedbackValuesEntry)
+         mFeedbackValuesEntry->SetPosition(mMidiOffEntry->GetPosition(K(local)).x, mMidiOffEntry->GetPosition(K(local)).y);
       (*iter)->Draw();
 
       x += (*iter)->GetRect().width + 3;
@@ -2948,9 +2963,9 @@ void UIControlConnection::DrawLayout()
    mFeedbackDropdown->PositionTo(mTwoWayCheckbox, kAnchor_Right_Padded);
    mPagelessCheckbox->PositionTo(mTwoWayCheckbox, kAnchor_Below);
    m14BitModeCheckbox->PositionTo(mPagelessCheckbox, kAnchor_Right);
-   mFeedbackValuesEntry->PositionTo(mPagelessCheckbox, kAnchor_Below);
-   mRemoveButton->PositionTo(mFeedbackValuesEntry, kAnchor_Below);
+   mRemoveButton->PositionTo(mPagelessCheckbox, kAnchor_Below);
    mCopyButton->SetShowing(false);
+   mFeedbackValuesEntry->PositionTo(mControlTypeDropdown, kAnchor_Below);
 
    if (mControl < 32)
       m14BitModeCheckbox->SetShowing(false);

--- a/Source/MidiController.h
+++ b/Source/MidiController.h
@@ -147,6 +147,8 @@ struct UIControlConnection
       connection->mPage = mPage;
       connection->mPageless = mPageless;
       connection->m14BitMode = m14BitMode;
+      connection->mFeedbackValues = mFeedbackValues;
+      StringCopy(connection->mFeedbackValuesInput, mFeedbackValuesInput, MAX_TEXTENTRY_LENGTH);
       return connection;
    }
 
@@ -180,6 +182,8 @@ struct UIControlConnection
    bool mPageless{ false };
    std::string mShouldRetryForUIControlAt{ "" };
    bool m14BitMode{ false };
+   std::vector<int> mFeedbackValues;
+   char mFeedbackValuesInput[MAX_TEXTENTRY_LENGTH]{};
 
    static bool sDrawCables;
 
@@ -202,6 +206,7 @@ struct UIControlConnection
    Checkbox* mScaleOutputCheckbox{ nullptr };
    Checkbox* mBlinkCheckbox{ nullptr };
    Checkbox* m14BitModeCheckbox{ nullptr };
+   TextEntry* mFeedbackValuesEntry{ nullptr };
    TextEntry* mIncrementalEntry{ nullptr };
    Checkbox* mTwoWayCheckbox{ nullptr };
    DropdownList* mFeedbackDropdown{ nullptr };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -662,6 +662,7 @@ midicontroller~get midi input from external devices. to get a nice display in th
 ~feedback~which cc or note should we send the feedback to?
 ~pageless~should this connection work across all pages of the midicontroller?
 ~14bit~is this a 14-bit midi control, with this control as the LSB and the control 32 less than this as the MSB?
+~fbvals~comma-separated midi values for feedback per control value (e.g. "53,21,9,0"). only used with "set"/"release" connections that have a nonzero increment amount. the control's current value is used as an index to look up the midi feedback value to send. useful for lighting controller LEDs with different colors per value.
 ~ x ~delete this connection
 ~copy~duplicate this connection
 ~layout~which layout file should we use for this controller? these can be created in your Documents/BespokeSynth/controllers folder.


### PR DESCRIPTION
When using setvalue connections with increment_amount (e.g., buttons that cycle through a dropdown's values), LED feedback was limited to binary on/off. This adds a "fbvals" field where users can enter comma-separated MIDI values (e.g., "53,21,9,0") that map each discrete control value to a specific LED color on the controller.

The control's current integer value indexes into the feedback_values array to determine which MIDI value to send back. If the value exceeds the array length, the last entry is used. When the field is empty, existing binary feedback behavior is preserved.

This is useful for controllers like the Launchpad Mk3 where different velocity values produce different pad colors, allowing visual feedback of which value is currently selected (e.g., M185 gate types).

Used only with set/release controller type that has nonzero increment.

<img width="496" height="249" alt="image" src="https://github.com/user-attachments/assets/729ae292-b410-4640-acf9-c1f0ccd5fc01" />
