### PR TITLE
fix stutter effect stuck at full blend after rapid automation toggling

### DIFF
--- a/Source/Stutter.cpp
+++ b/Source/Stutter.cpp
@@ -60,6 +60,16 @@ void Stutter::ProcessAudio(double time, ChannelBuffer* buffer)
    for (int ch = 0; ch < buffer->NumActiveChannels(); ++ch)
       mRecordBuffer.WriteChunk(buffer->GetChannel(ch), bufferSize, ch);
 
+   // Safety net: if the blend ramp is still active but the stutter state says stopped,
+   // start a proper ramp to zero. This catches edge cases where DoStutter and StopStutter
+   // create ramp entries with the same start time, causing the Ramp's ring buffer
+   // search (strict less-than) to miss the stop entry.
+   // The Target>0 check avoids re-triggering once a ramp-to-zero is already in progress.
+   if (!mStuttering && mStutterStack.empty() && mBlendRamp.Value(time) > 0 && mBlendRamp.Target(time) > 0)
+   {
+      mBlendRamp.Start(time, 0, time + STUTTER_START_BLEND_MS);
+   }
+
    if (mBlendRamp.Target(time) > 0 || mBlendRamp.Value(time) > 0)
    {
       if (mCurrentStutter.interval == kInterval_None)
@@ -177,17 +187,20 @@ void Stutter::EndStutter(double time, StutterParams stutter)
    {
       mStutterStack.remove(stutter);
    }
+   bool stackEmpty = mStutterStack.empty();
    mMutex.unlock();
 
-   bool quantize = sQuantize;
-   if (stutter.interval == kInterval_None && mStutterStack.empty())
-      quantize = false; //"free stutter" shouldn't be quantized if we're releasing the only stutter
-
-   if (!quantize)
+   if (stackEmpty)
    {
-      if (mStutterStack.empty())
-         StopStutter(time);
-      else if (hasNewStutter)
+      StopStutter(time);
+   }
+   else
+   {
+      bool quantize = sQuantize;
+      if (stutter.interval == kInterval_None)
+         quantize = false; //"free stutter" shouldn't be quantized
+
+      if (!quantize && hasNewStutter)
          DoStutter(time, stutter);
    }
 }


### PR DESCRIPTION
When DoStutter and StopStutter are called within the same audio buffer (same timestamp), the Ramp ring buffer's GetCurrentRampData uses strict less-than comparison and cannot find the stop entry. The StopStutter ramp becomes invisible, leaving blendTarget=1.0 permanently.

Root cause is in Ramp::GetCurrentRampData (Ramp.cpp) which uses mStartTime < time instead of <=, so entries created at exactly the queried time are skipped. This is not fixed directly to avoid side effects on other Ramp users throughout the codebase.

Three fixes in Stutter.cpp:
- EndStutter: always call StopStutter when stack empties, regardless of quantize setting, for immediate response
- ProcessAudio: when mStuttering is false and stack is empty but the blend ramp is still stuck (both Value and Target > 0), start a proper 3ms ramp to zero rather than hard-jumping via SetValue(0), preserving the crossfade and avoiding unnecessary writes on the audio thread