### PR TITLE
add pan for on_note script input

### DIFF
--- a/Source/ScriptModule.cpp
+++ b/Source/ScriptModule.cpp
@@ -571,7 +571,7 @@ void ScriptModule::Poll()
          {
             //if (mPendingNoteInput[i].time < time)
             //   ofLog() << "trying to run script triggered by note too late!";
-            RunCode(mPendingNoteInput[i].time, "on_note(" + ofToString(mPendingNoteInput[i].pitch) + ", " + ofToString(mPendingNoteInput[i].velocity) + ")");
+            RunCode(mPendingNoteInput[i].time, "on_note(" + ofToString(mPendingNoteInput[i].pitch) + ", " + ofToString(mPendingNoteInput[i].velocity) + ", " + ofToString(mPendingNoteInput[i].pan) + ")");
          }
          mPendingNoteInput[i].time = -1;
       }
@@ -1200,6 +1200,7 @@ void ScriptModule::PlayNote(NoteMessage note)
          mPendingNoteInput[i].time = note.time;
          mPendingNoteInput[i].pitch = note.pitch;
          mPendingNoteInput[i].velocity = note.velocity;
+         mPendingNoteInput[i].pan = note.modulation.pan;
          break;
       }
    }
@@ -1371,6 +1372,7 @@ void ScriptModule::FixUpCode(std::string& code)
    std::string prefix = GetMethodPrefix();
    ofStringReplace(code, "on_pulse(", "on_pulse__" + prefix + "(");
    ofStringReplace(code, "on_note(", "on_note__" + prefix + "(");
+   ofStringReplace(code, "def on_note__" + prefix + "(pitch, velocity)", "def on_note__" + prefix + "(pitch, velocity, pan=0)");
    ofStringReplace(code, "on_grid_button(", "on_grid_button__" + prefix + "(");
    ofStringReplace(code, "on_osc(", "on_osc__" + prefix + "(");
    ofStringReplace(code, "on_midi(", "on_midi__" + prefix + "(");

--- a/Source/ScriptModule.h
+++ b/Source/ScriptModule.h
@@ -239,6 +239,7 @@ private:
       double time{ 0 };
       int pitch{ 0 };
       int velocity{ 0 };
+      float pan{ 0 };
    };
    std::array<PendingNoteInput, 50> mPendingNoteInput;
 

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -6,7 +6,7 @@ the typical way to install jedi on your system is to enter 'pip install jedi' in
 
 script module inputs:
    on_pulse(): called by pulse input
-   on_note(pitch, velocity): called by note input
+   on_note(pitch, velocity, pan): called by note input
    on_grid_button(col, row, velocity): called by grid input
    on_osc(message): called by external osc source, after registering with me.connect_osc_input(port)
    on_midi(messageType, control, value, channel): called by midicontroller, after registering with add_script_listener(me.me())


### PR DESCRIPTION
This PR adds the missing pan parameter on script module input on_note.
It has been done so existing scripts will not break and has been tested with this in mind.

Documentation in /resource/scripting_reference.txt has been updated accordingly.

It was built and tested on Apple Silicon M1, macOS 26.4.1

First contribution here, looking forward to any corrections or pointers — happy to iterate.