### PR TITLE
feat: do not include autosaves in the welcome screen

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -3177,7 +3177,8 @@ void ModularSynth::LoadStatePopupImp()
 
 void ModularSynth::SaveState(std::string file, bool autosave)
 {
-   AddRecentFile(file, true);
+   if (!autosave)
+      AddRecentFile(file, true);
 
    mQueuedSaveStateInfo.mFile = file;
    mQueuedSaveStateInfo.mAutosave = autosave;

--- a/Source/WelcomeScreen.cpp
+++ b/Source/WelcomeScreen.cpp
@@ -98,7 +98,8 @@ void WelcomeScreen::CreateUIControls()
       recentFile.mFile = File(workspaceData["recent_files"][i]["file"].asString());
       recentFile.mTime = Time::fromISO8601(workspaceData["recent_files"][i]["time"].asString());
       recentFile.mRecentlyOpened = !workspaceData["recent_files"][i]["saved"].asBool();
-      if (recentFile.mFile.existsAsFile())
+      if (recentFile.mFile.existsAsFile() &&
+          recentFile.mFile.getParentDirectory().getFileName() != "autosave")
          mRecentFiles.insert(mRecentFiles.begin(), recentFile);
    }
 

--- a/Source/WelcomeScreen.cpp
+++ b/Source/WelcomeScreen.cpp
@@ -103,6 +103,24 @@ void WelcomeScreen::CreateUIControls()
          mRecentFiles.insert(mRecentFiles.begin(), recentFile);
    }
 
+   //include the most recent autosave as the first entry
+   File autosaveDir(ofToDataPath("savestate/autosave"));
+   Array<File> autosaveFiles;
+   autosaveDir.findChildFiles(autosaveFiles, File::findFiles, false, "*.bsk;*.bskt");
+   if (!autosaveFiles.isEmpty())
+   {
+      std::sort(autosaveFiles.begin(), autosaveFiles.end(),
+                [](const File& lhs, const File& rhs)
+                {
+                   return lhs.getLastModificationTime().toMilliseconds() > rhs.getLastModificationTime().toMilliseconds();
+                });
+      RecentFile recentFile;
+      recentFile.mFile = autosaveFiles[0];
+      recentFile.mTime = autosaveFiles[0].getLastModificationTime();
+      recentFile.mRecentlyOpened = false;
+      mRecentFiles.insert(mRecentFiles.begin(), recentFile);
+   }
+
    if (mRecentFiles.size() < kMaxDesiredFiles)
    {
       File dir(ofToDataPath("savestate"));


### PR DESCRIPTION
If autosaves are on, the welcome screen is cluttered with them and IMHO this defeats the purpose of recent files.
This change does not store autosaves in recent files, except if they were manually loaded by the user.

<img width="1419" height="726" alt="image" src="https://github.com/user-attachments/assets/6b613838-7fb3-4097-94c1-04fc1cf93d68" />
