### PR TITLE
feat: add Novation Launchkey 61 MK4 controller json

### DIFF
--- a/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI BUTTONS.json
+++ b/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI BUTTONS.json
@@ -1,0 +1,35 @@
+{
+	"channelfilter": 16,
+	"groups": [
+		{
+			"rows": 1,
+			"cols": 2,
+			"position": [0, 0],
+			"dimensions": [22, 14],
+			"spacing": [28],
+			"controls": [103, 102],
+			"messageType": "control",
+			"drawType": "button"
+		},
+		{
+			"rows": 2,
+			"cols": 2,
+			"position": [80, 0],
+			"dimensions": [22, 22],
+			"spacing": [28, 28],
+			"controls": [74, 77, 75, 76],
+			"messageType": "control",
+			"drawType": "button"
+		},
+		{
+			"rows": 2,
+			"cols": 1,
+			"position": [108, 64],
+			"dimensions": [22, 14],
+			"spacing": [0, 20],
+			"controls": [118, 117],
+			"messageType": "control",
+			"drawType": "button"
+		}
+	]
+}

--- a/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI PADS.json
+++ b/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI PADS.json
@@ -1,0 +1,19 @@
+{
+	"channelfilter": 10,
+	"groups": [
+		{
+			"rows": 2,
+			"cols": 8,
+			"position": [0, 0],
+			"dimensions": [40, 30],
+			"spacing": [45, 35],
+			"controls": [
+				40, 41, 42, 43, 48, 49, 50, 51,
+				36, 37, 38, 39, 44, 45, 46, 47
+			],
+			"colors": [0, 127],
+			"messageType": "note",
+			"drawType": "button"
+		}
+	]
+}

--- a/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI.json
+++ b/resource/userdata_original/controllers/Novation Launchkey 61 MK4 MIDI.json
@@ -1,0 +1,76 @@
+{
+	"channelfilter": 1,
+	"groups": [
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [0, 65],
+			"dimensions": [18, 80],
+			"messageType": "pitchbend",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 1,
+			"position": [25, 65],
+			"dimensions": [18, 80],
+			"controls": [1],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 2,
+			"cols": 8,
+			"position": [65, 0],
+			"dimensions": [22, 22],
+			"spacing": [28, 28],
+			"controls": [
+				21, 22, 23, 24, 25, 26, 27, 28,
+				31, 32, 33, 34, 35, 36, 37, 38
+			],
+			"messageType": "control",
+			"drawType": "knob"
+		},
+		{
+			"rows": 1,
+			"cols": 9,
+			"position": [65, 60],
+			"dimensions": [16, 80],
+			"spacing": [26],
+			"controls": [71, 72, 73, 74, 75, 76, 77, 78, 79],
+			"messageType": "control",
+			"drawType": "slider"
+		},
+		{
+			"rows": 1,
+			"cols": 9,
+			"position": [65, 150],
+			"dimensions": [16, 12],
+			"spacing": [26],
+			"controls": [11, 12, 13, 14, 15, 16, 17, 18, 19],
+			"messageType": "control",
+			"drawType": "button"
+		},
+		{
+			"rows": 1,
+			"cols": 128,
+			"position": [-235, 195],
+			"dimensions": [6, 40],
+			"spacing": [8, 25],
+			"controls": [
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+				18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+				34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+				50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
+				66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
+				82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+				98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+				111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+				124, 125, 126, 127
+			],
+			"messageType": "note",
+			"drawType": "button",
+			"connection_type": "slider"
+		}
+	]
+}


### PR DESCRIPTION
This PR adds the Novation Launchkey 61 MK4 controller specification. There are three files, grouped by the MIDI channel on which messages are being sent, since the same CC values are used for different controls.