### PR TITLE
fix: envelope crash, curve memory corruption

### DIFF
--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -186,7 +186,7 @@ void EnvelopeControl::OnClicked(float x, float y, bool right)
                mAdsr->GetStageData(mHighlightPoint + 1).time += mAdsr->GetStageData(mHighlightPoint).time;
                mAdsr->GetStageData(mHighlightPoint + 1).curve = mAdsr->GetStageData(mHighlightPoint).curve;
 
-               for (int i = mHighlightPoint; i < mAdsr->GetNumStages(); ++i)
+               for (int i = mHighlightPoint; i < mAdsr->GetNumStages() - 1; ++i)
                {
                   mAdsr->GetStageData(i).time = mAdsr->GetStageData(i + 1).time;
                   mAdsr->GetStageData(i).target = mAdsr->GetStageData(i + 1).target;
@@ -206,29 +206,36 @@ void EnvelopeControl::OnClicked(float x, float y, bool right)
                mHighlightCurve != -1 &&
                (mClickStart - ofVec2f(x, y)).lengthSquared() < pointClickRadius * pointClickRadius)
       {
-         float clickTime = GetTimeForX(x);
-         if (clickTime > GetPreSustainTime())
-            clickTime -= GetReleaseTime() - GetPreSustainTime();
-
-         for (int i = mAdsr->GetNumStages(); i > mHighlightCurve; --i)
+         if (mAdsr->GetNumStages() >= MAX_ADSR_STAGES)
          {
-            mAdsr->GetStageData(i).time = mAdsr->GetStageData(i - 1).time;
-            mAdsr->GetStageData(i).target = mAdsr->GetStageData(i - 1).target;
-            mAdsr->GetStageData(i).curve = mAdsr->GetStageData(i - 1).curve;
+            mHighlightCurve = -1;
          }
-         float priorStageTimes = 0;
-         for (int i = 0; i < mHighlightCurve; ++i)
-            priorStageTimes += mAdsr->GetStageData(i).time;
-         mAdsr->GetStageData(mHighlightCurve).time = clickTime - priorStageTimes;
-         mAdsr->GetStageData(mHighlightCurve).target = GetValueForY(y);
-         mAdsr->GetStageData(mHighlightCurve + 1).time -= mAdsr->GetStageData(mHighlightCurve).time;
-         mAdsr->SetNumStages(mAdsr->GetNumStages() + 1);
-         if (mAdsr->GetHasSustainStage() &&
-             mHighlightCurve <= mAdsr->GetSustainStage())
-            mAdsr->SetSustainStage(mAdsr->GetSustainStage() + 1);
+         else
+         {
+            float clickTime = GetTimeForX(x);
+            if (clickTime > GetPreSustainTime())
+               clickTime -= GetReleaseTime() - GetPreSustainTime();
 
-         mHighlightPoint = mHighlightCurve;
-         mHighlightCurve = -1;
+            for (int i = mAdsr->GetNumStages(); i > mHighlightCurve; --i)
+            {
+               mAdsr->GetStageData(i).time = mAdsr->GetStageData(i - 1).time;
+               mAdsr->GetStageData(i).target = mAdsr->GetStageData(i - 1).target;
+               mAdsr->GetStageData(i).curve = mAdsr->GetStageData(i - 1).curve;
+            }
+            float priorStageTimes = 0;
+            for (int i = 0; i < mHighlightCurve; ++i)
+               priorStageTimes += mAdsr->GetStageData(i).time;
+            mAdsr->GetStageData(mHighlightCurve).time = clickTime - priorStageTimes;
+            mAdsr->GetStageData(mHighlightCurve).target = GetValueForY(y);
+            mAdsr->GetStageData(mHighlightCurve + 1).time -= mAdsr->GetStageData(mHighlightCurve).time;
+            mAdsr->SetNumStages(mAdsr->GetNumStages() + 1);
+            if (mAdsr->GetHasSustainStage() &&
+                mHighlightCurve <= mAdsr->GetSustainStage())
+               mAdsr->SetSustainStage(mAdsr->GetSustainStage() + 1);
+
+            mHighlightPoint = mHighlightCurve;
+            mHighlightCurve = -1;
+         }
       }
 
       mLastClickTime = gTime;
@@ -508,7 +515,10 @@ void EnvelopeEditor::DrawModule()
       }
 
       //move release level checkbox below final stage control
-      ofVec2f pos = mStageControls[numStages - 1].mSustainCheckbox->GetPosition(K(local));
+      int lastVisibleStage = numStages - 1;
+      if (lastVisibleStage >= (int)mStageControls.size())
+         lastVisibleStage = (int)mStageControls.size() - 1;
+      ofVec2f pos = mStageControls[lastVisibleStage].mSustainCheckbox->GetPosition(K(local));
       mFreeReleaseLevelCheckbox->SetPosition(pos.x, pos.y);
    }
 }

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -136,5 +136,5 @@ private:
    FloatSlider* mMaxSustainSlider{ nullptr };
    Checkbox* mFreeReleaseLevelCheckbox{ nullptr };
    PatchCableSource* mTargetCable{ nullptr };
-   std::array<StageControls, 10> mStageControls{};
+   std::array<StageControls, MAX_ADSR_STAGES> mStageControls{};
 };


### PR DESCRIPTION
On @ArkyonVeil 's impulse, I've fired up Claude Code to fix `envelope` crash when adding 10+ points and `curve` memory corruption that caused curve to be stuck with no way of bringing it back:
<img width="179" height="216" alt="image" src="https://github.com/user-attachments/assets/901c87fa-dec1-4870-bd04-4284e4b96c00" />

This is after the fix:
<img width="1456" height="372" alt="image" src="https://github.com/user-attachments/assets/59825b5a-c068-401d-807f-44d6f0e85f64" />

I just glanced over the changes and didn't have time to review them. Code compiles, and bugs are gone.
Review required.



Claude Code summary:
---

# Bug Fixes: Envelope Crash and Curve Corruption

## Bug 1: Envelope crash at 10+ points

The `EnvelopeEditor` has a UI controls array of size 10 (`mStageControls[10]`), but the backing ADSR data allows up to 20 stages (`MAX_ADSR_STAGES`). When you add an 11th point, `DrawModule()` at `EnvelopeEditor.cpp:511` accesses `mStageControls[10]` — out of bounds — and crashes.

## Bug 2: Curve module corruption at 20+ points

The "curve" module (`ModulatorCurve`) doesn't have `mStageControls`, so it survives past 10 points. But at 20 stages, the double-click "add point" code in `EnvelopeControl::OnClicked()` writes to `mStages[20]` (one past the 20-element array), causing memory corruption. This manifests as the garbled point positions you see in the screenshot — and can crash on some systems.

## Proposed fix (3 changes across 2 files)

1. **`EnvelopeEditor.h`** — increase `mStageControls` from 10 to `MAX_ADSR_STAGES` (20) so the UI matches the data capacity
2. **`EnvelopeEditor.cpp`** — add a bounds guard (if `numStages >= MAX_ADSR_STAGES`, skip insertion) before the add-point code
3. **`EnvelopeEditor.cpp`** — fix a delete-loop off-by-one that reads one-past-end, plus add a defensive clamp in `DrawModule()`

All four modules using `EnvelopeControl` (envelope, curve, velocitycurve, curvelooper) benefit from the fix.

---

# Fix: Envelope crash at 10+ points & Curve corruption at 20+ points

## Context

Two user-reported bugs in BespokeSynth's `EnvelopeControl` (shared by envelope, curve, velocitycurve, and curvelooper modules):

1. Envelope module crashes when adding 10+ control points (double-click to add)
2. Curve module corrupts visually / crashes for some users when adding 20+ points

Both stem from missing bounds checks in `EnvelopeControl::OnClicked()` and a size mismatch between `mStageControls[10]` and `MAX_ADSR_STAGES` (20).

## Root Causes

### Crash at 10+ points (envelope editor only)

`EnvelopeEditor::DrawModule()` line 511 accesses `mStageControls[numStages - 1]` with no bounds check. `mStageControls` has 10 elements, so when `numStages > 10`, this is an out-of-bounds access.

### Corruption/crash at 20+ points (all EnvelopeControl users)

`EnvelopeControl::OnClicked()` line 213 — the "add stage on double-click" code shifts stages right starting from `i = GetNumStages()` and accesses `GetStageData(GetNumStages())`. When there are already 20 stages (`MAX_ADSR_STAGES`), this writes to `mStages[20]` — one past the end of the fixed-size array. Memory corruption follows.

### Delete loop off-by-one (latent bug)

Line 189 — the delete-stage shift loop runs `i < GetNumStages()`, reading `GetStageData(i + 1)` where `i+1 = GetNumStages()` on the last iteration. This reads one-past-end; if `GetNumStages() == MAX_ADSR_STAGES`, it's an out-of-bounds array access.

## Changes

### 1. `EnvelopeEditor.h` line 139 — increase `mStageControls` to match `MAX_ADSR_STAGES`

```cpp
// Before:
std::array<StageControls, 10> mStageControls{};

// After:
std::array<StageControls, MAX_ADSR_STAGES> mStageControls{};
```

This ensures the UI can display controls for all possible stages. Adds ~400 bytes (negligible). Uses the named constant so the sizes stay in sync.

### 2. `EnvelopeEditor.cpp` — three changes

**A. Add bounds guard before inserting a new stage (lines 208–231)**

Wrap the existing insertion code in `if (mAdsr->GetNumStages() >= MAX_ADSR_STAGES) { reset highlight } else { existing code }`. This prevents the shift loop from ever writing past the array.

**B. Fix delete loop off-by-one (line 189)**

Change `i < mAdsr->GetNumStages()` to `i < mAdsr->GetNumStages() - 1`. The loop copies slot `i+1` into `i`; stopping one earlier avoids reading past the last valid stage.

**C. Defensive clamp in `DrawModule()` (line 511)**

Clamp the index used to access `mStageControls`:

```cpp
int lastVisibleStage = numStages - 1;
if (lastVisibleStage >= (int)mStageControls.size())
    lastVisibleStage = (int)mStageControls.size() - 1;
```

Even though change #1 makes this unreachable under normal operation, it prevents crashes from corrupted save files.

## Files to modify

- `/data/code/sources/BespokeSynth/Source/EnvelopeEditor.h` (line 139)
- `/data/code/sources/BespokeSynth/Source/EnvelopeEditor.cpp` (lines 189, 208, 511)

## Not changed

- `ADSRDisplay.h` `mDrawTimeHistory[10]` — this is a circular buffer for visual draw trail (10 frames), unrelated to stage count
- `ADSR.h` `GetStageData()` — no bounds check added; callers are now correct, and adding a clamp here would mask bugs