### PR TITLE
Feature: Sampler module now supports Pulse Input

### DIFF
--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -271,7 +271,34 @@ void Sampler::OnPulse(double time, float velocity, int flags)
    //   note.velocity = velocity;
    note.velocity = 127;
    note.pitch = 48;
+
+   int repeatFlagInfo = -1;
+   if (flags & kPulseFlag_Reset) //Stops all sound.
+   {
+      mPolyMgr.KillAll();
+      note.velocity = 0;
+   }
+   else if (flags & kPulseFlag_Random) //Plays the sample at a random pos
+   {
+      repeatFlagInfo = mVoiceParams.mStartSample;
+      int range = mVoiceParams.mStopSample - mVoiceParams.mStartSample;
+      mVoiceParams.mStartSample = mVoiceParams.mStartSample + (gRandom() % range);
+   }
+   else if (flags & kPulseFlag_Repeat) //Replays on the last voice channel.
+   {
+      note.voiceIdx = mMostRecentVoiceIdx;
+   }
+   else if (flags & kPulseFlag_Backward)
+   {
+      //Obvious, but not supported. Pending polyphonic player/SampleVoice support.
+   }
+
    PlayNote(note);
+
+   if (repeatFlagInfo != -1)
+   {
+      mVoiceParams.mStartSample = repeatFlagInfo;
+   }
 }
 
 void Sampler::FilesDropped(std::vector<std::string> files, int x, int y)

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -268,7 +268,7 @@ void Sampler::OnPulse(double time, float velocity, int flags)
    if (velocity != 1)
       note.velocity = velocity;
    note.velocity = 127;
-   note.pitch = mVoiceParams.mSamplePitch;
+   note.pitch = 48;
    PlayNote(note);
 }
 

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -260,6 +260,18 @@ void Sampler::UpdateForNewSample()
    mVoiceParams.mSustainLoopEnd = -1;
 }
 
+void Sampler::OnPulse(double time, float velocity, int flags)
+{
+   NoteMessage note;
+   note.time = time;
+
+   if (velocity != 1)
+      note.velocity = velocity;
+   note.velocity = 127;
+   note.pitch = mVoiceParams.mSamplePitch;
+   PlayNote(note);
+}
+
 void Sampler::FilesDropped(std::vector<std::string> files, int x, int y)
 {
    mSample.LockDataMutex(true);

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -264,9 +264,11 @@ void Sampler::OnPulse(double time, float velocity, int flags)
 {
    NoteMessage note;
    note.time = time;
-
-   if (velocity != 1)
-      note.velocity = velocity;
+   //Pretty much all pulses come in velocity 1, which is insignificant.
+   //Pending improved support (or full deprecation) on pulse velocity. All pulses here play at full power.
+   //Reason for this is so there's no accidental jump to MAX velocity in lower leaning LFOs.
+   //if (velocity != 1)
+   //   note.velocity = velocity;
    note.velocity = 127;
    note.pitch = 48;
    PlayNote(note);

--- a/Source/Sampler.cpp
+++ b/Source/Sampler.cpp
@@ -278,19 +278,22 @@ void Sampler::OnPulse(double time, float velocity, int flags)
       mPolyMgr.KillAll();
       note.velocity = 0;
    }
-   else if (flags & kPulseFlag_Random) //Plays the sample at a random pos
+   else
    {
-      repeatFlagInfo = mVoiceParams.mStartSample;
-      int range = mVoiceParams.mStopSample - mVoiceParams.mStartSample;
-      mVoiceParams.mStartSample = mVoiceParams.mStartSample + (gRandom() % range);
-   }
-   else if (flags & kPulseFlag_Repeat) //Replays on the last voice channel.
-   {
-      note.voiceIdx = mMostRecentVoiceIdx;
-   }
-   else if (flags & kPulseFlag_Backward)
-   {
-      //Obvious, but not supported. Pending polyphonic player/SampleVoice support.
+      if (flags & kPulseFlag_Random) //Plays the sample at a random pos
+      {
+         repeatFlagInfo = mVoiceParams.mStartSample;
+         int range = mVoiceParams.mStopSample - mVoiceParams.mStartSample;
+         mVoiceParams.mStartSample = mVoiceParams.mStartSample + (gRandom() % range);
+      }
+      if (flags & kPulseFlag_Repeat) //Replays on the last voice channel.
+      {
+         note.voiceIdx = mMostRecentVoiceIdx;
+      }
+      if (flags & kPulseFlag_Backward)
+      {
+         //Obvious, but not supported. Pending polyphonic player/SampleVoice support.
+      }
    }
 
    PlayNote(note);

--- a/Source/Sampler.h
+++ b/Source/Sampler.h
@@ -41,7 +41,7 @@
 
 class ofxJSONElement;
 
-class Sampler : public IAudioProcessor, public INoteReceiver, public IDrawableModule, public IDropdownListener, public IFloatSliderListener, public IIntSliderListener, public ITextEntryListener, public IButtonListener
+class Sampler : public IAudioProcessor, public INoteReceiver, public IPulseReceiver, public IDrawableModule, public IDropdownListener, public IFloatSliderListener, public IIntSliderListener, public ITextEntryListener, public IButtonListener
 {
 public:
    Sampler();
@@ -49,7 +49,7 @@ public:
    static IDrawableModule* Create() { return new Sampler(); }
    static bool AcceptsAudio() { return true; }
    static bool AcceptsNotes() { return true; }
-   static bool AcceptsPulses() { return false; }
+   static bool AcceptsPulses() { return true; }
 
    void CreateUIControls() override;
 
@@ -65,6 +65,9 @@ public:
    //INoteReceiver
    void PlayNote(NoteMessage note) override;
    void SendCC(int control, int value, int voiceIdx = -1) override {}
+
+   //IPulseReciever
+   void OnPulse(double time, float velocity, int flags) override;
 
    void FilesDropped(std::vector<std::string> files, int x, int y) override;
    void SampleDropped(int x, int y, Sample* sample) override;
@@ -96,6 +99,7 @@ private:
    void DrawModule() override;
    void DrawModuleUnclipped() override;
 
+private:
    PolyphonyMgr mPolyMgr;
    NoteInputBuffer mNoteInputBuffer;
    SampleVoiceParams mVoiceParams;


### PR DESCRIPTION
Samplers now accept pulses and play the sample with a full velocity, pitch 48 note. (Affected by the Sampler's pitch value)

Supporting this was trivial and the pitch textbox was practically begging for pulser inputs.

...

Because one is quite overambitious, I decided to also throw in support for a couple pulse flags.

- Reset --> Stops all sound
- Repeat --> Interrupts the previous note and plays it on the same channel.
- Random --> Plays the sample with a random offset. Handy for granular play.

Repeat and Random are compatible and can optionally be layered.

https://github.com/user-attachments/assets/8f634f9a-474e-4cf7-bf01-7e28b84638d4