### PR TITLE
Fix: Adds a failsafe for when CustomDivisor is 1. Resolves #1999

### DIFF
--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -456,6 +456,14 @@ int Transport::GetQuantized(double time, const TransportListenerInfo* listenerIn
       }
       case kInterval_CustomDivisor:
       {
+         if (listenerInfo->mCustomDivisor <= 1)
+         {
+            pos *= double(mTimeSigTop) / mTimeSigBottom;
+            int ret = measure;
+            if (remainderMs != nullptr)
+               *remainderMs = (pos + measure % 1) * MsPerBar();
+            return ret;
+         }
          double ret = pos * listenerInfo->mCustomDivisor;
          if (remainderMs != nullptr)
          {

--- a/Source/Transport.cpp
+++ b/Source/Transport.cpp
@@ -457,18 +457,12 @@ int Transport::GetQuantized(double time, const TransportListenerInfo* listenerIn
       case kInterval_CustomDivisor:
       {
          if (listenerInfo->mCustomDivisor <= 1)
-         {
-            pos *= double(mTimeSigTop) / mTimeSigBottom;
-            int ret = measure;
-            if (remainderMs != nullptr)
-               *remainderMs = (pos + measure % 1) * MsPerBar();
-            return ret;
-         }
+            pos += measure;
          double ret = pos * listenerInfo->mCustomDivisor;
          if (remainderMs != nullptr)
          {
             double remainder = ret - (int)ret;
-            if (mSwing == .5f)
+            if (mSwing == .5f && listenerInfo->mCustomDivisor > 0)
                *remainderMs = remainder * (MsPerBar() / listenerInfo->mCustomDivisor);
             else
                *remainderMs = 0; //TODO(Ryan) this is incorrect, figure out how to properly calculate remainderMs when swing is applied


### PR DESCRIPTION
The customDivisor's transport never quite makes it through the threshold if the customDivisor is 1, resulting in 0 calls. 

This fix reuses the kInterval_1n code since it should be functionally equivalent. 

Should resolve #1999