### PR TITLE
Improvement: Dropdown Extensions

### DIFF
--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -221,7 +221,7 @@ void DropdownList::Render()
       ofPushMatrix();
       ofClipWindow(mX, mY, w - (mDrawTriangle ? 12 : 0), h, true);
       auto dropdownLabel = GetDisplayLabel(*mVar);
-      DrawTextNormal(GetDisplayValue(dropdownLabel.mValue), mX + 2 + xOffset, mY + 12);
+      DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
       if (dropdownLabel.mRenderer)
       {
          dropdownLabel.mRenderer(ofRectangle(mX,mY,mWidth,mHeight),false,false,dropdownLabel.mRenderArgs);

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -744,6 +744,14 @@ std::string DropdownListModal::GetHoveredLabel()
    return "";
 }
 
+DropdownListElement DropdownListModal::GetHoveredLabelObject()
+{
+   int index = mOwner->GetItemIndexAt((int)mMouseX, (int)mMouseY);
+   if (index >= 0 && index < mOwner->GetNumValues())
+      return mOwner->GetElement(index);
+   return {};
+}
+
 bool DropdownListModal::MouseMoved(float x, float y)
 {
    IDrawableModule::MouseMoved(x, y);

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -220,7 +220,7 @@ void DropdownList::Render()
       DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
       if (dropdownLabel.mCustomRenderer)
       {
-         dropdownLabel.mCustomRenderer(ofRectangle(mX, mY, mWidth, mHeight), false, false, dropdownLabel.mCustomRenderArgs);
+         dropdownLabel.mCustomRenderer(ofRectangle(mX, mY, mWidth, mHeight), false, false, dropdownLabel);
       }
       ofPopMatrix();
       if (mDrawTriangle)
@@ -340,7 +340,7 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
 
       if (mElements[i].mCustomRenderer)
       {
-         mElements[i].mCustomRenderer(labelRect, isHovering, true, mElements[i].mCustomRenderArgs);
+         mElements[i].mCustomRenderer(labelRect, isHovering, true, mElements[i]);
       }
    }
    ofSetColor(255, 255, 255);

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -73,7 +73,6 @@ void DropdownList::AddLabel(const DropdownListElement& item)
    CalculateWidth();
    mHeight = kItemSpacing;
    CalcSliderVal();
-   mIndexDisplayCache = -1;
 }
 
 void DropdownList::RemoveLabel(int value)
@@ -86,7 +85,6 @@ void DropdownList::RemoveLabel(int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
-         mIndexDisplayCache = -1;
          CalcSliderVal();
          break;
       }
@@ -103,7 +101,6 @@ void DropdownList::SetLabel(const std::string& label, int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
-         mIndexDisplayCache = -1;
          CalcSliderVal();
          return;
       }
@@ -120,7 +117,6 @@ void DropdownList::SetLabel(const DropdownListElement& item, int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
-         mIndexDisplayCache = -1;
          CalcSliderVal();
          return;
       }
@@ -222,9 +218,9 @@ void DropdownList::Render()
       ofClipWindow(mX, mY, w - (mDrawTriangle ? 12 : 0), h, true);
       auto dropdownLabel = GetDisplayLabel(*mVar);
       DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
-      if (dropdownLabel.mRenderer)
+      if (dropdownLabel.mCustomRenderer)
       {
-         dropdownLabel.mRenderer(ofRectangle(mX, mY, mWidth, mHeight), false, true, dropdownLabel.mRenderArgs);
+         dropdownLabel.mCustomRenderer(ofRectangle(mX, mY, mWidth, mHeight), false, false, dropdownLabel.mCustomRenderArgs);
       }
       ofPopMatrix();
       if (mDrawTriangle)
@@ -342,9 +338,9 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
 
       DrawTextNormal(mElements[i].mLabel, 1 + mMaxItemWidth * col, (i % maxPerColumn) * kItemSpacing + 12 + pageHeaderShift);
 
-      if (mElements[i].mRenderer)
+      if (mElements[i].mCustomRenderer)
       {
-         mElements[i].mRenderer(labelRect, isHovering, false, mElements[i].mRenderArgs);
+         mElements[i].mCustomRenderer(labelRect, isHovering, true, mElements[i].mCustomRenderArgs);
       }
    }
    ofSetColor(255, 255, 255);
@@ -608,14 +604,7 @@ int DropdownList::FindItemIndex(const int val) const
 
 std::string DropdownList::GetDisplayValue(float val) const
 {
-   int itemIndex;
-   if (mIndexDisplayCache != static_cast<int>(val))
-   {
-      itemIndex = FindItemIndex(val);
-      mIndexDisplayCache = static_cast<int>(val);
-   }
-   else
-      itemIndex = mIndexDisplayCache;
+   int itemIndex = FindItemIndex(static_cast<int>(val));
 
    if (itemIndex >= 0 && itemIndex < mElements.size())
       return mElements[itemIndex].mLabel;
@@ -625,14 +614,7 @@ std::string DropdownList::GetDisplayValue(float val) const
 
 DropdownListElement DropdownList::GetDisplayLabel(int val) const
 {
-   int itemIndex;
-   if (mIndexDisplayCache != val)
-   {
-      itemIndex = FindItemIndex(val);
-      mIndexDisplayCache = val;
-   }
-   else
-      itemIndex = mIndexDisplayCache;
+   int itemIndex = FindItemIndex(val);
 
    if (itemIndex >= 0 && itemIndex < mElements.size())
       return mElements[itemIndex];
@@ -738,15 +720,12 @@ void DropdownListModal::DrawModule()
       mPageNextButton->Draw();
 }
 
-std::string DropdownListModal::GetHoveredLabel()
+std::string DropdownListModal::GetHoveredLabel() const
 {
-   int index = mOwner->GetItemIndexAt((int)mMouseX, (int)mMouseY);
-   if (index >= 0 && index < mOwner->GetNumValues())
-      return mOwner->GetElement(index).mLabel;
-   return "";
+   return GetHoveredLabelObject().mLabel;
 }
 
-DropdownListElement DropdownListModal::GetHoveredLabelObject()
+DropdownListElement DropdownListModal::GetHoveredLabelObject() const
 {
    int index = mOwner->GetItemIndexAt((int)mMouseX, (int)mMouseY);
    if (index >= 0 && index < mOwner->GetNumValues())

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -60,16 +60,18 @@ DropdownList::~DropdownList()
 {
 }
 
-void DropdownList::AddLabel(std::string label, int value)
+void DropdownList::AddLabel(const std::string& label, int value)
 {
    DropdownListElement element;
    element.mLabel = label;
    element.mValue = value;
-   mElements.push_back(element);
-
+   AddLabel(element);
+}
+void DropdownList::AddLabel(const DropdownListElement& item)
+{
+   mElements.push_back(item);
    CalculateWidth();
    mHeight = kItemSpacing;
-
    CalcSliderVal();
 }
 
@@ -90,26 +92,38 @@ void DropdownList::RemoveLabel(int value)
    }
 }
 
-void DropdownList::SetLabel(std::string label, int value)
+void DropdownList::SetLabel(const std::string& label, int value)
 {
-   bool found = false;
    for (auto iter = mElements.begin(); iter != mElements.end(); ++iter)
    {
       if (iter->mValue == value)
       {
-         found = true;
          iter->mLabel = label;
 
          CalculateWidth();
          mHeight = kItemSpacing;
 
          CalcSliderVal();
-         break;
+         return;
       }
    }
+   AddLabel(label, value);
+}
+void DropdownList::SetLabel(const DropdownListElement& item, int value)
+{
+   for (auto iter = mElements.begin(); iter != mElements.end(); ++iter)
+   {
+      if (iter->mValue == value)
+      {
+         *iter = item;
 
-   if (!found)
-      AddLabel(label, value);
+         CalculateWidth();
+         mHeight = kItemSpacing;
+         CalcSliderVal();
+         return;
+      }
+   }
+   AddLabel(item);
 }
 
 void DropdownList::CalculateWidth()
@@ -117,7 +131,7 @@ void DropdownList::CalculateWidth()
    mMaxItemWidth = mWidth;
    for (int i = 0; i < mElements.size(); ++i)
    {
-      int width = GetStringWidth(mElements[i].mLabel) + (mDrawTriangle ? 15 : 3);
+      int width = GetStringWidth(mElements[i].mLabel)+mElements[i].mReservedWidth + (mDrawTriangle ? 15 : 3);
       if (width > mMaxItemWidth)
          mMaxItemWidth = width;
    }
@@ -143,6 +157,15 @@ std::string DropdownList::GetLabel(int val) const
          return mElements[i].mLabel;
    }
    return "";
+}
+DropdownListElement DropdownList::GetLabelObject(int val) const
+{
+   for (int i = 0; i < mElements.size(); ++i)
+   {
+      if (mElements[i].mValue == val)
+         return mElements[i];
+   }
+   return {};
 }
 
 bool DropdownList::HasLabel(int val) const
@@ -282,10 +305,17 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
       if (col >= displayColumns)
          break;
 
-      if (i == hoverIndex)
+      ofRectangle labelRect {
+         static_cast<float>(mMaxItemWidth * col),
+         (i % maxPerColumn) * kItemSpacing + pageHeaderShift,
+         static_cast<float>(mMaxItemWidth),
+         kItemSpacing};
+      bool isHovering = i == hoverIndex;
+
+      if (isHovering)
       {
          ofSetColor(100, 100, 100, 100);
-         ofRect(mMaxItemWidth * col, (i % maxPerColumn) * kItemSpacing + pageHeaderShift, mMaxItemWidth, kItemSpacing);
+         ofRect(labelRect);
       }
 
       if (VectorContains(i, mSeparators))
@@ -303,6 +333,10 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
          ofSetColor(255, 255, 255);
 
       DrawTextNormal(mElements[i].mLabel, 1 + mMaxItemWidth * col, (i % maxPerColumn) * kItemSpacing + 12 + pageHeaderShift);
+      if (mElements[i].mRenderer)
+      {
+         mElements[i].mRenderer(labelRect,isHovering,true,mElements[i].mRenderArgs);
+      }
    }
    ofSetColor(255, 255, 255);
 

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -133,7 +133,7 @@ void DropdownList::CalculateWidth()
    mMaxItemWidth = mWidth;
    for (int i = 0; i < mElements.size(); ++i)
    {
-      int width = GetStringWidth(mElements[i].mLabel)+mElements[i].mReservedWidth + (mDrawTriangle ? 15 : 3);
+      int width = GetStringWidth(mElements[i].mLabel) + mElements[i].mReservedWidth + (mDrawTriangle ? 15 : 3);
       if (width > mMaxItemWidth)
          mMaxItemWidth = width;
    }
@@ -224,7 +224,7 @@ void DropdownList::Render()
       DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
       if (dropdownLabel.mRenderer)
       {
-         dropdownLabel.mRenderer(ofRectangle(mX,mY,mWidth,mHeight),false,false,dropdownLabel.mRenderArgs);
+         dropdownLabel.mRenderer(ofRectangle(mX, mY, mWidth, mHeight), false, true, dropdownLabel.mRenderArgs);
       }
       ofPopMatrix();
       if (mDrawTriangle)
@@ -312,11 +312,12 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
       if (col >= displayColumns)
          break;
 
-      ofRectangle labelRect {
+      ofRectangle labelRect{
          static_cast<float>(mMaxItemWidth * col),
          (i % maxPerColumn) * kItemSpacing + pageHeaderShift,
          static_cast<float>(mMaxItemWidth),
-         kItemSpacing};
+         kItemSpacing
+      };
       bool isHovering = i == hoverIndex;
 
       if (isHovering)
@@ -340,9 +341,10 @@ void DropdownList::DrawDropdown(int w, int h, bool isScrolling)
          ofSetColor(255, 255, 255);
 
       DrawTextNormal(mElements[i].mLabel, 1 + mMaxItemWidth * col, (i % maxPerColumn) * kItemSpacing + 12 + pageHeaderShift);
+
       if (mElements[i].mRenderer)
       {
-         mElements[i].mRenderer(labelRect,isHovering,true,mElements[i].mRenderArgs);
+         mElements[i].mRenderer(labelRect, isHovering, false, mElements[i].mRenderArgs);
       }
    }
    ofSetColor(255, 255, 255);
@@ -635,7 +637,7 @@ DropdownListElement DropdownList::GetDisplayLabel(int val) const
    if (itemIndex >= 0 && itemIndex < mElements.size())
       return mElements[itemIndex];
 
-   return {mUnknownItemString};
+   return { mUnknownItemString };
 }
 
 void DropdownList::CalcSliderVal()

--- a/Source/DropdownList.cpp
+++ b/Source/DropdownList.cpp
@@ -73,6 +73,7 @@ void DropdownList::AddLabel(const DropdownListElement& item)
    CalculateWidth();
    mHeight = kItemSpacing;
    CalcSliderVal();
+   mIndexDisplayCache = -1;
 }
 
 void DropdownList::RemoveLabel(int value)
@@ -85,7 +86,7 @@ void DropdownList::RemoveLabel(int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
-
+         mIndexDisplayCache = -1;
          CalcSliderVal();
          break;
       }
@@ -102,7 +103,7 @@ void DropdownList::SetLabel(const std::string& label, int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
-
+         mIndexDisplayCache = -1;
          CalcSliderVal();
          return;
       }
@@ -119,6 +120,7 @@ void DropdownList::SetLabel(const DropdownListElement& item, int value)
 
          CalculateWidth();
          mHeight = kItemSpacing;
+         mIndexDisplayCache = -1;
          CalcSliderVal();
          return;
       }
@@ -218,7 +220,12 @@ void DropdownList::Render()
 
       ofPushMatrix();
       ofClipWindow(mX, mY, w - (mDrawTriangle ? 12 : 0), h, true);
-      DrawTextNormal(GetDisplayValue(*mVar), mX + 2 + xOffset, mY + 12);
+      auto dropdownLabel = GetDisplayLabel(*mVar);
+      DrawTextNormal(GetDisplayValue(dropdownLabel.mValue), mX + 2 + xOffset, mY + 12);
+      if (dropdownLabel.mRenderer)
+      {
+         dropdownLabel.mRenderer(ofRectangle(mX,mY,mWidth,mHeight),false,false,dropdownLabel.mRenderArgs);
+      }
       ofPopMatrix();
       if (mDrawTriangle)
       {
@@ -565,7 +572,7 @@ void DropdownList::SetIndex(int i, double time, bool forceUpdate)
 
 void DropdownList::SetValue(float value, double time, bool forceUpdate /*= false*/)
 {
-   int intValue = (int)value;
+   int intValue = static_cast<int>(value);
    if (intValue != *mVar || forceUpdate)
    {
       int oldVal = *mVar;
@@ -586,7 +593,7 @@ float DropdownList::GetMidiValue() const
    return mSliderVal;
 }
 
-int DropdownList::FindItemIndex(float val) const
+int DropdownList::FindItemIndex(const int val) const
 {
    for (int i = 0; i < mElements.size(); ++i)
    {
@@ -599,12 +606,36 @@ int DropdownList::FindItemIndex(float val) const
 
 std::string DropdownList::GetDisplayValue(float val) const
 {
-   int itemIndex = FindItemIndex(val);
+   int itemIndex;
+   if (mIndexDisplayCache != static_cast<int>(val))
+   {
+      itemIndex = FindItemIndex(val);
+      mIndexDisplayCache = static_cast<int>(val);
+   }
+   else
+      itemIndex = mIndexDisplayCache;
 
    if (itemIndex >= 0 && itemIndex < mElements.size())
       return mElements[itemIndex].mLabel;
    else
       return mUnknownItemString.c_str();
+}
+
+DropdownListElement DropdownList::GetDisplayLabel(int val) const
+{
+   int itemIndex;
+   if (mIndexDisplayCache != val)
+   {
+      itemIndex = FindItemIndex(val);
+      mIndexDisplayCache = val;
+   }
+   else
+      itemIndex = mIndexDisplayCache;
+
+   if (itemIndex >= 0 && itemIndex < mElements.size())
+      return mElements[itemIndex];
+
+   return {mUnknownItemString};
 }
 
 void DropdownList::CalcSliderVal()

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -29,12 +29,17 @@
 #include "IDrawableModule.h"
 #include "ClickButton.h"
 #include "IPulseReceiver.h"
-#include "PatchCableSource.h"
 
+typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawnOnDropdownList, void* args);
 struct DropdownListElement
 {
-   std::string mLabel;
-   int mValue{ 0 };
+   std::string mLabel; //Text on the dropdown
+   int mValue{ 0 }; //Value of the dropdown, used for array indexing and modulation.
+   std::string mTooltipTag{}; //Localized Tooltip
+
+   float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
+   DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
+   void* mRenderArgs{ nullptr }; //Stores an argument for use. Sent into the function call.
 };
 
 class DropdownList;
@@ -104,10 +109,13 @@ public:
    DropdownList(IDropdownListener* owner, const char* name, int x, int y, int* var, float width = -1);
    DropdownList(IDropdownListener* owner, const char* name, IUIControl* anchor, AnchorDirection anchorDirection, int* var, float width = -1);
    IDropdownListener* GetOwner() { return mOwner; }
-   void AddLabel(std::string label, int value);
+   void AddLabel(const std::string& label, int value);
+   void AddLabel(const DropdownListElement& item);
    void RemoveLabel(int value);
-   void SetLabel(std::string label, int value);
+   void SetLabel(const std::string& label, int value);
+   void SetLabel(const DropdownListElement& item, int value);
    std::string GetLabel(int val) const;
+   DropdownListElement GetLabelObject(int val) const;
    bool HasLabel(int val) const;
    void SetDisplayStyle(DropdownDisplayStyle style) { mDisplayStyle = style; }
    void Render() override;

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -30,7 +30,9 @@
 #include "ClickButton.h"
 #include "IPulseReceiver.h"
 
-typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const std::string& args);
+
+struct DropdownListElement;
+typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const DropdownListElement& element);
 struct DropdownListElement
 {
    std::string mLabel; //Text on the dropdown
@@ -43,7 +45,7 @@ struct DropdownListElement
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
    DropdownRenderFn mCustomRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
-   std::string mCustomRenderArgs; //Stores an argument for use. Sent into the function call.
+   void* mArgs {nullptr}; //Optionally include an argument for rendering work.
 };
 
 class DropdownList;

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -30,7 +30,7 @@
 #include "ClickButton.h"
 #include "IPulseReceiver.h"
 
-typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool drawnOnButtonBody, const std::string& args);
+typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const std::string& args);
 struct DropdownListElement
 {
    std::string mLabel; //Text on the dropdown
@@ -42,8 +42,8 @@ struct DropdownListElement
    std::string mTooltipAddress{};
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
-   DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
-   std::string mRenderArgs; //Stores an argument for use. Sent into the function call.
+   DropdownRenderFn mCustomRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
+   std::string mCustomRenderArgs; //Stores an argument for use. Sent into the function call.
 };
 
 class DropdownList;
@@ -80,8 +80,8 @@ public:
    bool ShouldClipContents() override { return false; }
    DropdownList* GetOwner() const { return mOwner; }
    bool MouseMoved(float x, float y) override;
-   std::string GetHoveredLabel();
-   DropdownListElement GetHoveredLabelObject();
+   std::string GetHoveredLabel() const;
+   DropdownListElement GetHoveredLabelObject() const;
    float GetMouseX() { return mMouseX; }
    float GetMouseY() { return mMouseY; }
    void SetShowPagingControls(bool show);
@@ -211,7 +211,6 @@ private:
    bool mAutoCalculateWidth{ false };
    bool mDrawTriangle{ true };
    double mLastScrolledTime{ -9999 };
-   mutable int mIndexDisplayCache{ -1 };
    std::vector<int> mSeparators;
    DropdownDisplayStyle mDisplayStyle{ DropdownDisplayStyle::kNormal };
 };

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -30,7 +30,7 @@
 #include "ClickButton.h"
 #include "IPulseReceiver.h"
 
-typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawnOnDropdownList, void* args);
+typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool drawnOnButtonBody, const std::string& args);
 struct DropdownListElement
 {
    std::string mLabel; //Text on the dropdown
@@ -43,7 +43,7 @@ struct DropdownListElement
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
    DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
-   void* mRenderArgs{ nullptr }; //Stores an argument for use. Sent into the function call.
+   std::string mRenderArgs; //Stores an argument for use. Sent into the function call.
 };
 
 class DropdownList;

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -35,7 +35,7 @@ struct DropdownListElement
 {
    std::string mLabel; //Text on the dropdown
    int mValue{ 0 }; //Value of the dropdown, used for array indexing and modulation.
-   std::string mTooltipTag{}; //Localized Tooltip
+   std::string mTooltipAddress{}; //Custom tooltip address. Format: "module~control~subcontrol"
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
    DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
@@ -77,6 +77,7 @@ public:
    DropdownList* GetOwner() const { return mOwner; }
    bool MouseMoved(float x, float y) override;
    std::string GetHoveredLabel();
+   DropdownListElement GetHoveredLabelObject();
    float GetMouseX() { return mMouseX; }
    float GetMouseY() { return mMouseY; }
    void SetShowPagingControls(bool show);
@@ -207,8 +208,6 @@ private:
    bool mDrawTriangle{ true };
    double mLastScrolledTime{ -9999 };
    mutable int mIndexDisplayCache { -1 };
-   mutable std::string mCachedElementLabel;
-   mutable std::string mCachedElementTooltip;
    std::vector<int> mSeparators;
    DropdownDisplayStyle mDisplayStyle{ DropdownDisplayStyle::kNormal };
 

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -45,7 +45,7 @@ struct DropdownListElement
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
    DropdownRenderFn mCustomRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
-   void* mArgs {nullptr}; //Optionally include an argument for rendering work.
+   void* mArgs{ nullptr }; //Optionally include an argument for rendering work.
 };
 
 class DropdownList;

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -211,8 +211,7 @@ private:
    bool mAutoCalculateWidth{ false };
    bool mDrawTriangle{ true };
    double mLastScrolledTime{ -9999 };
-   mutable int mIndexDisplayCache { -1 };
+   mutable int mIndexDisplayCache{ -1 };
    std::vector<int> mSeparators;
    DropdownDisplayStyle mDisplayStyle{ DropdownDisplayStyle::kNormal };
-
 };

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -159,6 +159,7 @@ public:
    float GetMidiValue() const override;
    int GetNumValues() override { return (int)mElements.size(); }
    std::string GetDisplayValue(float val) const override;
+   DropdownListElement GetDisplayLabel(int val) const;
    bool InvertScrollDirection() override { return true; }
    void Increment(float amount) override;
    void Poll() override;
@@ -181,7 +182,7 @@ protected:
 private:
    void OnClicked(float x, float y, bool right) override;
    void CalcSliderVal();
-   int FindItemIndex(float val) const;
+   int FindItemIndex(int val) const;
    void CalculateWidth();
    ofVec2f GetModalListPosition() const;
 
@@ -205,6 +206,10 @@ private:
    bool mAutoCalculateWidth{ false };
    bool mDrawTriangle{ true };
    double mLastScrolledTime{ -9999 };
+   mutable int mIndexDisplayCache { -1 };
+   mutable std::string mCachedElementLabel;
+   mutable std::string mCachedElementTooltip;
    std::vector<int> mSeparators;
    DropdownDisplayStyle mDisplayStyle{ DropdownDisplayStyle::kNormal };
+
 };

--- a/Source/DropdownList.h
+++ b/Source/DropdownList.h
@@ -35,7 +35,11 @@ struct DropdownListElement
 {
    std::string mLabel; //Text on the dropdown
    int mValue{ 0 }; //Value of the dropdown, used for array indexing and modulation.
-   std::string mTooltipAddress{}; //Custom tooltip address. Format: "module~control~subcontrol"
+
+   //Custom tooltip address. Format: "module~control~subcontrol"
+   //Can point to any tooltip in the tooltip files.
+   //By default displays this if present --> thismodule~thisdropdown~thislabel~tooltip. If not present, no tooltip is shown.
+   std::string mTooltipAddress{};
 
    float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
    DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.

--- a/Source/EffectChain.cpp
+++ b/Source/EffectChain.cpp
@@ -61,7 +61,13 @@ void EffectChain::Init()
    mEffectTypesToSpawn = TheSynth->GetEffectFactory()->GetSpawnableEffects();
    mEffectSpawnList->SetUnknownItemString("add effect:");
    for (int i = 0; i < mEffectTypesToSpawn.size(); ++i)
-      mEffectSpawnList->AddLabel(mEffectTypesToSpawn[i].c_str(), i);
+   {
+      DropdownListElement label;
+      label.mValue = i;
+      label.mLabel = mEffectTypesToSpawn[i];
+      label.mTooltipAddress = mEffectTypesToSpawn[i];
+      mEffectSpawnList->AddLabel(label);
+   }
 
    mInitialized = true;
 }

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -236,7 +236,10 @@ void HelpDisplay::LoadTooltips()
             {
                subTooltipInfo.name = tokens[2];
                subTooltipInfo.tooltip = tokens[3];
-               controlInfo.subTooltips.push_back(subTooltipInfo);
+               if (tokens[1] != "*")
+                  controlInfo.subTooltips.push_back(subTooltipInfo);
+               else
+                  moduleInfo.globalSubTooltips.push_back(subTooltipInfo);
             }
          }
       }
@@ -395,6 +398,20 @@ std::string HelpDisplay::GetControlSubTooltip(IUIControl* control, const std::st
          if (sub.name == subTooltip)
          {
             return sub.name + ": " + (!sub.tooltip.empty() ? sub.tooltip : kNoTooltipFound);
+         }
+      }
+   }
+   //If nothing found, then we look in the module's shared subTooltip record.
+   if (auto mod = control->GetModuleParent())
+   {
+      if (const auto mInfo = FindModuleInfo(mod->GetTypeName()))
+      {
+         for (auto& sub : mInfo->globalSubTooltips)
+         {
+            if (sub.name == subTooltip)
+            {
+               return sub.name + ": " + (!sub.tooltip.empty() ? sub.tooltip : kNoTooltipFound);
+            }
          }
       }
    }

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -426,7 +426,7 @@ std::string HelpDisplay::GetTooltipFromAddress(const std::string& address)
    //Tokenize
    auto strings = ofSplitString(address, "~");
    //TODO, best to cache this as it's probably not super cheap.
-   const int tokens = strings.size();
+   const int tokens = static_cast<int>(strings.size());
 
    if (tokens == 1) //Asking for a module tooltip
       return GetModuleTooltipFromName(strings[0]);

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -360,7 +360,7 @@ std::string HelpDisplay::GetUIControlTooltip(IUIControl* control)
    if (controlInfo && controlInfo->tooltip.size() > 0)
       tooltip = controlInfo->tooltip;
    else
-      tooltip = "[no tooltip found]";
+      tooltip = kNoTooltipFound;
 
    return name + ": " + tooltip;
 }
@@ -381,9 +381,68 @@ std::string HelpDisplay::GetModuleTooltipFromName(std::string moduleTypeName)
    if (moduleInfo && moduleInfo->tooltip.size() > 0)
       tooltip = moduleInfo->tooltip;
    else
-      tooltip = "[no tooltip found]";
+      tooltip = kNoTooltipFound;
 
    return moduleTypeName + ": " + tooltip;
+}
+
+std::string HelpDisplay::GetControlSubTooltip(IUIControl* control, const std::string& subTooltip)
+{
+   if (const auto cInfo = FindControlInfo(control))
+   {
+      for (auto& sub : cInfo->subTooltips)
+      {
+         if (sub.name == subTooltip)
+         {
+            return sub.name + ": " + (!sub.tooltip.empty() ? sub.tooltip : kNoTooltipFound);
+         }
+      }
+   }
+   return "";
+}
+
+std::string HelpDisplay::GetTooltipFromAddress(const std::string& address)
+{
+   if (address.empty())
+      return "";
+
+   //Tokenize
+   auto strings = ofSplitString(address, "~");
+   //TODO, best to cache this as it's probably not super cheap.
+   const int tokens = strings.size();
+
+   if (tokens == 1) //Asking for a module tooltip
+      return GetModuleTooltipFromName(strings[0]);
+   if (tokens == 2) //Asking for a tooltip of a control of a module.
+   {
+      ModuleTooltipInfo* moduleInfo = FindModuleInfo(strings[0]);
+      for (auto& control : moduleInfo->controlTooltips)
+      {
+         if (control.controlName == strings[1])
+            return strings[1] + ": " + (!control.tooltip.empty() ? control.tooltip : kNoTooltipFound);
+      }
+      return strings[1] + ": " + kNoTooltipFound;
+   }
+   if (tokens == 3) //Asking for a tooltip of a sub control of a control of a module.
+   {
+      ModuleTooltipInfo* moduleInfo = FindModuleInfo(strings[0]);
+      for (auto& control : moduleInfo->controlTooltips)
+      {
+         if (control.controlName == strings[1])
+         {
+            for (auto& sub : control.subTooltips)
+            {
+               if (sub.name == strings[2])
+                  return strings[2] + ": " + (!sub.tooltip.empty() ? sub.tooltip : kNoTooltipFound);
+            }
+            return strings[2] + ": " + kNoTooltipFound;
+         }
+      }
+      return strings[1] + ": " + kNoTooltipFound;
+   }
+   assert(false); //Asking for disappointment.
+
+   return "";
 }
 
 //static
@@ -469,7 +528,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button, double time)
                continue;
             addedModuleNames.push_back(module->GetTypeName());
 
-            std::string moduleTooltip = "[no tooltip]";
+            std::string moduleTooltip = kNoTooltipFound;
             ModuleTooltipInfo* moduleInfo = FindModuleInfo(module->GetTypeName());
             if (moduleInfo)
             {
@@ -487,7 +546,7 @@ void HelpDisplay::ButtonClicked(ClickButton* button, double time)
                std::string controlName = control->Name();
                if (controlName != "enabled")
                {
-                  std::string controlTooltip = "[no tooltip]";
+                  std::string controlTooltip = kNoTooltipFound;
                   UIControlTooltipInfo* controlInfo = FindControlInfo(control);
                   if (controlInfo)
                   {

--- a/Source/HelpDisplay.cpp
+++ b/Source/HelpDisplay.cpp
@@ -198,6 +198,7 @@ void HelpDisplay::LoadTooltips()
 
    ModuleTooltipInfo moduleInfo;
    UIControlTooltipInfo controlInfo;
+   UIControlSubTooltipInfo subTooltipInfo;
 
    juce::File tooltipsFile(ofToResourcePath(UserPrefs.tooltips.Get()));
    if (tooltipsFile.existsAsFile())
@@ -211,19 +212,31 @@ void HelpDisplay::LoadTooltips()
          {
             juce::String line = lines[i].replace("\\n", "\n");
             std::vector<std::string> tokens = ofSplitString(line.toStdString(), "~");
-            if (tokens.size() == 2)
+            if (tokens.size() == 2) //2 tokens, ex: module~this is a module that does X.
             {
+               if (!controlInfo.controlName.empty())
+               {
+                  moduleInfo.controlTooltips.push_back(controlInfo);
+                  controlInfo.controlName.clear();
+               }
                if (!moduleInfo.module.empty())
                   sTooltips.push_back(moduleInfo); //add this one and start a new one
                moduleInfo.module = tokens[0];
                moduleInfo.tooltip = tokens[1];
                moduleInfo.controlTooltips.clear();
             }
-            else if (tokens.size() == 3)
+            else if (tokens.size() == 3) //3 tokens, ex: ~control~this dial does Y.
             {
+               if (!controlInfo.controlName.empty())
+                  moduleInfo.controlTooltips.push_back(controlInfo);
                controlInfo.controlName = tokens[1];
                controlInfo.tooltip = tokens[2];
-               moduleInfo.controlTooltips.push_back(controlInfo);
+            }
+            else if (tokens.size() == 4) //4 tokens, ex: ~~labelB~this dropdown does Z
+            {
+               subTooltipInfo.name = tokens[2];
+               subTooltipInfo.tooltip = tokens[3];
+               controlInfo.subTooltips.push_back(subTooltipInfo);
             }
          }
       }

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -99,6 +99,7 @@ private:
       std::string module;
       std::string tooltip;
       std::list<UIControlTooltipInfo> controlTooltips;
+      std::list<UIControlSubTooltipInfo> globalSubTooltips;
    };
 
    void LoadHelp();

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -73,10 +73,17 @@ private:
 
    void RenderScreenshot(int x, int y, int width, int height, std::string filename);
 
+   struct UIControlSubTooltipInfo
+   {
+      std::string name;
+      std::string tooltip;
+   };
+
    struct UIControlTooltipInfo
    {
       std::string controlName;
       std::string tooltip;
+      std::list<UIControlSubTooltipInfo> subTooltips;
    };
 
    struct ModuleTooltipInfo

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -51,9 +51,17 @@ public:
    static void OpenDocsLink();
    static void OpenDiscordLink();
 
-   std::string GetUIControlTooltip(IUIControl* control);
-   std::string GetModuleTooltip(IDrawableModule* module);
-   std::string GetModuleTooltipFromName(std::string moduleTypeName);
+   std::string GetUIControlTooltip(IUIControl* control);//Returns the tooltip of this control.
+   std::string GetModuleTooltip(IDrawableModule* module);//Returns the tooltip of this module.
+   std::string GetModuleTooltipFromName(std::string moduleTypeName); //Returns the tooltip of the module with this name.
+   std::string GetControlSubTooltip(IUIControl* control, const std::string& subTooltip);
+
+   //Returns the address of the tooltip in format. "Name: Tooltip"
+   //Addresses:
+   //modulename
+   //modulename~uiname
+   //modulename~uiname~subuiname
+   std::string GetTooltipFromAddress(const std::string& address);
 
    void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
@@ -124,4 +132,6 @@ private:
    };
    ScreenshotState mScreenshotState{ ScreenshotState::None };
    int mScreenshotCountdown{ 0 };
+
+   const std::string kNoTooltipFound = "[no tooltip found]";
 };

--- a/Source/HelpDisplay.h
+++ b/Source/HelpDisplay.h
@@ -51,8 +51,8 @@ public:
    static void OpenDocsLink();
    static void OpenDiscordLink();
 
-   std::string GetUIControlTooltip(IUIControl* control);//Returns the tooltip of this control.
-   std::string GetModuleTooltip(IDrawableModule* module);//Returns the tooltip of this module.
+   std::string GetUIControlTooltip(IUIControl* control); //Returns the tooltip of this control.
+   std::string GetModuleTooltip(IDrawableModule* module); //Returns the tooltip of this module.
    std::string GetModuleTooltipFromName(std::string moduleTypeName); //Returns the tooltip of the module with this name.
    std::string GetControlSubTooltip(IUIControl* control, const std::string& subTooltip);
 

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -766,24 +766,23 @@ void ModularSynth::Draw()
             tooltip = helpDisplay->GetModuleTooltipFromName(name);
             tooltipContainer = mQuickSpawn->GetOwningContainer();
          }
-         else if (gHoveredModule == GetTopModalFocusItem() && dynamic_cast<DropdownListModal*>(gHoveredModule))
+         else if (dynamic_cast<DropdownListModal*>(gHoveredModule))
          {
-            DropdownListModal* list = dynamic_cast<DropdownListModal*>(gHoveredModule);
-            //Render the header's dropdown tooltips
-            if (list->GetOwner()->GetModuleParent() == TheTitleBar)
-            {
-               std::string moduleTypeName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
-               ofStringReplace(moduleTypeName, " (exp.)", "");
-               tooltip = helpDisplay->GetModuleTooltipFromName(moduleTypeName);
+            auto* modal = dynamic_cast<DropdownListModal*>(gHoveredModule);
+
+            //Pick the proper container.
+            if (modal->GetOwner()->GetModuleParent() == TheTitleBar)
                tooltipContainer = &mUILayerModuleContainer;
-            }
-            //Render the effectchain's tooltips, and ONLY the effectchain
-            else if (dynamic_cast<EffectChain*>(list->GetOwner()->GetParent()) != nullptr)
-            {
-               std::string effectName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
-               tooltip = helpDisplay->GetModuleTooltipFromName(effectName);
-               tooltipContainer = list->GetModuleParent()->GetOwningContainer();
-            }
+            else
+               tooltipContainer = modal->GetModuleParent()->GetOwningContainer();
+
+            //Dropdown modals support both custom tooltip addresses and unique per-label tooltips.
+            auto label = modal->GetHoveredLabelObject();
+            if (!label.mTooltipAddress.empty())
+               tooltip = helpDisplay->GetTooltipFromAddress(label.mTooltipAddress);
+            else
+               tooltip = helpDisplay->GetControlSubTooltip(modal->GetOwner(),label.mLabel);
+
          }
          else if (GetMouseY(&mModuleContainer) < gHoveredModule->GetPosition().y && gHoveredModule->HasTitleBar()) //this means we're hovering over the module's title bar
          {

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -769,6 +769,7 @@ void ModularSynth::Draw()
          else if (gHoveredModule == GetTopModalFocusItem() && dynamic_cast<DropdownListModal*>(gHoveredModule))
          {
             DropdownListModal* list = dynamic_cast<DropdownListModal*>(gHoveredModule);
+            //Render the header's dropdown tooltips
             if (list->GetOwner()->GetModuleParent() == TheTitleBar)
             {
                std::string moduleTypeName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();
@@ -776,6 +777,7 @@ void ModularSynth::Draw()
                tooltip = helpDisplay->GetModuleTooltipFromName(moduleTypeName);
                tooltipContainer = &mUILayerModuleContainer;
             }
+            //Render the effectchain's tooltips, and ONLY the effectchain
             else if (dynamic_cast<EffectChain*>(list->GetOwner()->GetParent()) != nullptr)
             {
                std::string effectName = dynamic_cast<DropdownListModal*>(gHoveredModule)->GetHoveredLabel();

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -781,8 +781,7 @@ void ModularSynth::Draw()
             if (!label.mTooltipAddress.empty())
                tooltip = helpDisplay->GetTooltipFromAddress(label.mTooltipAddress);
             else
-               tooltip = helpDisplay->GetControlSubTooltip(modal->GetOwner(),label.mLabel);
-
+               tooltip = helpDisplay->GetControlSubTooltip(modal->GetOwner(), label.mLabel);
          }
          else if (GetMouseY(&mModuleContainer) < gHoveredModule->GetPosition().y && gHoveredModule->HasTitleBar()) //this means we're hovering over the module's title bar
          {

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -1126,43 +1126,31 @@ void SongBuilder::ControlTarget::CreateUIControls(SongBuilder* owner)
       DropdownListElement label;
       label.mValue = i;
       label.mLabel = owner->mColors[i].name;
-      label.mRenderArgs = owner->mColors[i].name;
-      label.mRenderer = DrawColourCircle;
+      ofColor col = owner->mColors[i].color;
+      std::string args;
+      args.push_back(static_cast<char>(col.r));
+      args.push_back(static_cast<char>(col.g));
+      args.push_back(static_cast<char>(col.b));
+      args.push_back(static_cast<char>(col.a));
+      label.mCustomRenderArgs = args;
+      label.mCustomRenderer = DrawColourCircle;
       mColorSelector->AddLabel(label);
    }
    mColorSelector->SetDrawTriangle(false);
 }
 
-void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool drawnOnBody, const std::string& args)
+void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const std::string& args)
 {
-   if (drawnOnBody)
+   if (!isDrawingOnPopup)
       return;
    ofPushStyle();
 
-   ofColor drawCol;
-   if (args == "grey")
-      drawCol = ofColor::grey;
-   else if (args == "red")
-      drawCol = ofColor::red;
-   else if (args == "orange")
-      drawCol = ofColor::orange;
-   else if (args == "yellow")
-      drawCol = ofColor::yellow;
-   else if (args == "green")
-      drawCol = ofColor::green;
-   else if (args == "cyan")
-      drawCol = ofColor::cyan;
-   else if (args == "blue")
-      drawCol = ofColor::blue;
-   else if (args == "purple")
-      drawCol = ofColor::purple;
-   else if (args == "magenta")
-      drawCol = ofColor::magenta;
-   else
-      drawCol = ofColor::black;
-
+   int r = static_cast<unsigned char>(args[0]);
+   int g = static_cast<unsigned char>(args[1]);
+   int b = static_cast<unsigned char>(args[2]);
+   int a = static_cast<unsigned char>(args[3]);
    float hHalf = renderRect.height / 2.0f;
-   ofSetColor(drawCol);
+   ofSetColor(ofColor(r, g, b, a));
    ofCircle(renderRect.x + renderRect.width - hHalf, renderRect.y + hHalf, 4.5f);
    ofPopStyle();
 }

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -1139,31 +1139,31 @@ void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool
       return;
    ofPushStyle();
 
-    ofColor drawCol;
-    if (args == "grey")
-       drawCol = ofColor::grey;
-    else if (args == "red")
-       drawCol = ofColor::red;
-    else if (args == "orange")
-       drawCol = ofColor::orange;
-    else if (args == "yellow")
-       drawCol = ofColor::yellow;
-    else if (args == "green")
-       drawCol = ofColor::green;
-    else if (args == "cyan")
-       drawCol = ofColor::cyan;
-    else if (args == "blue")
-       drawCol = ofColor::blue;
-    else if (args == "purple")
-       drawCol = ofColor::purple;
-    else if (args == "magenta")
-       drawCol = ofColor::magenta;
-    else
-       drawCol = ofColor::black;
+   ofColor drawCol;
+   if (args == "grey")
+      drawCol = ofColor::grey;
+   else if (args == "red")
+      drawCol = ofColor::red;
+   else if (args == "orange")
+      drawCol = ofColor::orange;
+   else if (args == "yellow")
+      drawCol = ofColor::yellow;
+   else if (args == "green")
+      drawCol = ofColor::green;
+   else if (args == "cyan")
+      drawCol = ofColor::cyan;
+   else if (args == "blue")
+      drawCol = ofColor::blue;
+   else if (args == "purple")
+      drawCol = ofColor::purple;
+   else if (args == "magenta")
+      drawCol = ofColor::magenta;
+   else
+      drawCol = ofColor::black;
 
    float hHalf = renderRect.height / 2.0f;
    ofSetColor(drawCol);
-   ofCircle(renderRect.x+renderRect.width-hHalf,renderRect.y+hHalf,4.5f);
+   ofCircle(renderRect.x + renderRect.width - hHalf, renderRect.y + hHalf, 4.5f);
    ofPopStyle();
 }
 

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -1126,31 +1126,22 @@ void SongBuilder::ControlTarget::CreateUIControls(SongBuilder* owner)
       DropdownListElement label;
       label.mValue = i;
       label.mLabel = owner->mColors[i].name;
-      ofColor col = owner->mColors[i].color;
-      std::string args;
-      args.push_back(static_cast<char>(col.r));
-      args.push_back(static_cast<char>(col.g));
-      args.push_back(static_cast<char>(col.b));
-      args.push_back(static_cast<char>(col.a));
-      label.mCustomRenderArgs = args;
+      label.mArgs = &owner->mColors[i].color;
       label.mCustomRenderer = DrawColourCircle;
       mColorSelector->AddLabel(label);
    }
    mColorSelector->SetDrawTriangle(false);
 }
 
-void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const std::string& args)
+void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const DropdownListElement& element)
 {
    if (!isDrawingOnPopup)
       return;
    ofPushStyle();
 
-   int r = static_cast<unsigned char>(args[0]);
-   int g = static_cast<unsigned char>(args[1]);
-   int b = static_cast<unsigned char>(args[2]);
-   int a = static_cast<unsigned char>(args[3]);
    float hHalf = renderRect.height / 2.0f;
-   ofSetColor(ofColor(r, g, b, a));
+   auto col = static_cast<ofColor*>(element.mArgs);
+   ofSetColor(*col);
    ofCircle(renderRect.x + renderRect.width - hHalf, renderRect.y + hHalf, 4.5f);
    ofPopStyle();
 }

--- a/Source/SongBuilder.cpp
+++ b/Source/SongBuilder.cpp
@@ -1122,8 +1122,49 @@ void SongBuilder::ControlTarget::CreateUIControls(SongBuilder* owner)
    mCycleDisplayTypeButton->SetCableTargetable(false);
 
    for (int i = 0; i < (int)owner->mColors.size(); ++i)
-      mColorSelector->AddLabel(owner->mColors[i].name, i);
+   {
+      DropdownListElement label;
+      label.mValue = i;
+      label.mLabel = owner->mColors[i].name;
+      label.mRenderArgs = owner->mColors[i].name;
+      label.mRenderer = DrawColourCircle;
+      mColorSelector->AddLabel(label);
+   }
    mColorSelector->SetDrawTriangle(false);
+}
+
+void SongBuilder::DrawColourCircle(ofRectangle renderRect, bool isHovering, bool drawnOnBody, const std::string& args)
+{
+   if (drawnOnBody)
+      return;
+   ofPushStyle();
+
+    ofColor drawCol;
+    if (args == "grey")
+       drawCol = ofColor::grey;
+    else if (args == "red")
+       drawCol = ofColor::red;
+    else if (args == "orange")
+       drawCol = ofColor::orange;
+    else if (args == "yellow")
+       drawCol = ofColor::yellow;
+    else if (args == "green")
+       drawCol = ofColor::green;
+    else if (args == "cyan")
+       drawCol = ofColor::cyan;
+    else if (args == "blue")
+       drawCol = ofColor::blue;
+    else if (args == "purple")
+       drawCol = ofColor::purple;
+    else if (args == "magenta")
+       drawCol = ofColor::magenta;
+    else
+       drawCol = ofColor::black;
+
+   float hHalf = renderRect.height / 2.0f;
+   ofSetColor(drawCol);
+   ofCircle(renderRect.x+renderRect.width-hHalf,renderRect.y+hHalf,4.5f);
+   ofPopStyle();
 }
 
 void SongBuilder::ControlTarget::Draw(float x, float y, int numRows)

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -98,7 +98,7 @@ private:
    bool ShowSongSequencer() const { return mUseSequencer; }
    void RefreshSequencerDropdowns();
    void PlaySequence(double time, int startIndex);
-   static void DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawnOnDropdownList, const std::string& args);
+   static void DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const DropdownListElement& element);
 
    enum class ContextMenuItems
    {

--- a/Source/SongBuilder.h
+++ b/Source/SongBuilder.h
@@ -98,6 +98,7 @@ private:
    bool ShowSongSequencer() const { return mUseSequencer; }
    void RefreshSequencerDropdowns();
    void PlaySequence(double time, int startIndex);
+   static void DrawColourCircle(ofRectangle renderRect, bool isHovering, bool isDrawnOnDropdownList, const std::string& args);
 
    enum class ContextMenuItems
    {

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -75,7 +75,11 @@ void SpawnList::SetList(std::vector<ModuleFactory::Spawnable> spawnables)
          name += " " + mSpawnables[i].mDecorator;
       if (TheSynth->GetModuleFactory()->IsExperimental(name))
          name += " (exp.)";
-      mSpawnList->AddLabel(name, i);
+      DropdownListElement label;
+      label.mLabel = name;
+      label.mValue = i;
+      label.mTooltipAddress = name;
+      mSpawnList->AddLabel(label);
    }
 }
 

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1000,6 +1000,13 @@ feedback~feed delayed audio back into earlier in the signal chain. use the "feed
 eq~multi-band equalizer, to adjust output levels at frequency ranges
 ~enabled*~enable this band?
 ~type*~what type of filter should this band use
+~*~lp~low pass
+~*~hp~high pass
+~*~bp~band pass
+~*~pk~peak
+~*~nt~notch
+~*~hs~high shelf
+~*~ls~low shelf
 ~f*~frequency cutoff for this band
 ~g*~gain for this band
 ~q*~resonance for this band
@@ -1991,43 +1998,43 @@ splitter~splits a stereo signal into two mono signals, or duplicates a mono sign
 scale~controls the global scale used by various modules
 ~root~root note of the scale
 ~scale~which set of notes to use
-~~ionian~1 2 3 4 5 6 7\n\nmood: bright, balanced, clear, confident, resolved\ngenres: pop, classical, folk, singer-songwriter, country
-~~aeolian~1 2 b3 4 5 b6 b7\n\nmood: dark, melancholic, natural, introspective, emotional\ngenres: rock, pop, metal, folk, indie
-~~dorian~1 2 b3 4 5 6 b7\n\nmood: moody, cool, soulful, hopeful, grooving\ngenres: jazz, funk, soul, modal rock, fusion
-~~mixolydian~1 2 3 4 5 6 b7\n\nmood: bluesy, open, earthy, relaxed, anthemic\ngenres: rock, blues, funk, folk, jam bands
-~~lydian~1 2 3 #4 5 6 7\n\nmood: bright, dreamy, floating, expansive, magical\ngenres: film, fusion, progressive rock, ambient, jazz
-~~phrygian~1 b2 b3 4 5 b6 b7\n\nmood: dark, tense, exotic, brooding, urgent\ngenres: metal, flamenco, soundtrack, dark folk, prog
-~~locrian~1 b2 b3 4 b5 b6 b7\n\nmood: unstable, eerie, dissonant, anxious, unresolved\ngenres: metal, avant-garde, experimental, fusion, soundtrack
-~~harmonic minor~1 2 b3 4 5 b6 7\n\nmood: dramatic, exotic, tense, regal, intense\ngenres: classical, neoclassical metal, film, jazz, world fusion
-~~melodic minor~1 2 b3 4 5 6 7\n\nmood: sophisticated, sleek, tense, modern, bittersweet\ngenres: jazz, fusion, film, progressive rock, contemporary classical
-~~super locrian~1 b2 #2 3 b5 #5 b7\n\nmood: altered, edgy, dissonant, unstable, aggressive\ngenres: jazz, fusion, modern classical, experimental, soundtrack
-~~neapolitan min~1 b2 b3 4 5 b6 7\n\nmood: dark, noble, dramatic, mysterious, old-world\ngenres: classical, film, neoclassical, gothic, metal
-~~neapolitan maj~1 b2 b3 4 5 6 7\n\nmood: bright but tense, ceremonial, mysterious, stately, exotic\ngenres: classical, film, prog, neoclassical, soundtrack
-~~enigmatic minor~1 b2 b3 #4 5 #6 7\n\nmood: cryptic, haunting, unstable, cerebral, suspenseful\ngenres: film, avant-garde, progressive rock, experimental, modern classical
-~~enigmatic~1 b2 3 #4 #5 #6 7\n\nmood: mysterious, surreal, floating, ornate, enigmatic\ngenres: film, classical, avant-garde, ambient, soundtrack
-~~composite~1 b2 3 #4 5 b6 7\n\nmood: uncanny, angular, tense, futuristic, dramatic\ngenres: fusion, experimental, soundtrack, prog, modern classical
-~~bhairav~1 b2 3 4 5 b6 7\n\nmood: austere, devotional, grave, majestic, meditative\ngenres: Indian classical, world, soundtrack, drone, fusion
-~~hungarian min~1 2 b3 #4 5 b6 7\n\nmood: fiery, dramatic, exotic, dark, virtuosic\ngenres: gypsy jazz, metal, classical, soundtrack, prog
-~~minor gypsy~1 b2 3 4 5 b6 b7\n\nmood: exotic, spicy, tense, earthy, dramatic\ngenres: flamenco, Balkan, folk, jazz, soundtrack
-~~persian~1 b2 3 4 b5 b6 7\n\nmood: exotic, dark, sharp, tense, regal\ngenres: Middle Eastern-inspired, metal, soundtrack, fusion, world
-~~asc minor~1 2 b3 4 5 6 7\n\nmood: lyrical, modern, upward, polished, bittersweet\ngenres: jazz, fusion, film, progressive rock, contemporary classical
-~~diminished~1 b2 #2 3 #4 5 6 b7\n\nmood: symmetrical, tense, restless, angular, suspenseful\ngenres: jazz, metal, fusion, soundtrack, experimental
-~~whole-half~1 2 b3 4 b5 b6 6 7\n\nmood: symmetrical, eerie, slick, tense, chromatic\ngenres: jazz, fusion, soundtrack, metal, experimental
-~~whole tone~1 2 3 #4 #5 #6\n\nmood: dreamy, floating, ambiguous, impressionistic, surreal\ngenres: impressionism, jazz, film, ambient, fusion
-~~minor blues~1 b3 4 b5 5 b7\n\nmood: bluesy, raw, soulful, gritty, expressive\ngenres: blues, rock, jazz, funk, soul
-~~minor penta~1 b3 4 5 b7\n\nmood: bluesy, soulful, earthy, tense but open\ngenres: blues, rock, R&B, soul, funk, gospel
-~~major penta~1 2 3 5 6\n\nmood: bright, open, uplifting, simple, melodic\ngenres: folk, country, pop, gospel, rock
-~~dominant sus~1 2 4 5 6 b7\n\nmood: open, suspended, earthy, funky, unresolved\ngenres: funk, jazz, gospel, rock, fusion
-~~bebop locrian~1 2 b3 4 b5 b6 b7 7\n\nmood: slippery, tense, jazzy, chromatic, agile\ngenres: bebop, jazz, fusion, modern swing, improvisation
-~~bebop dom~1 2 3 4 5 6 b7 7\n\nmood: lively, bluesy, jazzy, driving, playful\ngenres: bebop, jazz, swing, blues, funk
-~~bebop major~1 2 3 4 5 b6 6 7\n\nmood: bright, urbane, jazzy, nimble, sophisticated\ngenres: bebop, jazz, swing, big band, musical theater
-~~hirajoshi~1 2 b3 5 b6\n\nmood: sparse, wistful, delicate, introspective, haunting\ngenres: Japanese folk, soundtrack, ambient, post-rock, world
-~~in-sen~1 b2 4 5 b7\n\nmood: dark, sparse, meditative, mysterious, tense\ngenres: Japanese traditional, ambient, soundtrack, experimental, world
-~~iwato~1 b2 4 b5 b7\n\nmood: austere, eerie, hollow, minimal, suspenseful\ngenres: Japanese traditional, soundtrack, ambient, horror, experimental
-~~kumoi~1 2 b3 5 6\n\nmood: gentle, wistful, airy, reflective, pastoral\ngenres: Japanese folk, ambient, soundtrack, new age, world
-~~pelog~1 b2 b3 3 5 b6\n\nmood: earthy, ceremonial, unusual, colorful, hypnotic\ngenres: gamelan, world, experimental, soundtrack, ambient
-~~spanish~1 b2 b3 3 4 #4 b6 b7\n\nmood: fiery, dramatic, passionate, tense, exotic\ngenres: flamenco, Latin, metal, jazz, soundtrack
-~~chromatic~1 b2 2 b3 3 4 b5 5 #5 6 b7 7\n\nmood: tense, fluid, disorienting, colorful, unrestricted\ngenres: jazz, experimental, modern classical, film, avant-garde
+~~ionian~1 2 3 4 5 6 7
+~~aeolian~1 2 b3 4 5 b6 b7
+~~dorian~1 2 b3 4 5 6 b7
+~~mixolydian~1 2 3 4 5 6 b7
+~~lydian~1 2 3 #4 5 6 7
+~~phrygian~1 b2 b3 4 5 b6 b7
+~~locrian~1 b2 b3 4 b5 b6 b7
+~~harmonic minor~1 2 b3 4 5 b6 7
+~~melodic minor~1 2 b3 4 5 6 7
+~~super locrian~1 b2 #2 3 b5 #5 b7
+~~neapolitan min~1 b2 b3 4 5 b6 7
+~~neapolitan maj~1 b2 b3 4 5 6 7
+~~enigmatic minor~1 b2 b3 #4 5 #6 7
+~~enigmatic~1 b2 3 #4 #5 #6 7
+~~composite~1 b2 3 #4 5 b6 7
+~~bhairav~1 b2 3 4 5 b6 7
+~~hungarian min~1 2 b3 #4 5 b6 7
+~~minor gypsy~1 b2 3 4 5 b6 b7
+~~persian~1 b2 3 4 b5 b6 7
+~~asc minor~1 2 b3 4 5 6 7
+~~diminished~1 b2 #2 3 #4 5 6 b7
+~~whole-half~1 2 b3 4 b5 b6 6 7
+~~whole tone~1 2 3 #4 #5 #6
+~~minor blues~1 b3 4 b5 5 b7
+~~minor penta~1 b3 4 5 b7
+~~major penta~1 2 3 5 6
+~~dominant sus~1 2 4 5 6 b7
+~~bebop locrian~1 2 b3 4 b5 b6 b7 7
+~~bebop dom~1 2 3 4 5 6 b7 7
+~~bebop major~1 2 3 4 5 b6 6 7
+~~hirajoshi~1 2 b3 5 b6
+~~in-sen~1 b2 4 5 b7
+~~iwato~1 b2 4 b5
+~~kumoi~1 2 b3 5 6
+~~pelog~1 b2 b3 3 5 b6
+~~spanish~1 b2 b3 3 4 #4 b6 b7
+~~chromatic~1 b2 2 b3 3 4 b5 5 #5 6 b7 7
 ~degree~
 ~intonation~which method to use to tune the scale
 ~PPO~pitches per octave

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2003,8 +2003,8 @@ scale~controls the global scale used by various modules
 ~~super locrian~1 b2 #2 3 b5 #5 b7\n\nmood: altered, edgy, dissonant, unstable, aggressive\ngenres: jazz, fusion, modern classical, experimental, soundtrack
 ~~neapolitan min~1 b2 b3 4 5 b6 7\n\nmood: dark, noble, dramatic, mysterious, old-world\ngenres: classical, film, neoclassical, gothic, metal
 ~~neapolitan maj~1 b2 b3 4 5 6 7\n\nmood: bright but tense, ceremonial, mysterious, stately, exotic\ngenres: classical, film, prog, neoclassical, soundtrack
-~~enigmatic minor~1 b2 b3 #4 5 b7 7\n\nmood: cryptic, haunting, unstable, cerebral, suspenseful\ngenres: film, avant-garde, progressive rock, experimental, modern classical
-~~enigmatic~1 b2 3 #4 #5 b7 7\n\nmood: mysterious, surreal, floating, ornate, enigmatic\ngenres: film, classical, avant-garde, ambient, soundtrack
+~~enigmatic minor~1 b2 b3 #4 5 #6 7\n\nmood: cryptic, haunting, unstable, cerebral, suspenseful\ngenres: film, avant-garde, progressive rock, experimental, modern classical
+~~enigmatic~1 b2 3 #4 #5 #6 7\n\nmood: mysterious, surreal, floating, ornate, enigmatic\ngenres: film, classical, avant-garde, ambient, soundtrack
 ~~composite~1 b2 3 #4 5 b6 7\n\nmood: uncanny, angular, tense, futuristic, dramatic\ngenres: fusion, experimental, soundtrack, prog, modern classical
 ~~bhairav~1 b2 3 4 5 b6 7\n\nmood: austere, devotional, grave, majestic, meditative\ngenres: Indian classical, world, soundtrack, drone, fusion
 ~~hungarian min~1 2 b3 #4 5 b6 7\n\nmood: fiery, dramatic, exotic, dark, virtuosic\ngenres: gypsy jazz, metal, classical, soundtrack, prog
@@ -2013,7 +2013,7 @@ scale~controls the global scale used by various modules
 ~~asc minor~1 2 b3 4 5 6 7\n\nmood: lyrical, modern, upward, polished, bittersweet\ngenres: jazz, fusion, film, progressive rock, contemporary classical
 ~~diminished~1 b2 #2 3 #4 5 6 b7\n\nmood: symmetrical, tense, restless, angular, suspenseful\ngenres: jazz, metal, fusion, soundtrack, experimental
 ~~whole-half~1 2 b3 4 b5 b6 6 7\n\nmood: symmetrical, eerie, slick, tense, chromatic\ngenres: jazz, fusion, soundtrack, metal, experimental
-~~whole tone~1 2 3 #4 #5 b7\n\nmood: dreamy, floating, ambiguous, impressionistic, surreal\ngenres: impressionism, jazz, film, ambient, fusion
+~~whole tone~1 2 3 #4 #5 #6\n\nmood: dreamy, floating, ambiguous, impressionistic, surreal\ngenres: impressionism, jazz, film, ambient, fusion
 ~~minor blues~1 b3 4 b5 5 b7\n\nmood: bluesy, raw, soulful, gritty, expressive\ngenres: blues, rock, jazz, funk, soul
 ~~minor penta~1 b3 4 5 b7\n\nmood: bluesy, soulful, earthy, tense but open\ngenres: blues, rock, R&B, soul, funk, gospel
 ~~major penta~1 2 3 5 6\n\nmood: bright, open, uplifting, simple, melodic\ngenres: folk, country, pop, gospel, rock
@@ -2026,7 +2026,7 @@ scale~controls the global scale used by various modules
 ~~iwato~1 b2 4 b5 b7\n\nmood: austere, eerie, hollow, minimal, suspenseful\ngenres: Japanese traditional, soundtrack, ambient, horror, experimental
 ~~kumoi~1 2 b3 5 6\n\nmood: gentle, wistful, airy, reflective, pastoral\ngenres: Japanese folk, ambient, soundtrack, new age, world
 ~~pelog~1 b2 b3 3 5 b6\n\nmood: earthy, ceremonial, unusual, colorful, hypnotic\ngenres: gamelan, world, experimental, soundtrack, ambient
-~~spanish~1 b2 b3 3 4 b5 b6 b7\n\nmood: fiery, dramatic, passionate, tense, exotic\ngenres: flamenco, Latin, metal, jazz, soundtrack
+~~spanish~1 b2 b3 3 4 #4 b6 b7\n\nmood: fiery, dramatic, passionate, tense, exotic\ngenres: flamenco, Latin, metal, jazz, soundtrack
 ~~chromatic~1 b2 2 b3 3 4 b5 5 #5 6 b7 7\n\nmood: tense, fluid, disorienting, colorful, unrestricted\ngenres: jazz, experimental, modern classical, film, avant-garde
 ~degree~
 ~intonation~which method to use to tune the scale

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1998,13 +1998,13 @@ splitter~splits a stereo signal into two mono signals, or duplicates a mono sign
 scale~controls the global scale used by various modules
 ~root~root note of the scale
 ~scale~which set of notes to use
-~~ionian~1 2 3 4 5 6 7
-~~aeolian~1 2 b3 4 5 b6 b7
-~~dorian~1 2 b3 4 5 6 b7
-~~mixolydian~1 2 3 4 5 6 b7
-~~lydian~1 2 3 #4 5 6 7
-~~phrygian~1 b2 b3 4 5 b6 b7
-~~locrian~1 b2 b3 4 b5 b6 b7
+~~ionian~1 2 3 4 5 6 7 (major)
+~~aeolian~1 2 b3 4 5 b6 b7 (minor)
+~~dorian~1 2 b3 4 5 6 b7 (minor)
+~~mixolydian~1 2 3 4 5 6 b7 (major)
+~~lydian~1 2 3 #4 5 6 7 (major)
+~~phrygian~1 b2 b3 4 5 b6 b7 (minor)
+~~locrian~1 b2 b3 4 b5 b6 b7 (minor)
 ~~harmonic minor~1 2 b3 4 5 b6 7
 ~~melodic minor~1 2 b3 4 5 6 7
 ~~super locrian~1 b2 #2 3 b5 #5 b7

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1991,6 +1991,43 @@ splitter~splits a stereo signal into two mono signals, or duplicates a mono sign
 scale~controls the global scale used by various modules
 ~root~root note of the scale
 ~scale~which set of notes to use
+~~ionian~1 2 3 4 5 6 7\n\nmood: bright, balanced, clear, confident, resolved\ngenres: pop, classical, folk, singer-songwriter, country
+~~aeolian~1 2 b3 4 5 b6 b7\n\nmood: dark, melancholic, natural, introspective, emotional\ngenres: rock, pop, metal, folk, indie
+~~dorian~1 2 b3 4 5 6 b7\n\nmood: moody, cool, soulful, hopeful, grooving\ngenres: jazz, funk, soul, modal rock, fusion
+~~mixolydian~1 2 3 4 5 6 b7\n\nmood: bluesy, open, earthy, relaxed, anthemic\ngenres: rock, blues, funk, folk, jam bands
+~~lydian~1 2 3 #4 5 6 7\n\nmood: bright, dreamy, floating, expansive, magical\ngenres: film, fusion, progressive rock, ambient, jazz
+~~phrygian~1 b2 b3 4 5 b6 b7\n\nmood: dark, tense, exotic, brooding, urgent\ngenres: metal, flamenco, soundtrack, dark folk, prog
+~~locrian~1 b2 b3 4 b5 b6 b7\n\nmood: unstable, eerie, dissonant, anxious, unresolved\ngenres: metal, avant-garde, experimental, fusion, soundtrack
+~~harmonic minor~1 2 b3 4 5 b6 7\n\nmood: dramatic, exotic, tense, regal, intense\ngenres: classical, neoclassical metal, film, jazz, world fusion
+~~melodic minor~1 2 b3 4 5 6 7\n\nmood: sophisticated, sleek, tense, modern, bittersweet\ngenres: jazz, fusion, film, progressive rock, contemporary classical
+~~super locrian~1 b2 #2 3 b5 #5 b7\n\nmood: altered, edgy, dissonant, unstable, aggressive\ngenres: jazz, fusion, modern classical, experimental, soundtrack
+~~neapolitan min~1 b2 b3 4 5 b6 7\n\nmood: dark, noble, dramatic, mysterious, old-world\ngenres: classical, film, neoclassical, gothic, metal
+~~neapolitan maj~1 b2 b3 4 5 6 7\n\nmood: bright but tense, ceremonial, mysterious, stately, exotic\ngenres: classical, film, prog, neoclassical, soundtrack
+~~enigmatic minor~1 b2 b3 #4 5 b7 7\n\nmood: cryptic, haunting, unstable, cerebral, suspenseful\ngenres: film, avant-garde, progressive rock, experimental, modern classical
+~~enigmatic~1 b2 3 #4 #5 b7 7\n\nmood: mysterious, surreal, floating, ornate, enigmatic\ngenres: film, classical, avant-garde, ambient, soundtrack
+~~composite~1 b2 3 #4 5 b6 7\n\nmood: uncanny, angular, tense, futuristic, dramatic\ngenres: fusion, experimental, soundtrack, prog, modern classical
+~~bhairav~1 b2 3 4 5 b6 7\n\nmood: austere, devotional, grave, majestic, meditative\ngenres: Indian classical, world, soundtrack, drone, fusion
+~~hungarian min~1 2 b3 #4 5 b6 7\n\nmood: fiery, dramatic, exotic, dark, virtuosic\ngenres: gypsy jazz, metal, classical, soundtrack, prog
+~~minor gypsy~1 b2 3 4 5 b6 b7\n\nmood: exotic, spicy, tense, earthy, dramatic\ngenres: flamenco, Balkan, folk, jazz, soundtrack
+~~persian~1 b2 3 4 b5 b6 7\n\nmood: exotic, dark, sharp, tense, regal\ngenres: Middle Eastern-inspired, metal, soundtrack, fusion, world
+~~asc minor~1 2 b3 4 5 6 7\n\nmood: lyrical, modern, upward, polished, bittersweet\ngenres: jazz, fusion, film, progressive rock, contemporary classical
+~~diminished~1 b2 #2 3 #4 5 6 b7\n\nmood: symmetrical, tense, restless, angular, suspenseful\ngenres: jazz, metal, fusion, soundtrack, experimental
+~~whole-half~1 2 b3 4 b5 b6 6 7\n\nmood: symmetrical, eerie, slick, tense, chromatic\ngenres: jazz, fusion, soundtrack, metal, experimental
+~~whole tone~1 2 3 #4 #5 b7\n\nmood: dreamy, floating, ambiguous, impressionistic, surreal\ngenres: impressionism, jazz, film, ambient, fusion
+~~minor blues~1 b3 4 b5 5 b7\n\nmood: bluesy, raw, soulful, gritty, expressive\ngenres: blues, rock, jazz, funk, soul
+~~minor penta~1 b3 4 5 b7\n\nmood: bluesy, soulful, earthy, tense but open\ngenres: blues, rock, R&B, soul, funk, gospel
+~~major penta~1 2 3 5 6\n\nmood: bright, open, uplifting, simple, melodic\ngenres: folk, country, pop, gospel, rock
+~~dominant sus~1 2 4 5 6 b7\n\nmood: open, suspended, earthy, funky, unresolved\ngenres: funk, jazz, gospel, rock, fusion
+~~bebop locrian~1 2 b3 4 b5 b6 b7 7\n\nmood: slippery, tense, jazzy, chromatic, agile\ngenres: bebop, jazz, fusion, modern swing, improvisation
+~~bebop dom~1 2 3 4 5 6 b7 7\n\nmood: lively, bluesy, jazzy, driving, playful\ngenres: bebop, jazz, swing, blues, funk
+~~bebop major~1 2 3 4 5 b6 6 7\n\nmood: bright, urbane, jazzy, nimble, sophisticated\ngenres: bebop, jazz, swing, big band, musical theater
+~~hirajoshi~1 2 b3 5 b6\n\nmood: sparse, wistful, delicate, introspective, haunting\ngenres: Japanese folk, soundtrack, ambient, post-rock, world
+~~in-sen~1 b2 4 5 b7\n\nmood: dark, sparse, meditative, mysterious, tense\ngenres: Japanese traditional, ambient, soundtrack, experimental, world
+~~iwato~1 b2 4 b5 b7\n\nmood: austere, eerie, hollow, minimal, suspenseful\ngenres: Japanese traditional, soundtrack, ambient, horror, experimental
+~~kumoi~1 2 b3 5 6\n\nmood: gentle, wistful, airy, reflective, pastoral\ngenres: Japanese folk, ambient, soundtrack, new age, world
+~~pelog~1 b2 b3 3 5 b6\n\nmood: earthy, ceremonial, unusual, colorful, hypnotic\ngenres: gamelan, world, experimental, soundtrack, ambient
+~~spanish~1 b2 b3 3 4 b5 b6 b7\n\nmood: fiery, dramatic, passionate, tense, exotic\ngenres: flamenco, Latin, metal, jazz, soundtrack
+~~chromatic~1 b2 2 b3 3 4 b5 5 #5 6 b7 7\n\nmood: tense, fluid, disorienting, colorful, unrestricted\ngenres: jazz, experimental, modern classical, film, avant-garde
 ~degree~
 ~intonation~which method to use to tune the scale
 ~PPO~pitches per octave


### PR DESCRIPTION
Currently, dropdown elements are used extensively throughout Bespoke. Despite this, they are seriously lacking in capabilities, Internally, a label only supports a name, and an index.

This is plenty for most option selections, but comes with several problems:

- Tooltips on labels aren't really supported, so the tooltip renderer is required to give special treatment to the dropdowns in the top bar. As well the EffectChain.
- If a developer wishes to provide non-module related tooltip information, this is currently not possible without significant workarounds. If they want their tooltips localized that's yet another problem.
- If a developer wishes to draw custom graphics on an item. This is not possible.
- Localized labels aren't a thing either, to the best of my knowledge. (Edit: Out of scope for this PR)

I intend to extend dropdowns so they can reasonably handle all of these cases while still largely using the same API.

I opted to create this PR early as a draft since it has far-reaching effects, and early notes would be greatly appreciated.

### Update 1

- Localization is seriously lacking in Bespoke. But I personally consider this out of scope for this PR. So my thoughts are to just extend the current tokenizer so dropdowns can support custom unique tooltips for now. This goes along the custom tooltip addresses, which will patch out the unique support required for dropdowns that spawn elements.

### Update 2

Should be ready for review.

Furthermore, I added two examples of the new features in use. As seen here:

https://github.com/user-attachments/assets/f0b2ac91-174b-4000-a60b-8efd9acc6664

Additionally, the effectchain, and the topbar now use the new API, with no need for hardcoded behavior in the ModularSynth.cpp file.

The new label struct:
```
struct DropdownListElement
{
   std::string mLabel; //Text on the dropdown
   int mValue{ 0 }; //Value of the dropdown, used for array indexing and modulation.

   //Custom tooltip address. Format: "module~control~subcontrol"
   //Can point to any tooltip in the tooltip files.
   //By default displays this if present --> thismodule~thisdropdown~thislabel~tooltip. If not present, no tooltip is shown.
   std::string mTooltipAddress{};

   float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
   DropdownRenderFn mRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
   std::string mRenderArgs; //Stores an argument for use. Sent into the function call.
};
```
Tokenizer also has been expanded to accept four tokens at once. Used for this. While I personally would like to do more, it's out of scope for this PR.


### Update 3

New format:

```
typedef void (*DropdownRenderFn)(ofRectangle renderRect, bool isHovering, bool isDrawingOnPopup, const DropdownListElement& element);
struct DropdownListElement
{
   std::string mLabel; //Text on the dropdown
   int mValue{ 0 }; //Value of the dropdown, used for array indexing and modulation.

   //Custom tooltip address. Format: "module~control~subcontrol"
   //Can point to any tooltip in the tooltip files.
   //By default displays this if present --> thismodule~thisdropdown~thislabel~tooltip. If not present, no tooltip is shown.
   std::string mTooltipAddress{};

   float mReservedWidth{ 0.0f }; //Try to reserve additional space for special rendering
   DropdownRenderFn mCustomRenderer{ nullptr }; //If set, will call this function on draw, for custom rendering. Still draws the label.
   void* mArgs {nullptr}; //Optionally include an argument for rendering work.
};
```