### PR TITLE
Improvement: Unlimited Envelopes + Envelope Editor Rework  - Design Proposal, Discussion Welcome!

### DIFF
--- a/Source/ADSR.cpp
+++ b/Source/ADSR.cpp
@@ -29,7 +29,7 @@
 #include "FileStream.h"
 #include "SynthGlobals.h"
 
-void ::ADSR::Set(float a, float d, float s, float r, float h /*=-1*/)
+void ADSR::Set(float a, float d, float s, float r, float h /*=-1*/)
 {
    mStages[0].target = 1;
    mStages[0].time = MAX(a, 1);
@@ -46,7 +46,7 @@ void ::ADSR::Set(float a, float d, float s, float r, float h /*=-1*/)
    mHasSustainStage = true;
 }
 
-void ::ADSR::Set(const ADSR& other)
+void ADSR::Set(const ADSR& other)
 {
    for (int i = 0; i < other.mNumStages; ++i)
       mStages[i] = other.mStages[i];
@@ -57,19 +57,19 @@ void ::ADSR::Set(const ADSR& other)
    mFreeReleaseLevel = other.mFreeReleaseLevel;
 }
 
-void ::ADSR::Start(double time, float target, float a, float d, float s, float r, float timeScale /*=1*/, float curve /*=0*/)
+void ADSR::Start(double time, float target, float a, float d, float s, float r, float timeScale /*=1*/, float curve /*=0*/)
 {
    Set(a, d, s, r);
    Start(time, target, timeScale, curve);
 }
 
-void ::ADSR::Start(double time, float target, const ADSR& adsr, float timeScale /*=1*/, float curve /*=0*/)
+void ADSR::Start(double time, float target, const ADSR& adsr, float timeScale /*=1*/, float curve /*=0*/)
 {
    Set(adsr);
    Start(time, target, timeScale, curve);
 }
 
-void ::ADSR::Start(double time, float target, float timeScale /*=1*/, float curve /*=0*/)
+void ADSR::Start(double time, float target, float timeScale /*=1*/, float curve /*=0*/)
 {
    mEvents[mNextEventPointer].Reset();
    mEvents[mNextEventPointer].mStartBlendFromValue = Value(time);
@@ -93,7 +93,7 @@ void ::ADSR::Start(double time, float target, float timeScale /*=1*/, float curv
    }
 }
 
-void ::ADSR::Stop(double time, bool warn /*= true*/)
+void ADSR::Stop(double time, bool warn /*= true*/)
 {
    EventInfo* e = GetEvent(time);
 
@@ -108,7 +108,7 @@ void ::ADSR::Stop(double time, bool warn /*= true*/)
    e->mStopTime = time;
 }
 
-::ADSR::EventInfo* ::ADSR::GetEvent(double time)
+ADSR::EventInfo* ADSR::GetEvent(double time)
 {
    int ret = 0;
    double latestTime = -1;
@@ -123,7 +123,7 @@ void ::ADSR::Stop(double time, bool warn /*= true*/)
    return &(mEvents[ret]);
 }
 
-const ::ADSR::EventInfo* ::ADSR::GetEventConst(double time) const
+const ADSR::EventInfo* ADSR::GetEventConst(double time) const
 {
    int ret = 0;
    double latestTime = -1;
@@ -138,13 +138,13 @@ const ::ADSR::EventInfo* ::ADSR::GetEventConst(double time) const
    return &(mEvents[ret]);
 }
 
-float ::ADSR::Value(double time) const
+float ADSR::Value(double time) const
 {
    const EventInfo* e = GetEventConst(time);
    return Value(time, e);
 }
 
-float ::ADSR::Value(double time, const EventInfo* e) const
+float ADSR::Value(double time, const EventInfo* e) const
 {
    float stageStartValue;
    double stageStartTime;
@@ -175,20 +175,20 @@ float ::ADSR::Value(double time, const EventInfo* e) const
    return ofLerp(stageStartValue, mStages[stage].target * e->mMult, lerp);
 }
 
-float ::ADSR::GetStageTimeScale(int stage) const
+float ADSR::GetStageTimeScale(int stage) const
 {
    if (stage >= mNumStages - 1)
       return 1;
    return mTimeScale;
 }
 
-int ::ADSR::GetStage(double time, double& stageStartTimeOut) const
+int ADSR::GetStage(double time, double& stageStartTimeOut) const
 {
    const EventInfo* e = GetEventConst(time);
    return GetStage(time, stageStartTimeOut, e);
 }
 
-int ::ADSR::GetStage(double time, double& stageStartTimeOut, const EventInfo* e) const
+int ADSR::GetStage(double time, double& stageStartTimeOut, const EventInfo* e) const
 {
    if (e->mStartTime < 0)
       return mNumStages;
@@ -216,7 +216,7 @@ int ::ADSR::GetStage(double time, double& stageStartTimeOut, const EventInfo* e)
    return stage;
 }
 
-bool ::ADSR::IsDone(double time) const
+bool ADSR::IsDone(double time) const
 {
    double dummy;
    return GetStage(time, dummy) == mNumStages;
@@ -227,7 +227,7 @@ namespace
    const int kSaveStateRev = 1;
 }
 
-void ::ADSR::SaveState(FileStreamOut& out)
+void ADSR::SaveState(FileStreamOut& out)
 {
    out << kSaveStateRev;
 
@@ -248,7 +248,7 @@ void ::ADSR::SaveState(FileStreamOut& out)
    out << mTimeScale;
 }
 
-void ::ADSR::LoadState(FileStreamIn& in)
+void ADSR::LoadState(FileStreamIn& in)
 {
    int rev;
    in >> rev;

--- a/Source/ADSRDisplay.cpp
+++ b/Source/ADSRDisplay.cpp
@@ -35,7 +35,7 @@
 
 ADSRDisplay::DisplayMode ADSRDisplay::sDisplayMode = ADSRDisplay::kDisplayEnvelope;
 
-ADSRDisplay::ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y, int w, int h, ::ADSR* adsr)
+ADSRDisplay::ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y, int w, int h, ADSR* adsr)
 : mWidth(w)
 , mHeight(h)
 , mAdsr(adsr)
@@ -337,7 +337,7 @@ void ADSRDisplay::SetMaxTime(float maxTime)
    }
 }
 
-void ADSRDisplay::SetADSR(::ADSR* adsr)
+void ADSRDisplay::SetADSR(ADSR* adsr)
 {
    mAdsr = adsr;
    if (mASlider)

--- a/Source/ADSRDisplay.h
+++ b/Source/ADSRDisplay.h
@@ -36,7 +36,7 @@ class EnvelopeEditor;
 class ADSRDisplay : public IUIControl, public IControlVisualizer
 {
 public:
-   ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y, int w, int h, ::ADSR* adsr);
+   ADSRDisplay(IDrawableModule* owner, const char* name, int x, int y, int w, int h, ADSR* adsr);
    void Render() override;
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
@@ -46,8 +46,8 @@ public:
    float GetMaxTime() const { return mMaxTime; }
    float& GetMaxTime() { return mMaxTime; }
    void SetMaxTime(float maxTime);
-   void SetADSR(::ADSR* adsr);
-   ::ADSR* GetADSR() { return mAdsr; }
+   void SetADSR(ADSR* adsr);
+   ADSR* GetADSR() { return mAdsr; }
    void SpawnEnvelopeEditor();
    bool IsSliderControl() override { return false; }
    bool IsButtonControl() override { return false; }
@@ -118,9 +118,9 @@ private:
    float mVol{ 1 };
    float mMaxTime{ 1000 };
    bool mClick{ false };
-   ::ADSR* mAdsr;
+   ADSR* mAdsr;
    ofVec2f mClickStart;
-   ::ADSR mClickAdsr;
+   ADSR mClickAdsr;
    float mClickLength{ 1000 };
    bool mHighlighted{ false };
    FloatSlider* mASlider{ nullptr };

--- a/Source/CurveLooper.h
+++ b/Source/CurveLooper.h
@@ -87,7 +87,7 @@ private:
    DropdownList* mLengthSelector{ nullptr };
    PatchCableSource* mControlCable{ nullptr };
    EnvelopeControl mEnvelopeControl{ ofVec2f(5, 25), ofVec2f(mWidth - 10, mHeight - 30), nullptr };
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    ClickButton* mRandomizeButton{ nullptr };
    float mFreeRate{ 1000 };
    FloatSlider* mFreeRateSlider{ nullptr };

--- a/Source/DrumPlayer.h
+++ b/Source/DrumPlayer.h
@@ -253,7 +253,7 @@ private:
       ModulationChain* mPitchBend{ nullptr };
 
       bool mUseEnvelope{ false };
-      ::ADSR mEnvelope{ 1, 1, 1, 100 };
+      ADSR mEnvelope{ 1, 1, 1, 100 };
       float mEnvelopeLength{ 200 };
       float mPan{ 0 };
       int mWiden{ 0 };

--- a/Source/DrumSynth.h
+++ b/Source/DrumSynth.h
@@ -90,8 +90,8 @@ private:
 
       EnvOscillator mTone{ OscillatorType::kOsc_Sin };
       EnvOscillator mNoise{ OscillatorType::kOsc_Random };
-      ::ADSR mFreqAdsr;
-      ::ADSR mFilterAdsr;
+      ADSR mFreqAdsr;
+      ADSR mFilterAdsr;
       float mFreqMax{ 150 };
       float mFreqMin{ 10 };
       float mVol{ 0 };

--- a/Source/EnvOscillator.h
+++ b/Source/EnvOscillator.h
@@ -40,18 +40,18 @@ public:
    void SetADSR(float a, float d, float s, float r) { mAdsr.Set(a, d, s, r); }
    void Start(double time, float target) { mAdsr.Start(time, target); }
    void Start(double time, float target, float a, float d, float s, float r) { mAdsr.Start(time, target, a, d, s, r); }
-   void Start(double time, float target, ::ADSR adsr)
+   void Start(double time, float target, ADSR adsr)
    {
       mAdsr.Set(adsr);
       mAdsr.Start(time, target);
    }
    void Stop(double time) { mAdsr.Stop(time); }
    float Audio(double time, float phase);
-   ::ADSR* GetADSR() { return &mAdsr; }
+   ADSR* GetADSR() { return &mAdsr; }
    void SetPulseWidth(float width) { mOsc.SetPulseWidth(width); }
    Oscillator mOsc{ OscillatorType::kOsc_Sin };
 
 private:
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    float mPulseWidth{ .5 };
 };

--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -186,7 +186,7 @@ void EnvelopeControl::OnClicked(float x, float y, bool right)
                mAdsr->GetStageData(mHighlightPoint + 1).time += mAdsr->GetStageData(mHighlightPoint).time;
                mAdsr->GetStageData(mHighlightPoint + 1).curve = mAdsr->GetStageData(mHighlightPoint).curve;
 
-               for (int i = mHighlightPoint; i < mAdsr->GetNumStages(); ++i)
+               for (int i = mHighlightPoint; i < mAdsr->GetNumStages() - 1; ++i)
                {
                   mAdsr->GetStageData(i).time = mAdsr->GetStageData(i + 1).time;
                   mAdsr->GetStageData(i).target = mAdsr->GetStageData(i + 1).target;
@@ -206,29 +206,36 @@ void EnvelopeControl::OnClicked(float x, float y, bool right)
                mHighlightCurve != -1 &&
                (mClickStart - ofVec2f(x, y)).lengthSquared() < pointClickRadius * pointClickRadius)
       {
-         float clickTime = GetTimeForX(x);
-         if (clickTime > GetPreSustainTime())
-            clickTime -= GetReleaseTime() - GetPreSustainTime();
-
-         for (int i = mAdsr->GetNumStages(); i > mHighlightCurve; --i)
+         if (mAdsr->GetNumStages() >= MAX_ADSR_STAGES)
          {
-            mAdsr->GetStageData(i).time = mAdsr->GetStageData(i - 1).time;
-            mAdsr->GetStageData(i).target = mAdsr->GetStageData(i - 1).target;
-            mAdsr->GetStageData(i).curve = mAdsr->GetStageData(i - 1).curve;
+            mHighlightCurve = -1;
          }
-         float priorStageTimes = 0;
-         for (int i = 0; i < mHighlightCurve; ++i)
-            priorStageTimes += mAdsr->GetStageData(i).time;
-         mAdsr->GetStageData(mHighlightCurve).time = clickTime - priorStageTimes;
-         mAdsr->GetStageData(mHighlightCurve).target = GetValueForY(y);
-         mAdsr->GetStageData(mHighlightCurve + 1).time -= mAdsr->GetStageData(mHighlightCurve).time;
-         mAdsr->SetNumStages(mAdsr->GetNumStages() + 1);
-         if (mAdsr->GetHasSustainStage() &&
-             mHighlightCurve <= mAdsr->GetSustainStage())
-            mAdsr->SetSustainStage(mAdsr->GetSustainStage() + 1);
+         else
+         {
+            float clickTime = GetTimeForX(x);
+            if (clickTime > GetPreSustainTime())
+               clickTime -= GetReleaseTime() - GetPreSustainTime();
 
-         mHighlightPoint = mHighlightCurve;
-         mHighlightCurve = -1;
+            for (int i = mAdsr->GetNumStages(); i > mHighlightCurve; --i)
+            {
+               mAdsr->GetStageData(i).time = mAdsr->GetStageData(i - 1).time;
+               mAdsr->GetStageData(i).target = mAdsr->GetStageData(i - 1).target;
+               mAdsr->GetStageData(i).curve = mAdsr->GetStageData(i - 1).curve;
+            }
+            float priorStageTimes = 0;
+            for (int i = 0; i < mHighlightCurve; ++i)
+               priorStageTimes += mAdsr->GetStageData(i).time;
+            mAdsr->GetStageData(mHighlightCurve).time = clickTime - priorStageTimes;
+            mAdsr->GetStageData(mHighlightCurve).target = GetValueForY(y);
+            mAdsr->GetStageData(mHighlightCurve + 1).time -= mAdsr->GetStageData(mHighlightCurve).time;
+            mAdsr->SetNumStages(mAdsr->GetNumStages() + 1);
+            if (mAdsr->GetHasSustainStage() &&
+                mHighlightCurve <= mAdsr->GetSustainStage())
+               mAdsr->SetSustainStage(mAdsr->GetSustainStage() + 1);
+
+            mHighlightPoint = mHighlightCurve;
+            mHighlightCurve = -1;
+         }
       }
 
       mLastClickTime = gTime;
@@ -508,7 +515,10 @@ void EnvelopeEditor::DrawModule()
       }
 
       //move release level checkbox below final stage control
-      ofVec2f pos = mStageControls[numStages - 1].mSustainCheckbox->GetPosition(K(local));
+      int lastVisibleStage = numStages - 1;
+      if (lastVisibleStage >= (int)mStageControls.size())
+         lastVisibleStage = (int)mStageControls.size() - 1;
+      ofVec2f pos = mStageControls[lastVisibleStage].mSustainCheckbox->GetPosition(K(local));
       mFreeReleaseLevelCheckbox->SetPosition(pos.x, pos.y);
    }
 }

--- a/Source/EnvelopeEditor.cpp
+++ b/Source/EnvelopeEditor.cpp
@@ -305,8 +305,8 @@ void EnvelopeControl::MouseMoved(float x, float y)
    {
       if (mHighlightPoint != -1)
       {
-         ::ADSR::Stage& stage = mAdsr->GetStageData(mHighlightPoint);
-         ::ADSR::Stage& originalStage = mClickAdsr.GetStageData(mHighlightPoint);
+         ADSR::Stage& stage = mAdsr->GetStageData(mHighlightPoint);
+         ADSR::Stage& originalStage = mClickAdsr.GetStageData(mHighlightPoint);
 
          float maxLength = 10000;
          if (mFixedLengthMode)
@@ -338,8 +338,8 @@ void EnvelopeControl::MouseMoved(float x, float y)
 
       if (mHighlightCurve != -1)
       {
-         ::ADSR::Stage& stage = mAdsr->GetStageData(mHighlightCurve);
-         ::ADSR::Stage& originalStage = mClickAdsr.GetStageData(mHighlightCurve);
+         ADSR::Stage& stage = mAdsr->GetStageData(mHighlightCurve);
+         ADSR::Stage& originalStage = mClickAdsr.GetStageData(mHighlightCurve);
          ofVec2f sliderLimits{ -2, 2 };
          if (mEditor)
             sliderLimits = mEditor->GetCurveSliderExtentsForStage(mHighlightCurve);

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -136,5 +136,5 @@ private:
    FloatSlider* mMaxSustainSlider{ nullptr };
    Checkbox* mFreeReleaseLevelCheckbox{ nullptr };
    PatchCableSource* mTargetCable{ nullptr };
-   std::array<StageControls, 10> mStageControls{};
+   std::array<StageControls, MAX_ADSR_STAGES> mStageControls{};
 };

--- a/Source/EnvelopeEditor.h
+++ b/Source/EnvelopeEditor.h
@@ -39,7 +39,7 @@ class EnvelopeControl
 {
 public:
    EnvelopeControl(ofVec2f position, ofVec2f dimensions, EnvelopeEditor* editor);
-   void SetADSR(::ADSR* adsr) { mAdsr = adsr; }
+   void SetADSR(ADSR* adsr) { mAdsr = adsr; }
    void OnClicked(float x, float y, bool right);
    void MouseMoved(float x, float y);
    void MouseReleased();
@@ -63,8 +63,8 @@ private:
    ofVec2f mPosition;
    ofVec2f mDimensions;
    EnvelopeEditor* mEditor{ nullptr };
-   ::ADSR* mAdsr{ nullptr };
-   ::ADSR mClickAdsr;
+   ADSR* mAdsr{ nullptr };
+   ADSR mClickAdsr;
    bool mClick{ false };
    ofVec2f mClickStart;
    float mViewLength{ 2000 };

--- a/Source/EnvelopeModulator.cpp
+++ b/Source/EnvelopeModulator.cpp
@@ -68,7 +68,7 @@ void EnvelopeModulator::DrawModule()
    mAdsrDisplay->Draw();
 }
 
-void EnvelopeModulator::Start(double time, const ::ADSR& adsr)
+void EnvelopeModulator::Start(double time, const ADSR& adsr)
 {
    mAdsr.Start(time, 1, adsr);
 }

--- a/Source/EnvelopeModulator.h
+++ b/Source/EnvelopeModulator.h
@@ -50,7 +50,7 @@ public:
    bool ShouldSuppressAutomaticOutputCable() override { return true; }
    void DrawModule() override;
 
-   void Start(double time, const ::ADSR& adsr);
+   void Start(double time, const ADSR& adsr);
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
    bool IsEnabled() const override { return mEnabled; }
 
@@ -93,7 +93,7 @@ private:
    float mHeight{ 122 };
 
    ADSRDisplay* mAdsrDisplay{ nullptr };
-   ::ADSR mAdsr{ 10, 100, .5, 100 };
+   ADSR mAdsr{ 10, 100, .5, 100 };
 
    bool mUseVelocity{ false };
    Checkbox* mUseVelocityCheckbox{ nullptr };

--- a/Source/FMVoice.h
+++ b/Source/FMVoice.h
@@ -35,11 +35,11 @@ class IDrawableModule;
 class FMVoiceParams : public IVoiceParams
 {
 public:
-   ::ADSR mOscADSRParams;
-   ::ADSR mModIdxADSRParams;
-   ::ADSR mHarmRatioADSRParams;
-   ::ADSR mModIdxADSRParams2;
-   ::ADSR mHarmRatioADSRParams2;
+   ADSR mOscADSRParams;
+   ADSR mModIdxADSRParams;
+   ADSR mHarmRatioADSRParams;
+   ADSR mModIdxADSRParams2;
+   ADSR mHarmRatioADSRParams2;
    float mModIdx{ 0 };
    float mHarmRatio{ 1 };
    float mModIdx2{ 0 };
@@ -69,10 +69,10 @@ private:
    EnvOscillator mOsc{ kOsc_Sin };
    float mHarmPhase{ 0 };
    EnvOscillator mHarm{ kOsc_Sin };
-   ::ADSR mModIdx;
+   ADSR mModIdx;
    float mHarmPhase2{ 0 };
    EnvOscillator mHarm2{ kOsc_Sin };
-   ::ADSR mModIdx2;
+   ADSR mModIdx2;
    FMVoiceParams* mVoiceParams{ nullptr };
    IDrawableModule* mOwner;
 };

--- a/Source/KarplusStrongVoice.h
+++ b/Source/KarplusStrongVoice.h
@@ -90,7 +90,7 @@ private:
 
    float mOscPhase{ 0 };
    EnvOscillator mOsc{ OscillatorType::kOsc_Sin };
-   ::ADSR mEnv;
+   ADSR mEnv;
    KarplusStrongVoiceParams* mVoiceParams{ nullptr };
    RollingBuffer mBuffer;
    float mFilteredSample{ 0 };

--- a/Source/ModulatorCurve.h
+++ b/Source/ModulatorCurve.h
@@ -88,7 +88,7 @@ private:
    EnvelopeControl mEnvelopeControl{ ofVec2f(3, 19), ofVec2f(100, 100), nullptr };
    static constexpr float kMinWidth = 106;
    static constexpr float kMinHeight = 121;
-   ::ADSR mAdsr;
+   ADSR mAdsr;
 
    FloatSlider* mInputSlider{ nullptr };
 };

--- a/Source/MultitapDelay.h
+++ b/Source/MultitapDelay.h
@@ -120,7 +120,7 @@ private:
       ModulationChain* mPressure{ nullptr };
       ModulationChain* mModWheel{ nullptr };
 
-      ::ADSR mADSR{ 100, 0, 1, 100 };
+      ADSR mADSR{ 100, 0, 1, 100 };
 
       MultitapDelay* mOwner{ nullptr };
    };

--- a/Source/Pumper.h
+++ b/Source/Pumper.h
@@ -70,7 +70,7 @@ private:
    FloatSlider* mCurveSlider{ nullptr };
    FloatSlider* mAttackSlider{ nullptr };
 
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    NoteInterval mInterval{ NoteInterval::kInterval_4n };
    DropdownList* mIntervalSelector{ nullptr };
    float mLastValue{ 0 };

--- a/Source/Razor.h
+++ b/Source/Razor.h
@@ -91,7 +91,7 @@ private:
 
    float mVol{ .05 };
    float mPhase{ 0 };
-   ::ADSR mAdsr[NUM_PARTIALS]{};
+   ADSR mAdsr[NUM_PARTIALS]{};
    float mAmp[NUM_PARTIALS]{};
    float mPhases[NUM_PARTIALS]{};
    float mDetune[NUM_PARTIALS]{};

--- a/Source/SamplePlayer.h
+++ b/Source/SamplePlayer.h
@@ -170,7 +170,7 @@ private:
    ChannelBuffer mDrawBuffer{ 0 };
 
    NoteInputBuffer mNoteInputBuffer;
-   ::ADSR mAdsr{ 10, 1, 1, 10 };
+   ADSR mAdsr{ 10, 1, 1, 10 };
 
    struct SampleCuePoint
    {

--- a/Source/SampleVoice.h
+++ b/Source/SampleVoice.h
@@ -35,7 +35,7 @@ class IDrawableModule;
 class SampleVoiceParams : public IVoiceParams
 {
 public:
-   ::ADSR mAdsr{ 1, 0, 1, 10 };
+   ADSR mAdsr{ 1, 0, 1, 10 };
    float mVol{ 1 };
    Sample* mSample{ nullptr };
    float mSamplePitch{ 48 };
@@ -62,7 +62,7 @@ public:
    bool IsDone(double time) override;
 
 private:
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    SampleVoiceParams* mVoiceParams{};
    float mPos{ 0 };
    IDrawableModule* mOwner{ nullptr };

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -682,7 +682,7 @@ namespace
 {
    void StartEnvelope(EnvelopeModulator& envelope, double time, const std::vector< std::tuple<float,float> >& stages)
    {
-      ::ADSR adsr;
+      ADSR adsr;
       adsr.SetNumStages((int)stages.size());
       adsr.GetHasSustainStage() = false;
       for (int i=0; i<adsr.GetNumStages() && i<(int)stages.size(); ++i)

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -120,7 +120,7 @@ private:
 
       float mGain{ 0 };
 
-      ::ADSR mADSR{ 100, 0, 1, 100 };
+      ADSR mADSR{ 100, 0, 1, 100 };
       Granulator mGranulator;
       SeaOfGrain* mOwner{ nullptr };
    };

--- a/Source/SingleOscillatorVoice.h
+++ b/Source/SingleOscillatorVoice.h
@@ -38,7 +38,7 @@
 class OscillatorVoiceParams : public IVoiceParams
 {
 public:
-   ::ADSR mAdsr{ 10, 0, 1, 10 };
+   ADSR mAdsr{ 10, 0, 1, 10 };
    float mVol{ .25 };
    float mPulseWidth{ .5 };
    Oscillator::SyncMode mSyncMode{ Oscillator::SyncMode::None };
@@ -56,7 +56,7 @@ public:
    float mFilterCutoffMax{ SINGLEOSCILLATOR_NO_CUTOFF };
    float mFilterCutoffMin{ 10 };
    float mFilterQ{ float(sqrt(2) / 2) };
-   ::ADSR mFilterAdsr{ 1, 0, 1, 1000 };
+   ADSR mFilterAdsr{ 1, 0, 1, 1000 };
 
    float mVelToVolume{ 1.0 };
    float mVelToEnvelope{ 0 };
@@ -99,10 +99,10 @@ private:
       float mCurrentPhaseInc{ 0 };
    };
    OscData mOscData[kMaxUnison];
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    OscillatorVoiceParams* mVoiceParams{ nullptr };
 
-   ::ADSR mFilterAdsr;
+   ADSR mFilterAdsr;
    BiquadFilter mFilterLeft;
    BiquadFilter mFilterRight;
    bool mUseFilter{ false };

--- a/Source/VelocityCurve.h
+++ b/Source/VelocityCurve.h
@@ -70,7 +70,7 @@ private:
    void OnClicked(float x, float y, bool right) override;
 
    EnvelopeControl mEnvelopeControl{ ofVec2f{ 3, 3 }, ofVec2f{ 100, 100 }, nullptr };
-   ::ADSR mAdsr;
+   ADSR mAdsr;
    float mLastInputVelocity{ 0 };
    double mLastInputTime{ -9999 };
 };


### PR DESCRIPTION
For several years now, envelopes have effectively been a handful of points away from crashing Bespoke. A hard cap is set at 20, but oversights mean that it can crash at around 10 points. This is an extremely small limit for an envelope system. When it doesn't crash, it malfunctions and corrupts the current envelope.

My personal motivations are as an enthusiast in heavy EDM music. Half-broken envelopes are a key issue to resolve. As the envelopes common in that style can be highly detailed and of great length. Things not quite possible in current versions.

Therefore the goal of this PR is to resolve these issues, while reworking the envelope editor to cleanly support envelopes of arbitrary size.

### Obstacles
- Performance, as the audio thread is of key importance. Minimizing costs in every occasion is paramount, as lag is directly reflected on the user's work.
- The limits are hardcoded, and several parts of both the ADSR system and the envelope editor work on this assumption, IE, pre-making arrays of UI elements for all 20. This needs to be reworked.
- The Envelope editor is largely built on the assumption of only having 20 points maximum. Any point added, it draws additional point editors. While this is effective in small limits. It gets increasingly unworkable for dense workspaces, even with a scrollbar. 

### Goals
- Fixing crashes (largely done by @vrozkovec 's #2012 )
- Outright removal of the ADSR/Envelope limit
- Minimizing performance costs of this improvement by making use of hybrid stack/heap iteration techniques.
- Overhauling the envelope editor so it cleanly supports arbitrarily dense envelopes.
- Maintaining save compatibility.

### Design
<img width="1289" height="499" alt="Designer_jCLg6VQbeB" src="https://github.com/user-attachments/assets/84312f42-78b9-413b-b056-c9ee1a08ec2e" />

- Now by default, editable/patchable options are only available if the user double-clicks or shift-clicks a point on the envelope. Expanding the workspace vertically and drawing editable controls.
- "Open-menu" points have their IDs highlighted in yellow for contrast.
- These controls can be deleted by either removing the point itself, or click the (X) on the menu.
- Their IDs are ordered by horizontal left-to-right position, incremented for every  "open-menu" point. This id will shift if a new point is place in between or before.
- Point feedback is drawn on the bottom left. (Or top left if the user is hovering that area), they are only drawn if the user is hovering over a line or a point.
- Scrollbars are drawn if the amount of information necessary exceeds the workspace. This avoid having to resize the workspace to edit previously offscreen options.
- Additional highlights for user feedback will be drawn when applicable.

As this is a WIP project with far-reaching effects. Therefore I have opted to once again, perform an early draft pull request. Early feedback is welcome as it helps to narrow and focus development to have a more useful envelope system for everyone.