### PR TITLE
Feature: Unsafe Cable Connections

### DIFF
--- a/Source/IUIControl.cpp
+++ b/Source/IUIControl.cpp
@@ -29,6 +29,7 @@
 #include "ModularSynth.h"
 #include "PatchCable.h"
 #include "Push2Control.h"
+#include "UserPrefs.h"
 
 //static
 IUIControl* IUIControl::sLastHoveredUIControl = nullptr;
@@ -117,9 +118,28 @@ void IUIControl::DrawHover(float x, float y, float w, float h)
    }
    else if (gHoveredUIControl == this && IKeyboardFocusListener::GetActiveKeyboardFocus() == nullptr && TheSynth->GetGroupSelectedModules().empty())
    {
+      double time = gTime / 1000.0f;
       ofPushStyle();
       ofNoFill();
-      ofSetColor(0, 255, 255, 255);
+      if (mHoverWarningFlashTime < time)
+      {
+         if (mCableTargetable == 1)
+            ofSetColor(0, 255, 255, 255);
+         else
+         {
+            ofSetColor(255, 255, 255, 255);
+         }
+      }
+      else
+      {
+         int iTime = static_cast<int>(time * 4);
+
+         iTime = iTime % 2;
+         if (iTime == 0)
+            ofSetColor(255, 255, 255, 0);
+         else
+            ofSetColor(mHoverWarningColour);
+      }
       ofRect(x, y, w, h, 4);
       ofPopStyle();
    }
@@ -161,7 +181,10 @@ void IUIControl::DrawPatchCableHover()
       ofPushStyle();
       ofNoFill();
       ofSetLineWidth(1.5f);
-      ofSetColor(255, 0, 255, 200);
+      if (mCableTargetable == 1)
+         ofSetColor(255, 0, 255, 200);
+      else
+         ofSetColor(255, 115, 0, 235);
       ofRect(mX, mY, w, h);
       ofPopStyle();
    }
@@ -169,9 +192,7 @@ void IUIControl::DrawPatchCableHover()
 
 bool IUIControl::CanBeTargetedBy(PatchCableSource* source) const
 {
-   if (!mCableTargetable)
-      return false;
-   if (GetNoHover())
+   if (!GetCableTargetable())
       return false;
    return source->GetConnectionType() == kConnectionType_Modulator || source->GetConnectionType() == kConnectionType_ValueSetter || source->GetConnectionType() == kConnectionType_UIControl;
 }
@@ -184,6 +205,20 @@ void IUIControl::StartBeacon()
       moduleParent->StartBeacon();
 }
 
+bool IUIControl::GetCableTargetable() const
+{
+   if (!UserPrefs.unsafe_cable_connections.Get())
+   {
+      if (!mCableTargetable || GetNoHover())
+         return false;
+   }
+   else
+   {
+      if (mCableTargetable == -1)
+         return false;
+   }
+   return true;
+}
 void IUIControl::PositionTo(IUIControl* anchor, AnchorDirection direction)
 {
    ofRectangle rect = anchor->GetRect(true);
@@ -407,4 +442,9 @@ void IUIControl::DestroyCablesTargetingControls(std::vector<IUIControl*> control
    }
    for (const auto cable : cablesToDestroy)
       cable->Destroy(false);
+}
+void IUIControl::TriggerHoverWarning(ofColor colour, float seconds)
+{
+   mHoverWarningColour = colour;
+   mHoverWarningFlashTime = gTime / 1000.0 + static_cast<double>(seconds);
 }

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -87,7 +87,7 @@ public:
    //Enable/disable cable patching on compatible cables
    //Can be user overridden by ticking unsafe_cable_patching
    void SetCableTargetable(bool targetable) { mCableTargetable = static_cast<int>(targetable); }
-   void SetCableTargetableBlockedHard() { mCableTargetable = -1; } //Disallows cable patching, even unsafe.
+   void SetCableTargetableBlockHard() { mCableTargetable = -1; } //Disallows cable patching, even unsafe.
    bool GetCableTargetable() const;
 
    void SetNoHover(bool noHover) { mNoHover = noHover; }

--- a/Source/IUIControl.h
+++ b/Source/IUIControl.h
@@ -27,6 +27,7 @@
 
 #include "IClickable.h"
 #include "SynthGlobals.h"
+#include "UserPrefs.h"
 
 class FileStreamIn;
 class FileStreamOut;
@@ -82,8 +83,13 @@ public:
    virtual void Halve() {}
    virtual void ResetToOriginal() {}
    virtual void Increment(float amount) {}
-   void SetCableTargetable(bool targetable) { mCableTargetable = targetable; }
-   bool GetCableTargetable() const { return mCableTargetable; }
+
+   //Enable/disable cable patching on compatible cables
+   //Can be user overridden by ticking unsafe_cable_patching
+   void SetCableTargetable(bool targetable) { mCableTargetable = static_cast<int>(targetable); }
+   void SetCableTargetableBlockedHard() { mCableTargetable = -1; } //Disallows cable patching, even unsafe.
+   bool GetCableTargetable() const;
+
    void SetNoHover(bool noHover) { mNoHover = noHover; }
    virtual bool GetNoHover() const { return mNoHover; }
    virtual bool AttemptTextInput() { return false; }
@@ -116,6 +122,7 @@ public:
 
    static void DestroyCablesTargetingControls(std::vector<IUIControl*> controls);
 
+   void TriggerHoverWarning(ofColor colour, float seconds);
    virtual void SaveState(FileStreamOut& out) = 0;
    virtual void LoadState(FileStreamIn& in, bool shouldSetValue = true) = 0;
 
@@ -126,13 +133,16 @@ protected:
    ~IUIControl() override;
 
    int mRemoteControlCount{ 0 };
-   bool mCableTargetable{ true };
+   int mCableTargetable{ 1 }; //-1 = hard blocked | 0 = unsafe patching required | 1 = allowed
    bool mNoHover{ false };
    bool mShouldSaveState{ true };
    bool mSnapshotHighlight{ false };
    bool mIsDeleted{ false };
    IControlVisualizer* mControlVisualizer{ nullptr };
    bool mIsRandomizable{ true };
+
+   double mHoverWarningFlashTime{ 0 };
+   ofColor mHoverWarningColour{ ofColor(255, 0, 0, 255) };
 
    static IUIControl* sLastHoveredUIControl;
    static bool sLastUIHoverWasSetManually;

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -104,15 +104,21 @@ void ModuleSaveDataPanel::ReloadSaveData()
 
    mNameEntry = new TextEntry(this, "", x, y, 27, mSaveModule->NameMutable());
    mNameEntry->SetNoHover(true);
+   mNameEntry->SetCableTargetableBlockedHard();
+
    mSaveDataControls.push_back(mNameEntry);
    y += kItemSpacing;
 
    mPresetFileSelector = new DropdownList(this, "preset", x, y, &mPresetFileIndex, 150);
    mPresetFileSelector->SetNoHover(true);
+   mPresetFileSelector->SetCableTargetableBlockedHard();
    mPresetFileSelector->SetUnknownItemString("[none]");
+
    mSaveDataControls.push_back(mPresetFileSelector);
+
    mSavePresetAsButton = new ClickButton(this, "save as", mPresetFileSelector, kAnchor_Right);
    mSavePresetAsButton->SetNoHover(true);
+   mSavePresetAsButton->SetCableTargetableBlockedHard();
    mSaveDataControls.push_back(mSavePresetAsButton);
    y += kItemSpacing;
 
@@ -176,7 +182,10 @@ void ModuleSaveDataPanel::ReloadSaveData()
       }
 
       if (control != nullptr)
+      {
          control->SetNoHover(true);
+         control->SetCableTargetableBlockedHard();
+      }
       mSaveDataControls.push_back(control);
       y += kItemSpacing;
    }
@@ -184,11 +193,13 @@ void ModuleSaveDataPanel::ReloadSaveData()
    y += 6;
    mApplyButton = new ClickButton(this, "apply", x, y);
    mApplyButton->SetNoHover(true);
+   mApplyButton->SetCableTargetableBlockedHard();
    mSaveDataControls.push_back(mApplyButton);
    if (mSaveModule->CanBeDeleted())
    {
       mDeleteButton = new ClickButton(this, "delete module", x + 50, y);
       mDeleteButton->SetNoHover(true);
+      mDeleteButton->SetCableTargetableBlockedHard();
       mSaveDataControls.push_back(mDeleteButton);
    }
    y += kItemSpacing;
@@ -197,6 +208,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
    {
       mDrawDebugCheckbox = new Checkbox(this, "draw debug", x, y, &mSaveModule->mDrawDebug);
       mDrawDebugCheckbox->SetNoHover(true);
+      mDrawDebugCheckbox->SetCableTargetableBlockedHard();
       mSaveDataControls.push_back(mDrawDebugCheckbox);
       y += kItemSpacing;
    }
@@ -206,6 +218,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
    {
       mResetSequencerButton = new ClickButton(this, "resume self-advance mode", x, y);
       mResetSequencerButton->SetNoHover(true);
+      mResetSequencerButton->SetCableTargetableBlockedHard();
       mSaveDataControls.push_back(mResetSequencerButton);
       y += kItemSpacing;
    }

--- a/Source/ModuleSaveDataPanel.cpp
+++ b/Source/ModuleSaveDataPanel.cpp
@@ -104,21 +104,21 @@ void ModuleSaveDataPanel::ReloadSaveData()
 
    mNameEntry = new TextEntry(this, "", x, y, 27, mSaveModule->NameMutable());
    mNameEntry->SetNoHover(true);
-   mNameEntry->SetCableTargetableBlockedHard();
+   mNameEntry->SetCableTargetableBlockHard();
 
    mSaveDataControls.push_back(mNameEntry);
    y += kItemSpacing;
 
    mPresetFileSelector = new DropdownList(this, "preset", x, y, &mPresetFileIndex, 150);
    mPresetFileSelector->SetNoHover(true);
-   mPresetFileSelector->SetCableTargetableBlockedHard();
+   mPresetFileSelector->SetCableTargetableBlockHard();
    mPresetFileSelector->SetUnknownItemString("[none]");
 
    mSaveDataControls.push_back(mPresetFileSelector);
 
    mSavePresetAsButton = new ClickButton(this, "save as", mPresetFileSelector, kAnchor_Right);
    mSavePresetAsButton->SetNoHover(true);
-   mSavePresetAsButton->SetCableTargetableBlockedHard();
+   mSavePresetAsButton->SetCableTargetableBlockHard();
    mSaveDataControls.push_back(mSavePresetAsButton);
    y += kItemSpacing;
 
@@ -184,7 +184,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
       if (control != nullptr)
       {
          control->SetNoHover(true);
-         control->SetCableTargetableBlockedHard();
+         control->SetCableTargetableBlockHard();
       }
       mSaveDataControls.push_back(control);
       y += kItemSpacing;
@@ -193,13 +193,13 @@ void ModuleSaveDataPanel::ReloadSaveData()
    y += 6;
    mApplyButton = new ClickButton(this, "apply", x, y);
    mApplyButton->SetNoHover(true);
-   mApplyButton->SetCableTargetableBlockedHard();
+   mApplyButton->SetCableTargetableBlockHard();
    mSaveDataControls.push_back(mApplyButton);
    if (mSaveModule->CanBeDeleted())
    {
       mDeleteButton = new ClickButton(this, "delete module", x + 50, y);
       mDeleteButton->SetNoHover(true);
-      mDeleteButton->SetCableTargetableBlockedHard();
+      mDeleteButton->SetCableTargetableBlockHard();
       mSaveDataControls.push_back(mDeleteButton);
    }
    y += kItemSpacing;
@@ -208,7 +208,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
    {
       mDrawDebugCheckbox = new Checkbox(this, "draw debug", x, y, &mSaveModule->mDrawDebug);
       mDrawDebugCheckbox->SetNoHover(true);
-      mDrawDebugCheckbox->SetCableTargetableBlockedHard();
+      mDrawDebugCheckbox->SetCableTargetableBlockHard();
       mSaveDataControls.push_back(mDrawDebugCheckbox);
       y += kItemSpacing;
    }
@@ -218,7 +218,7 @@ void ModuleSaveDataPanel::ReloadSaveData()
    {
       mResetSequencerButton = new ClickButton(this, "resume self-advance mode", x, y);
       mResetSequencerButton->SetNoHover(true);
-      mResetSequencerButton->SetCableTargetableBlockedHard();
+      mResetSequencerButton->SetCableTargetableBlockHard();
       mSaveDataControls.push_back(mResetSequencerButton);
       y += kItemSpacing;
    }

--- a/Source/Slider.cpp
+++ b/Source/Slider.cpp
@@ -304,7 +304,23 @@ void FloatSlider::OnClicked(float x, float y, bool right)
 {
    if (right)
    {
-      DisplayLFOControl();
+      if (GetCableTargetable())
+      {
+         if (mCableTargetable == 1)
+            DisplayLFOControl();
+         else if (mCableTargetable == 0)
+         {
+            double rTime = gTime / 1000.0;
+            if (mHoverWarningFlashTime < rTime)
+            {
+               TriggerHoverWarning(ofColor(255, 115, 0, 255), 2);
+            }
+            else
+            {
+               DisplayLFOControl();
+            }
+         } //No warning whatsoever is displayed if hard blocked.
+      }
       return;
    }
 

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -290,6 +290,11 @@ public:
    float LastTargetFramerate;
    ofxJSONElement mUserPrefsFile;
    std::vector<UserPref*> mUserPrefs;
+
+   ///////////////
+   /// GENERAL ///
+   ///////////////
+
    UserPrefDropdownString devicetype{ "devicetype", "auto", 200, UserPrefCategory::General };
    UserPrefDropdownString audio_output_device{ "audio_output_device", "auto", 350, UserPrefCategory::General };
    UserPrefDropdownString audio_input_device{ "audio_input_device", "none", 350, UserPrefCategory::General };
@@ -314,6 +319,7 @@ public:
    UserPrefBool show_tooltips_on_load{ "show_tooltips_on_load", true, UserPrefCategory::General };
    UserPrefBool show_welcome_screen{ "show_welcome_screen", true, UserPrefCategory::General };
    UserPrefBool show_minimap{ "show_minimap", false, UserPrefCategory::General };
+   UserPrefBool unsafe_cable_connections{ "unsafe_cable_connections", false, UserPrefCategory::General };
    UserPrefFloat minimap_margin{ "minimap_margin", 10, 0, 50, UserPrefCategory::General };
    UserPrefDropdownString minimap_corner{ "minimap_corner", "Top right", 150, UserPrefCategory::General };
    UserPrefBool immediate_paste{ "immediate_paste", false, UserPrefCategory::General };
@@ -324,6 +330,10 @@ public:
    UserPrefTextEntryInt max_output_channels{ "max_output_channels", 16, 1, 1024, 5, UserPrefCategory::General };
    UserPrefTextEntryInt max_input_channels{ "max_input_channels", 16, 1, 1024, 5, UserPrefCategory::General };
    UserPrefString plugin_preference_order{ "plugin_preference_order", "VST3;VST;AudioUnit;LV2", 70, UserPrefCategory::General };
+
+   ////////////////
+   /// GRAPHICS ///
+   ////////////////
 
    UserPrefBool draw_background_lissajous{ "draw_background_lissajous", true, UserPrefCategory::Graphics };
    UserPrefBool background_lissajous_autocorrelate{ "background_lissajous_autocorrelate", true, UserPrefCategory::Graphics };
@@ -350,6 +360,10 @@ public:
 #endif
       -100, 100, 5, UserPrefCategory::Graphics
    };
+
+   /////////////
+   /// PATHS ///
+   /////////////
 
    UserPrefString recordings_path{ "recordings_path", "recordings/", 70, UserPrefCategory::Paths };
    UserPrefString samples_path{ "samples_path", "samples/", 70, UserPrefCategory::Paths };

--- a/Source/UserPrefs.h
+++ b/Source/UserPrefs.h
@@ -318,8 +318,8 @@ public:
    UserPrefBool autosave{ "autosave", false, UserPrefCategory::General };
    UserPrefBool show_tooltips_on_load{ "show_tooltips_on_load", true, UserPrefCategory::General };
    UserPrefBool show_welcome_screen{ "show_welcome_screen", true, UserPrefCategory::General };
-   UserPrefBool show_minimap{ "show_minimap", false, UserPrefCategory::General };
    UserPrefBool unsafe_cable_connections{ "unsafe_cable_connections", false, UserPrefCategory::General };
+   UserPrefBool show_minimap{ "show_minimap", false, UserPrefCategory::General };
    UserPrefFloat minimap_margin{ "minimap_margin", 10, 0, 50, UserPrefCategory::General };
    UserPrefDropdownString minimap_corner{ "minimap_corner", "Top right", 150, UserPrefCategory::General };
    UserPrefBool immediate_paste{ "immediate_paste", false, UserPrefCategory::General };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2034,6 +2034,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~autosave~should autosave be enabled on startup
 ~show_tooltips_on_load~should tooltips be enabled on startup
 ~show_minimap~should the minimap be displayed (requires restart)
+~unsafe_cable_connections~allow cable connections on several controls that are not meant to be patched.\n\nunsafe controls are highlighted in red when patching.\n\nWARNING: may cause crashes if misused.
 ~show_welcome_screen~should we show the welcome screen when you first open bespoke?
 ~immediate_paste~when enabled, pasting values on UI controls will apply immediately instead of requiring you to press enter
 ~record_buffer_length_minutes~length of always-on recording buffer for "write audio" button in the title bar (requires restart)

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -2034,7 +2034,7 @@ userprefseditor~settings for bespoke. some settings changes require bespoke to b
 ~autosave~should autosave be enabled on startup
 ~show_tooltips_on_load~should tooltips be enabled on startup
 ~show_minimap~should the minimap be displayed (requires restart)
-~unsafe_cable_connections~allow cable connections on several controls that are not meant to be patched.\n\nunsafe controls are highlighted in red when patching.\n\nWARNING: may cause crashes if misused.
+~unsafe_cable_connections~allow cable connections on several controls that are not meant to be patched.\n\nunsafe controls are highlighted in orange when patching.\n\nWARNING: may cause crashes if misused.
 ~show_welcome_screen~should we show the welcome screen when you first open bespoke?
 ~immediate_paste~when enabled, pasting values on UI controls will apply immediately instead of requiring you to press enter
 ~record_buffer_length_minutes~length of always-on recording buffer for "write audio" button in the title bar (requires restart)


### PR DESCRIPTION
Currently, there is an oversight in cable patching the float slider. In that elements that are marked as noHover, and can't be currently connected, still allow this.

While I personally prodded on interest to have this oversight patched, an user indicated that in certain cases, users may desire the upmost freedom to undergo any risk for whatever they're messing with at the time. Even if the use of that option is not typically intended by the developer.

So, in tandem, I thought about officially supporting this. By the means of adding a dedicated unsafe cable connections mode, which allows even expressly disallowed connections.

<img width="1226" height="589" alt="BespokeSynth_AOQOBxpPVe" src="https://github.com/user-attachments/assets/3538590b-f3ab-4a90-99c1-a8a5c6b2d298" />

This PR adds a couple things:

- Adds an option for unsafe_cable_connections
- This allows for connecting cables even when 'unsafe' as well as formally allowing unsafe LFO attachments.
- Unsafe controls are drawn in orange, and attached LFO attempts flash briefly before allowing with another click.
- These interactions are only visible when unsafe is on. If off, the default, is to not render any hover highlights as previous.
- Affects disallowed connections via GetCableTargetable() and GetNotHover
- Unpatchable IUIcontrols hover in white.

However, since this allows the user to do things which may cause instability. I opted to add the following for more extreme cases:
- An extension to IUIControl, which allows the developer to flag controls using SetCableTargetableBlockHard().
- This overrides all unsafe cable patching options. And is meant for cases where misuse may cause instability, crashing or corruption.
- The ModuleSaveDataPanel has this enabled by default.