### PR TITLE
Optimization: Sea of Grain

### DIFF
--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -143,10 +143,15 @@ void Granulator::QueueGrainSpawn(double spawnTime)
    mQueuedGrainSpawnTimes.enqueue(spawnTime);
 }
 
-void Granulator::Draw(float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain)
+void Granulator::Draw(float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain) const
 {
+   if (gain <= 0)
+      return;
+   ofPushStyle();
+   ofFill();
    for (int i = 0; i < MAX_GRAINS; ++i)
       mGrains[i].DrawGrain(i, x, y, w, h, bufferStart, viewLength, bufferLength, gain, this);
+   ofPopStyle();
 }
 
 void Granulator::DrawWindow(float x, float y, float w, float h)
@@ -266,16 +271,17 @@ void Grain::Process(double time, ChannelBuffer* buffer, int bufferLength, float*
    }
 }
 
-void Grain::DrawGrain(int idx, float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain, const Granulator* granulator)
+void Grain::DrawGrain(int idx, float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain, const Granulator* granulator) const
 {
    float a = fmod((mPos - bufferStart), bufferLength) / viewLength;
    if (a < 0 || a > 1)
       return;
-   ofPushStyle();
-   ofFill();
+
    double phase = (std::clamp(gTime, mStartTime, mEndTime) - mStartTime) * mStartToEndInv;
    float alpha = Granulator::GetWindow(granulator->mWindowType, granulator->mWindowShape, granulator->mGrainLengthMs, phase) * gain;
-   ofSetColor(255, 0, 0, alpha * 255);
-   ofCircle(x + a * w, y + mDrawPos * h, MAX(3, h / MAX_GRAINS / 2));
-   ofPopStyle();
+   if (alpha >= 0)
+   {
+      ofSetColor(255, 0, 0, alpha * 255);
+      ofCircle(x + a * w, y + mDrawPos * h, MAX(3, h / MAX_GRAINS / 2));
+   }
 }

--- a/Source/Granulator.cpp
+++ b/Source/Granulator.cpp
@@ -279,7 +279,7 @@ void Grain::DrawGrain(int idx, float x, float y, float w, float h, int bufferSta
 
    double phase = (std::clamp(gTime, mStartTime, mEndTime) - mStartTime) * mStartToEndInv;
    float alpha = Granulator::GetWindow(granulator->mWindowType, granulator->mWindowShape, granulator->mGrainLengthMs, phase) * gain;
-   if (alpha >= 0)
+   if (alpha > 0)
    {
       ofSetColor(255, 0, 0, alpha * 255);
       ofCircle(x + a * w, y + mDrawPos * h, MAX(3, h / MAX_GRAINS / 2));

--- a/Source/Granulator.h
+++ b/Source/Granulator.h
@@ -47,7 +47,7 @@ class Grain
 public:
    void Spawn(double time, double pos, float speedMult, float lengthInMs, float vol, float width);
    void Process(double time, ChannelBuffer* buffer, int bufferLength, float* output, const Granulator* granulator);
-   void DrawGrain(int idx, float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain, const Granulator* granulator);
+   void DrawGrain(int idx, float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain, const Granulator* granulator) const;
    void Clear() { mVol = 0; }
 
 private:
@@ -66,7 +66,7 @@ class Granulator
 public:
    Granulator();
    void ProcessFrame(double time, ChannelBuffer* buffer, int bufferLength, double offset, float speed, float* output);
-   void Draw(float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain);
+   void Draw(float x, float y, float w, float h, int bufferStart, int viewLength, int bufferLength, float gain) const;
    void DrawWindow(float x, float y, float w, float h);
    void Reset();
    void ClearGrains();

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -50,7 +50,11 @@ SeaOfGrain::SeaOfGrain()
       mMPEVoices[i].mOwner = this;
 
    for (int i = 0; i < kNumManualVoices; ++i)
+   {
       mManualVoices[i].mOwner = this;
+      if (i >= 1)
+         mManualVoices[i].mGranulator.mSpawnGrains = false;
+   }
 }
 
 void SeaOfGrain::CreateUIControls()
@@ -109,6 +113,8 @@ void SeaOfGrain::CreateUIControls()
       mManualVoices[i].mOctaveCheckbox = new Checkbox(this, ("octaves " + ofToString(i + 1)).c_str(), mManualVoices[i].mSpacingRandomizeSlider, kAnchor_Below, &mManualVoices[i].mGranulator.mOctaves);
       mManualVoices[i].mWidthSlider = new FloatSlider(this, ("width " + ofToString(i + 1)).c_str(), mManualVoices[i].mOctaveCheckbox, kAnchor_Below, 120, 15, &mManualVoices[i].mGranulator.mWidth, 0, 1);
       mManualVoices[i].mPanSlider = new FloatSlider(this, ("pan " + ofToString(i + 1)).c_str(), mManualVoices[i].mWidthSlider, kAnchor_Below, 120, 15, &mManualVoices[i].mPan, -1, 1);
+
+      RefreshOptionRenderStates(i);
    }
 }
 
@@ -180,6 +186,7 @@ void SeaOfGrain::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
 
+
    mLoadButton->Draw();
    mRecordInputCheckbox->Draw();
    mVolumeSlider->Draw();
@@ -212,6 +219,7 @@ void SeaOfGrain::DrawModule()
       ofTranslate(mBufferX, mBufferY);
       ofPushStyle();
 
+
       if (mHasRecordedInput)
       {
          mRecordBuffer.Draw(0, 0, mBufferW, mBufferH, mDisplayLength * gSampleRate);
@@ -224,6 +232,7 @@ void SeaOfGrain::DrawModule()
          mSample->LockDataMutex(false);
       }
 
+
       ofPushStyle();
       ofFill();
       for (int i = 0; i < mKeyboardNumPitches; ++i)
@@ -233,10 +242,17 @@ void SeaOfGrain::DrawModule()
       }
       ofPopStyle();
 
+
       for (int i = 0; i < kNumMPEVoices; ++i)
+      {
          mMPEVoices[i].Draw(mBufferW, mBufferH);
+      }
+
       for (int i = 0; i < kNumManualVoices; ++i)
-         mManualVoices[i].Draw(i, mBufferW, mBufferH);
+      {
+         if (mManualVoices[i].mGranulator.mSpawnGrains)
+            mManualVoices[i].Draw(i, mBufferW, mBufferH);
+      }
 
       ofPopStyle();
       ofPopMatrix();
@@ -369,6 +385,7 @@ void SeaOfGrain::LoadFile()
 
 void SeaOfGrain::ButtonClicked(ClickButton* button, double time)
 {
+
    if (button == mLoadButton)
       LoadFile();
 }
@@ -388,8 +405,33 @@ bool SeaOfGrain::MouseMoved(float x, float y)
    return IDrawableModule::MouseMoved(x, y);
 }
 
+void SeaOfGrain::RefreshOptionRenderStates(int idx) const
+{
+   int i = idx;
+   bool doRender = mManualVoices[i].mGranulator.mSpawnGrains;
+   mManualVoices[i].mGainSlider->SetShowing(doRender);
+   mManualVoices[i].mPositionSlider->SetShowing(doRender);
+   mManualVoices[i].mOverlapSlider->SetShowing(doRender);
+   mManualVoices[i].mSpeedSlider->SetShowing(doRender);
+   mManualVoices[i].mLengthMsSlider->SetShowing(doRender);
+   mManualVoices[i].mPosRandomizeSlider->SetShowing(doRender);
+   mManualVoices[i].mSpeedRandomizeSlider->SetShowing(doRender);
+   mManualVoices[i].mSpacingRandomizeSlider->SetShowing(doRender);
+   mManualVoices[i].mOctaveCheckbox->SetShowing(doRender);
+   mManualVoices[i].mWidthSlider->SetShowing(doRender);
+   mManualVoices[i].mPanSlider->SetShowing(doRender);
+}
+
 void SeaOfGrain::CheckboxUpdated(Checkbox* checkbox, double time)
 {
+   for (int i = 0; i < kNumManualVoices; ++i)
+   {
+      if (mManualVoices[i].mEnabledCheckbox == checkbox)
+      {
+         RefreshOptionRenderStates(i);
+      }
+   }
+
    if (checkbox == mRecordInputCheckbox)
    {
       if (mRecordInput)
@@ -503,6 +545,11 @@ void SeaOfGrain::LoadState(FileStreamIn& in, int rev)
       mSample->LoadState(in);
       UpdateSample();
    }
+
+   for (int i = 0; i < kNumManualVoices; ++i)
+   {
+      RefreshOptionRenderStates(i);
+   }
 }
 
 
@@ -607,6 +654,7 @@ void SeaOfGrain::GrainManualVoice::Process(ChannelBuffer* output, int bufferSize
 
 void SeaOfGrain::GrainManualVoice::Draw(int index, float w, float h)
 {
+
    ofPushStyle();
    ofFill();
    float x = mPosition * w;

--- a/Source/SeaOfGrain.cpp
+++ b/Source/SeaOfGrain.cpp
@@ -186,7 +186,6 @@ void SeaOfGrain::DrawModule()
    if (Minimized() || IsVisible() == false)
       return;
 
-
    mLoadButton->Draw();
    mRecordInputCheckbox->Draw();
    mVolumeSlider->Draw();
@@ -219,7 +218,6 @@ void SeaOfGrain::DrawModule()
       ofTranslate(mBufferX, mBufferY);
       ofPushStyle();
 
-
       if (mHasRecordedInput)
       {
          mRecordBuffer.Draw(0, 0, mBufferW, mBufferH, mDisplayLength * gSampleRate);
@@ -241,7 +239,6 @@ void SeaOfGrain::DrawModule()
          ofRect(mBufferW * float(i) / mKeyboardNumPitches, mBufferH, mBufferW / mKeyboardNumPitches, 10);
       }
       ofPopStyle();
-
 
       for (int i = 0; i < kNumMPEVoices; ++i)
       {
@@ -385,7 +382,6 @@ void SeaOfGrain::LoadFile()
 
 void SeaOfGrain::ButtonClicked(ClickButton* button, double time)
 {
-
    if (button == mLoadButton)
       LoadFile();
 }
@@ -654,7 +650,6 @@ void SeaOfGrain::GrainManualVoice::Process(ChannelBuffer* output, int bufferSize
 
 void SeaOfGrain::GrainManualVoice::Draw(int index, float w, float h)
 {
-
    ofPushStyle();
    ofFill();
    float x = mPosition * w;

--- a/Source/SeaOfGrain.h
+++ b/Source/SeaOfGrain.h
@@ -67,6 +67,7 @@ public:
    //IClickable
    void MouseReleased() override;
    bool MouseMoved(float x, float y) override;
+   void RefreshOptionRenderStates(int idx) const;
 
 
    void CheckboxUpdated(Checkbox* checkbox, double time) override;


### PR DESCRIPTION
For a while now, every time I added a Sea of Grain module, my framerate has consistently dropped by a third. Which is impressive for a module that draws so little when brand new.

After some profiling, I came into the conclusion that... to use an industry term, "pisses away" frames doing pretty much nothing at all.

So I ended up doing some aggressive culling to cut down on the amount of drawing as much as possible + batching some operations when they do not interfere. The end result is about a 90%-95%~ draw framerate increase. Even when all controls are active and blasting.

### Before

<img width="1630" height="246" alt="BespokeSynth_fEr4owhRe6" src="https://github.com/user-attachments/assets/441191a9-9d7d-4c37-8f3c-9a6f05cf78bd" />

### After

<img width="1637" height="1033" alt="BespokeSynth_RXVq7sivnj" src="https://github.com/user-attachments/assets/d455c1e9-843a-45d6-8095-58ccf48a0b56" />

An unrelated change is that by default, only the first set of controls is shown to the user. This improves performance to a minor extent and makes the module look significantly less intimidating.