### PR TITLE
allow minimum pitchbend range to be 0 in midicontroller

### DIFF
--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -475,7 +475,7 @@ void MidiController::OnMidiPitchBend(MidiPitchBend& pitchBend)
 
    int voiceIdx = -1;
 
-   float amount = (pitchBend.mValue - 8192.0f) * mPitchBendRange / 8192.0f;
+   float amount = (pitchBend.mValue - 8192.0f) * (mPitchBendRange / 8192.0f);
 
    if (mUseChannelAsVoice)
       voiceIdx = pitchBend.mChannel - 1;

--- a/Source/MidiController.cpp
+++ b/Source/MidiController.cpp
@@ -475,7 +475,7 @@ void MidiController::OnMidiPitchBend(MidiPitchBend& pitchBend)
 
    int voiceIdx = -1;
 
-   float amount = (pitchBend.mValue - 8192.0f) / (8192.0f / mPitchBendRange);
+   float amount = (pitchBend.mValue - 8192.0f) * mPitchBendRange / 8192.0f;
 
    if (mUseChannelAsVoice)
       voiceIdx = pitchBend.mChannel - 1;
@@ -2441,7 +2441,7 @@ void MidiController::LoadLayout(const ofxJSONElement& moduleInfo)
    channelMap["16"] = (int)ChannelFilter::k16;
    mModuleSaveData.LoadEnum<ChannelFilter>("channelfilter", moduleInfo, (int)ChannelFilter::kAny, nullptr, &channelMap);
    mModuleSaveData.LoadInt("noteoffset", moduleInfo, 0, -999, 999, K(isTextField));
-   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 1, 96, K(isTextField));
+   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 0, 96, K(isTextField));
    mModuleSaveData.LoadInt("modwheelcc(1or74)", moduleInfo, 1, 0, 127, K(isTextField));
    mModuleSaveData.LoadFloat("modwheeloffset", moduleInfo, 0, 0, 1, K(isTextField));
    mModuleSaveData.LoadFloat("pressureoffset", moduleInfo, 0, 0, 1, K(isTextField));

--- a/Source/MidiOutput.cpp
+++ b/Source/MidiOutput.cpp
@@ -130,7 +130,8 @@ void MidiOutputModule::OnTransportAdvanced(float amount)
       if (bend != mod.mLastPitchBend)
       {
          mod.mLastPitchBend = bend;
-         mDevice.SendPitchBend((int)ofMap(bend, -mPitchBendRange, mPitchBendRange, 0, 16383, K(clamp)), channel);
+         if (mPitchBendRange != 0)
+            mDevice.SendPitchBend((int)ofMap(bend, -mPitchBendRange, mPitchBendRange, 0, 16383, K(clamp)), channel);
       }
       float modWheel = mod.mModulation.modWheel ? mod.mModulation.modWheel->GetValue(0) : ModulationParameters::kDefaultModWheel;
       if (modWheel != mod.mLastModWheel)
@@ -162,7 +163,7 @@ void MidiOutputModule::LoadLayout(const ofxJSONElement& moduleInfo)
    mModuleSaveData.LoadString("controller", moduleInfo, "", FillDropdown<MidiController*>);
    mModuleSaveData.LoadInt("channel", moduleInfo, 1, 1, 16);
    mModuleSaveData.LoadBool("usevoiceaschannel", moduleInfo, false);
-   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 1, 96, K(isTextField));
+   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 0, 96, K(isTextField));
    mModuleSaveData.LoadInt("modwheelcc(1or74)", moduleInfo, 1, 0, 127, K(isTextField));
 
    SetUpFromSaveData();

--- a/Source/VSTPlugin.cpp
+++ b/Source/VSTPlugin.cpp
@@ -899,7 +899,8 @@ void VSTPlugin::Process(double time)
             if (bend != mod.mLastPitchBend)
             {
                mod.mLastPitchBend = bend;
-               mMidiBuffer.addEvent(juce::MidiMessage::pitchWheel(channel, (int)ofMap(bend, -mPitchBendRange, mPitchBendRange, 0, 16383, K(clamp))), 0);
+               if (mPitchBendRange != 0)
+                  mMidiBuffer.addEvent(juce::MidiMessage::pitchWheel(channel, (int)ofMap(bend, -mPitchBendRange, mPitchBendRange, 0, 16383, K(clamp))), 0);
             }
             float modWheel = mod.mModulation.modWheel ? mod.mModulation.modWheel->GetValue(0) : ModulationParameters::kDefaultModWheel;
             if (modWheel != mod.mLastModWheel)
@@ -1394,7 +1395,7 @@ void VSTPlugin::LoadLayout(const ofxJSONElement& moduleInfo)
 
    mModuleSaveData.LoadInt("channel", moduleInfo, 1, 0, 16);
    mModuleSaveData.LoadBool("usevoiceaschannel", moduleInfo, false);
-   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 1, 96, K(isTextField));
+   mModuleSaveData.LoadFloat("pitchbendrange", moduleInfo, 2, 0, 96, K(isTextField));
    mModuleSaveData.LoadInt("modwheelcc(1or74)", moduleInfo, 1, 0, 127, K(isTextField));
    mModuleSaveData.LoadInt("numAdditionalStereoOutputs", moduleInfo, 0, 0, VSTPlugin::maxStereoOutputChannels, false);
 


### PR DESCRIPTION
This lowers the minimum range for the `pitchbendrange` setting in `midicontroller` to go as low as 0. It also changes the pitchbend calculation to avoid potential divison by zero.
This Closes #2015 in a pretty blunt way (`midioutput` and `vstplugin` are still limited to 1). Perhaps expanding `pitchbender` to allow _setting_ instead of only _adding_ would be smarter but I've wanted to try a very basic PR to solve an actual problem I'm having right now (and it's my first ever github PR!!! 🎉)

I'm also yet to build Bespoke myself so this is untested so far but it's such a tiny and contained change that it feels okay.