### PR TITLE
Introduce 'permutation' code for `binaryvalue`

### DIFF
--- a/Source/ModulatorBinaryValue.cpp
+++ b/Source/ModulatorBinaryValue.cpp
@@ -39,9 +39,7 @@ ModulatorBinaryValue::ModulatorBinaryValue()
       mBits[i].SetIndex(NUM_BITS - i - 1);
    }
    for (int i = 0; i < 1 << NUM_BITS; i++)
-   {
       mPermutations[i].value = i;
-   }
    std::sort(mPermutations.begin(), mPermutations.end());
 }
 

--- a/Source/ModulatorBinaryValue.cpp
+++ b/Source/ModulatorBinaryValue.cpp
@@ -38,6 +38,11 @@ ModulatorBinaryValue::ModulatorBinaryValue()
       mBits[i].SetOwner(this);
       mBits[i].SetIndex(NUM_BITS - i - 1);
    }
+   for (int i = 0; i < 1 << NUM_BITS; i++)
+   {
+      mPermutations[i].value = i;
+   }
+   std::sort(mPermutations.begin(), mPermutations.end());
 }
 
 void ModulatorBinaryValue::CreateUIControls()
@@ -53,6 +58,7 @@ void ModulatorBinaryValue::CreateUIControls()
 
    mCodeSelector->AddLabel("byte", kCodeByte);
    mCodeSelector->AddLabel("gray", kCodeGray);
+   mCodeSelector->AddLabel("permutation", kCodePermutation);
 
    for (int i = 0; i < NUM_BITS; ++i)
    {
@@ -93,6 +99,8 @@ void ModulatorBinaryValue::PostRepatch(PatchCableSource* cableSource, bool fromU
 int ModulatorBinaryValue::GetBitValue(int index)
 {
    int value = (int)mInput;
+   if (mCode == kCodePermutation)
+      value = mPermutations[value % (1 << NUM_BITS)].value;
    if (mCode == kCodeGray)
       value = value ^ (value >> 1);
    return (value & (1 << index)) != 0;

--- a/Source/ModulatorBinaryValue.h
+++ b/Source/ModulatorBinaryValue.h
@@ -98,7 +98,8 @@ private:
          if (!value)
             return 0;
          int ones = 0;
-         for (int i = 0; i < log(value) / log(2) + 1; i++) {
+         for (int i = 0; i < log(value) / log(2) + 1; i++)
+         {
             if (value & (1 << i))
                ones++;
          }

--- a/Source/ModulatorBinaryValue.h
+++ b/Source/ModulatorBinaryValue.h
@@ -105,7 +105,7 @@ private:
          }
          return ones;
       }
-      bool operator<(const Permutation& other)
+      bool operator<(const Permutation& other) const
       {
          int ones_this = ones();
          int ones_other = other.ones();

--- a/Source/ModulatorBinaryValue.h
+++ b/Source/ModulatorBinaryValue.h
@@ -36,7 +36,8 @@
 enum BinaryValueCode
 {
    kCodeByte,
-   kCodeGray
+   kCodeGray,
+   kCodePermutation
 };
 
 class PatchCableSource;
@@ -90,6 +91,32 @@ private:
       int mIndex{ 0 };
    };
 
+   struct Permutation
+   {
+      int ones() const
+      {
+         if (!value)
+            return 0;
+         int ones = 0;
+         for (int i = 0; i < log(value) / log(2) + 1; i++) {
+            if (value & (1 << i))
+               ones++;
+         }
+         return ones;
+      }
+      bool operator<(const Permutation& other)
+      {
+         int ones_this = ones();
+         int ones_other = other.ones();
+         if (ones_this == ones_other)
+            return this->value < other.value;
+         else
+            return ones_this < ones_other;
+      }
+      int value{ 0 };
+   };
+
+   std::array<Permutation, 1 << NUM_BITS> mPermutations;
    std::array<BitModulator, NUM_BITS> mBits;
 
    FloatSlider* mInputSlider{ nullptr };


### PR DESCRIPTION
This PR adds one more code type for `binaryvalue`: 'permutation'. In this regime, binary numbers are ordered by the number of 1s in them. Thus the sequence of binary numbers consists of 0, all the binary numbers having one 1, then all binary numbers having two 1s and so on (see [OEIS sequence A047869](https://oeis.org/A047869)).

This code type might be useful to, for example, gradual increase of notes allowed through `notefilter` or tracks enabled in `drumsequencer`. Two previous modes ('byte' and 'gray') do not have this property.