### PR TITLE
Fix Jack Input - issue #663

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -271,21 +271,8 @@ public:
          {
             ofLog() << "output: " << loadedSetup.outputDeviceName << "   input: " << loadedSetup.inputDeviceName;
 
-            int numInputChannels = 0;
-            int64 inputMask = loadedSetup.inputChannels.toInteger();
-            while (inputMask != 0)
-            {
-               ++numInputChannels;
-               inputMask >>= 1;
-            }
-
-            int numOutputChannels = 0;
-            int64 outputMask = loadedSetup.outputChannels.toInteger();
-            while (outputMask != 0)
-            {
-               ++numOutputChannels;
-               outputMask >>= 1;
-            }
+            int numInputChannels = loadedSetup.inputChannels.countNumberOfSetBits();
+            int numOutputChannels = loadedSetup.outputChannels.countNumberOfSetBits();
 
             mSynth.InitIOBuffers(numInputChannels, numOutputChannels);
 

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2454,9 +2454,9 @@ void ModularSynth::AudioIn(const float* const* input, int bufferSize, int nChann
    int oversampling = UserPrefs.oversampling.Get();
 
    assert(bufferSize * oversampling == mIOBufferSize);
-   assert(nChannels == (int)mInputBuffers.size());
 
-   for (int i = 0; i < nChannels; ++i)
+   int channelsToProcess = MIN(nChannels, (int)mInputBuffers.size());
+   for (int i = 0; i < channelsToProcess; ++i)
    {
       if (oversampling == 1)
       {


### PR DESCRIPTION
Two bugs in the Jack Audio input path:

Bug 1 — Wrong channel count (MainComponent.cpp:274–280):
The original code used a right-shift loop (while (mask != 0) { ++count; mask >>= 1; }) which counts the bit-length of the channel mask, not the number of set bits. For Jack, activeInputChannels can have non-consecutive bits set (e.g., ports 0 and 2 connected → mask 0b101). The old code would count 3 channels, but only 2 were provided in the audio callback, causing a mismatch. Fixed by using countNumberOfSetBits() — the same method JUCE's own tests use.

Bug 2 — Out-of-bounds crash in AudioIn() (ModularSynth.cpp:2457):
Jack's updateActivePorts() fires asynchronously whenever ports connect/disconnect, changing how many channels the audio callback delivers — after mInputBuffers was already sized at startup. If more channels arrive than mInputBuffers has space for, the loop for (int i = 0; i < nChannels; ++i) mInputBuffers[i][...] writes past the end of the vector → segfault. The assert only caught this in debug builds. Fixed by clamping the loop to std::min(nChannels, mInputBuffers.size()).

Both bugs were found by Claude.
Tested on Fedora 43 and the Input module worked with Jack audio inputs.

This PR fixes https://github.com/BespokeSynth/BespokeSynth/issues/663
It will certainly fix main other PR related to Jack problems with the Input module.
