### PR TITLE
tapelooper: remove unneeded "recording" checkbox

### DIFF
--- a/Source/TapeLooper.cpp
+++ b/Source/TapeLooper.cpp
@@ -49,7 +49,6 @@ void TapeLooper::CreateUIControls()
    FLOATSLIDER(mLoopBeatsAgoSlider, "loop beats ago", &mLoopBeatsAgo, 0, 4 * 16);
    FLOATSLIDER(mDownbeatOffsetBeatsSlider, "downbeat offset", &mDownbeatOffsetBeats, 0, 4 * 16);
    UIBLOCK_NEWCOLUMN();
-   CHECKBOX(mRecordCheckbox, "record", &mRecording);
    BUTTON(mLoop1BarButton, "loop 1 bar");
    BUTTON(mLoop2BarsButton, "loop 2 bars");
    BUTTON(mLoop4BarsButton, "loop 4 bars");
@@ -211,7 +210,6 @@ void TapeLooper::DrawModule()
    mLoopLengthBeatsSlider->Draw();
    mLoopBeatsAgoSlider->Draw();
    mDownbeatOffsetBeatsSlider->Draw();
-   mRecordCheckbox->Draw();
    mLoop1BarButton->Draw();
    mLoop2BarsButton->Draw();
    mLoop4BarsButton->Draw();
@@ -226,14 +224,12 @@ void TapeLooper::StartLoop(int numBars)
    mLoopBeatsAgo = 0;
    mDownbeatOffsetBeats = 0;
    mState = TapeLooperState::Loop;
-   mRecording = false;
 }
 
 void TapeLooper::SetRecording(bool record)
 {
    if (record)
    {
-      mRecording = true;
       mState = TapeLooperState::Capture;
       mStartRecordingMeasureTime = TheTransport->GetMeasureTime(gTime);
    }
@@ -247,7 +243,6 @@ void TapeLooper::SetRecording(bool record)
          else
             mState = TapeLooperState::Capture;
          mStartRecordingMeasureTime = -1;
-         mRecording = false;
       }
    }
 }
@@ -256,12 +251,6 @@ void TapeLooper::DoRetroactiveRecord(int numBars)
 {
    mLoopLengthBeats = numBars * TheTransport->GetTimeSigTop();
    mState = TapeLooperState::Loop;
-}
-
-void TapeLooper::CheckboxUpdated(Checkbox* checkbox, double time)
-{
-   if (checkbox == mRecordCheckbox)
-      SetRecording(mRecording);
 }
 
 void TapeLooper::FloatSliderUpdated(FloatSlider* slider, float oldVal, double time)

--- a/Source/TapeLooper.h
+++ b/Source/TapeLooper.h
@@ -60,16 +60,15 @@ public:
 
    //IInputRecordable
    void SetRecording(bool record) override;
-   bool IsRecording() const override { return mRecording; }
+   bool IsRecording() const override { return mState == TapeLooperState::Capture; }
    void ClearRecording() override { mState = TapeLooperState::Capture; }
    void CancelRecording() override { mState = TapeLooperState::Capture; }
    bool IsInRetroactiveRecorderMode() const override { return true; }
    void DoRetroactiveRecord(int numBars) override;
 
-   void CheckboxUpdated(Checkbox* checkbox, double time) override;
    void FloatSliderUpdated(FloatSlider* slider, float oldVal, double time) override;
-   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override {}
-   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override {}
+   void IntSliderUpdated(IntSlider* slider, int oldVal, double time) override { }
+   void RadioButtonUpdated(RadioButton* radio, int oldVal, double time) override { }
    void ButtonClicked(ClickButton* button, double time) override;
 
    void LoadLayout(const ofxJSONElement& moduleInfo) override;
@@ -98,8 +97,6 @@ private:
    float mLoopBeatsAgo{ 0.0f };
    FloatSlider* mDownbeatOffsetBeatsSlider{ nullptr };
    float mDownbeatOffsetBeats{ 0.0f };
-   Checkbox* mRecordCheckbox{ nullptr };
-   bool mRecording{ false };
    ClickButton* mLoop1BarButton{ nullptr };
    ClickButton* mLoop2BarsButton{ nullptr };
    ClickButton* mLoop4BarsButton{ nullptr };


### PR DESCRIPTION
Feel free to close if this is intended, or if you have other ideas for where to take this!

The tapelooper module tracks its recording state in two places, through the "recording" checkbox and through state selector. This removes the checkbox in favor of just having the state selector.

before:
<img width="1211" height="468" alt="image" src="https://github.com/user-attachments/assets/0b89b44b-6a46-43f1-84fb-0b987bc1c8af" />

after:
<img width="1470" height="624" alt="image" src="https://github.com/user-attachments/assets/f0ef268a-817c-4fc9-98df-24ff251debe5" />