### PR TITLE
feat: support horizontal scroll for sampleplayer

### DIFF
--- a/Source/SamplePlayer.cpp
+++ b/Source/SamplePlayer.cpp
@@ -1279,6 +1279,12 @@ void SamplePlayer::oscBundleReceived(const OSCBundle& bundle)
 
 bool SamplePlayer::MouseScrolled(float x, float y, float scrollX, float scrollY, bool isSmoothScroll, bool isInvertedScroll)
 {
+   if (GetKeyModifiers() & kModifier_Alt)
+   {
+      scrollX = scrollY;
+      scrollY = 0;
+   }
+
    if (fabs(scrollX) > fabsf(scrollY))
       scrollY = 0;
    else


### PR DESCRIPTION
Uses the Alt modifier for horizontal scroll, same behavior like notecanvas.