### PR TITLE
Accept OSC bundles in `osccontroller`

### DIFF
--- a/Source/OscController.cpp
+++ b/Source/OscController.cpp
@@ -354,6 +354,17 @@ void OscController::oscMessageReceived(const juce::OSCMessage& msg)
    }
 }
 
+void OscController::oscBundleReceived(const juce::OSCBundle& bundle)
+{
+   for (const juce::OSCBundle::Element* element = bundle.begin(); element != bundle.end(); ++element)
+   {
+      if (element->isMessage())
+         oscMessageReceived(element->getMessage());
+      else if (element->isBundle())
+         oscBundleReceived(element->getBundle());
+   }
+}
+
 int OscController::FindControl(std::string address)
 {
    for (int i = 0; i < mOscMap.size(); ++i)

--- a/Source/OscController.h
+++ b/Source/OscController.h
@@ -42,7 +42,7 @@ struct OscMap
 
 class OscController : public INonstandardController,
                       private juce::OSCReceiver,
-                      private juce::OSCReceiver::Listener<juce::OSCReceiver::MessageLoopCallback>
+                      private juce::OSCReceiver::Listener<juce::OSCReceiver::RealtimeCallback>
 {
 public:
    OscController(MidiDeviceListener* listener, std::string outAddress, int outPort, int inPort);
@@ -50,6 +50,7 @@ public:
 
    void Connect();
    void oscMessageReceived(const juce::OSCMessage& msg) override;
+   void oscBundleReceived(const juce::OSCBundle& bundle) override;
    void SendValue(int page, int control, float value, bool forceNoteOn = false, int channel = -1) override;
    int AddControl(std::string address, bool isFloat);
 


### PR DESCRIPTION
This PR makes `osccontroller` aware of OSC bundles. The bundles are split into OSC messages and executed without respecting their simultaneity, just as done in `sampleplayer`.