### PR TITLE
push2control: fix flickering of the module position in auto layout

### DIFF
--- a/Source/IDrawableModule.cpp
+++ b/Source/IDrawableModule.cpp
@@ -193,13 +193,9 @@ bool IDrawableModule::IsVisible()
 
 void IDrawableModule::DrawFrame(float w, float h, bool drawModule, float& titleBarHeight, float& highlight)
 {
-   if (mPinned)
-      ForcePosition();
    titleBarHeight = mTitleBarHeight;
    if (!HasTitleBar())
       titleBarHeight = 0;
-
-   ofTranslate(mX, mY, 0);
 
    ofColor color = GetColor(mModuleCategory);
 
@@ -431,6 +427,11 @@ void IDrawableModule::Render()
 
    ofPushMatrix();
    ofPushStyle();
+
+   if (mPinned)
+      ForcePosition();
+
+   ofTranslate(mX, mY, 0);
 
    float titleBarHeight;
    float highlight;

--- a/Source/Push2Control.cpp
+++ b/Source/Push2Control.cpp
@@ -777,14 +777,10 @@ void Push2Control::DrawDisplayModuleControls()
 
       //nvgFontSize(mVG, 16);
       //nvgText(mVG, 10, 10, mDisplayModule->Name(), nullptr);
-      float x;
-      float y;
-      mDisplayModule->GetPosition(x, y, true);
-      mDisplayModule->SetPosition(5 - kColumnSpacing * mModuleViewOffsetSmoothed, 15);
+      ofTranslate(5 - kColumnSpacing * mModuleViewOffsetSmoothed, 15);
       float titleBarHeight;
       float highlight;
       mDisplayModule->DrawFrame(kColumnSpacing * MAX(1, MAX(mSliderControls.size(), mButtonControls.size())) - 14, 80, false, titleBarHeight, highlight);
-      mDisplayModule->SetPosition(x, y);
 
       ofSetColor(IDrawableModule::GetColor(mDisplayModule->GetModuleCategory()));
       ofNoFill();
@@ -846,16 +842,12 @@ void Push2Control::DrawLowerModuleSelector()
 
       ofClipWindow(kColumnSpacing * (i - mModuleListOffsetSmoothed), 0, kColumnSpacing, ableton::Push2DisplayBitmap::kHeight * kPixelRatio, true);
 
-      float x;
-      float y;
-      mModules[i]->GetPosition(x, y, true);
-      mModules[i]->SetPosition(3 + kColumnSpacing * (i - mModuleListOffsetSmoothed), 120);
+      ofTranslate(3 + kColumnSpacing * (i - mModuleListOffsetSmoothed), 120);
       float titleBarHeight;
       float highlight;
       mModules[i]->DrawFrame(kColumnSpacing - 14, 80, true, titleBarHeight, highlight);
       if (mModules[i] == mDisplayModule)
          DrawDisplayModuleRect(ofRectangle(0, 0, kColumnSpacing - 14, 80), 3);
-      mModules[i]->SetPosition(x, y);
 
       if (i - round(mModuleListOffset) >= 0 && i - round(mModuleListOffset) < 8)
          bottomRowLedColors[i - (int)round(mModuleListOffset)] = GetPadColorForType(mModules[i]->GetModuleCategory(), true);
@@ -882,14 +874,10 @@ void Push2Control::DrawRoutingDisplay()
 
       ofClipWindow(kColumnSpacing * i, 0, kColumnSpacing, ableton::Push2DisplayBitmap::kHeight * kPixelRatio, true);
 
-      float x;
-      float y;
-      mRoutingInputModules[i].mModule->GetPosition(x, y, true);
-      mRoutingInputModules[i].mModule->SetPosition(3 + kColumnSpacing * i, 12);
+      ofTranslate(3 + kColumnSpacing * i, 12);
       float titleBarHeight;
       float highlight;
       mRoutingInputModules[i].mModule->DrawFrame(kColumnSpacing - 14, 25, true, titleBarHeight, highlight);
-      mRoutingInputModules[i].mModule->SetPosition(x, y);
 
       if (i >= 0 && i < 8)
          topRowLedColors[i] = GetPadColorForType(mRoutingInputModules[i].mModule->GetModuleCategory(), true);
@@ -908,14 +896,10 @@ void Push2Control::DrawRoutingDisplay()
 
       ofClipWindow(kColumnSpacing * i, 0, kColumnSpacing, ableton::Push2DisplayBitmap::kHeight * kPixelRatio, true);
 
-      float x;
-      float y;
-      mRoutingOutputModules[i].mModule->GetPosition(x, y, true);
-      mRoutingOutputModules[i].mModule->SetPosition(3 + kColumnSpacing * i, 132);
+      ofTranslate(3 + kColumnSpacing * i, 132);
       float titleBarHeight;
       float highlight;
       mRoutingOutputModules[i].mModule->DrawFrame(kColumnSpacing - 14, 25, true, titleBarHeight, highlight);
-      mRoutingOutputModules[i].mModule->SetPosition(x, y);
 
       if (i >= 0 && i < 8)
          bottomRowLedColors[i] = GetPadColorForType(mRoutingOutputModules[i].mModule->GetModuleCategory(), true);
@@ -930,14 +914,10 @@ void Push2Control::DrawRoutingDisplay()
 
       ofClipWindow(0, 0, kColumnSpacing, ableton::Push2DisplayBitmap::kHeight * kPixelRatio, true);
 
-      float x;
-      float y;
-      mDisplayModule->GetPosition(x, y, true);
-      mDisplayModule->SetPosition(3, 72);
+      ofTranslate(3, 72);
       float titleBarHeight;
       float highlight;
       mDisplayModule->DrawFrame(kColumnSpacing - 14, 25, true, titleBarHeight, highlight);
-      mDisplayModule->SetPosition(x, y);
 
       ofPopMatrix();
       ofPopStyle();


### PR DESCRIPTION
The Push2Control module was temporarily modifying the module position for drawing on the Push2 screen. This led to flickering of the modules on the Push2 grid (in auto layout mode). (#2073)

My suggested fix:

Make IDrawableModule::Render responsible for applying the module position instead of IDrawableModule::DrawFrame. That way Push2Control doesn't have to undo the module position when drawing the module to the display. It can then place it at an absolute position using ofTranslate.

IDrawableModule::DrawFrame is only called by IDrawableModule::Render and by Push2Control.