### PR TITLE
reorganize the title bar to have a dropdown menu, to make it more touchscreen friendly and make expansion easier

### DIFF
--- a/Source/ClickButton.cpp
+++ b/Source/ClickButton.cpp
@@ -67,6 +67,7 @@ void ClickButton::UpdateWidth()
       mWidth = GetStringWidth(GetDisplayName()) + 3 + .25f * strnlen(GetDisplayName().c_str(), 50);
       if (mDisplayStyle == ButtonDisplayStyle::kSampleIcon || mDisplayStyle == ButtonDisplayStyle::kFolderIcon)
          mWidth += 20;
+      mTextWidth = mWidth;
    }
 }
 
@@ -94,7 +95,9 @@ void ClickButton::Render()
    if (mDisplayStyle == ButtonDisplayStyle::kText)
    {
       ofSetColor(textColor);
-      DrawTextNormal(GetDisplayName(), mX + 2, mY + 12);
+      float textX = mX + 2 + (mWidth - mTextWidth) / 2;
+      float textY = mY + 12 + (mHeight - 15) / 2;
+      DrawTextNormal(GetDisplayName(), textX, textY);
    }
    else if (mDisplayStyle == ButtonDisplayStyle::kPlay)
    {

--- a/Source/ClickButton.h
+++ b/Source/ClickButton.h
@@ -106,6 +106,7 @@ private:
    void OnClicked(float x, float y, bool right) override;
    float mWidth{ 20 };
    float mHeight{ 15 };
+   float mTextWidth{ 20 };
    double mClickTime{ -9999 };
    IButtonListener* mOwner{ nullptr };
    ButtonDisplayStyle mDisplayStyle{ ButtonDisplayStyle::kText };

--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -2786,11 +2786,9 @@ void ModularSynth::ResetLayout()
       mWelcomeScreen->SetName("welcome");
       mWelcomeScreen->CreateUIControls();
       mWelcomeScreen->Init();
+      mWelcomeScreen->SetOwningContainer(GetUIContainer());
       if (!mIsLoadingState && sFrameCount < 10 && UserPrefs.show_welcome_screen.Get())
          mWelcomeScreen->Show();
-      else
-         mWelcomeScreen->SetShowing(false);
-      mModuleContainer.AddModule(mWelcomeScreen);
    }
 
    GetDrawOffset().set(0, 0);
@@ -3638,7 +3636,7 @@ void ModularSynth::OnConsoleInput(std::string command /* = "" */)
       }
       else if (tokens[0] == "welcomescreen")
       {
-         mWelcomeScreen->Show();
+         PushModalFocusItem(mWelcomeScreen);
       }
       else if (tokens[0] == "dump" && tokens.size() >= 2)
       {
@@ -3937,8 +3935,6 @@ void ModularSynth::SetFatalError(std::string error)
          mUserPrefsEditor->Show();
       if (TheTitleBar != nullptr)
          TheTitleBar->SetShowing(false);
-      if (mWelcomeScreen != nullptr)
-         mWelcomeScreen->SetShowing(false);
    }
 }
 

--- a/Source/TitleBar.cpp
+++ b/Source/TitleBar.cpp
@@ -130,8 +130,8 @@ TitleBar::TitleBar()
    mHelpDisplay = dynamic_cast<HelpDisplay*>(HelpDisplay::Create());
    mHelpDisplay->SetTypeName("helpdisplay", kModuleCategory_Other);
 
-   mNewPatchConfirmPopup.SetTypeName("newpatchconfirm", kModuleCategory_Other);
-   mNewPatchConfirmPopup.SetName("newpatchconfirm");
+   mMenuPopup.SetTypeName("menupopup", kModuleCategory_Other);
+   mMenuPopup.SetName("menupopup");
 
    SetShouldDrawOutline(false);
 }
@@ -140,29 +140,12 @@ void TitleBar::CreateUIControls()
 {
    IDrawableModule::CreateUIControls();
    UIBLOCK(140, 1);
-   BUTTON_STYLE(mPlayPauseButton, "play/pause", ButtonDisplayStyle::kPause);
-   UIBLOCK_SHIFTRIGHT();
-   UIBLOCK_SHIFTX(10);
-   //BUTTON(mLoadStateButton, "load");
-   //UIBLOCK_SHIFTRIGHT();
-   BUTTON(mSaveStateButton, "save");
-   UIBLOCK_SHIFTRIGHT();
-   BUTTON(mSaveStateAsButton, "save as");
-   UIBLOCK_SHIFTRIGHT();
-   UIBLOCK_SHIFTX(10);
-   BUTTON(mWriteAudioButton, "write audio");
-   UIBLOCK_NEWLINE();
-   //BUTTON(mResetLayoutButton, "new patch");
-   BUTTON(mWelcomeScreenButton, "load/new");
-   UIBLOCK_SHIFTRIGHT();
-   CHECKBOX(mEventLookaheadCheckbox, "lookahead (exp.)", &Transport::sDoEventLookahead);
-   UIBLOCK_SHIFTRIGHT();
-   CHECKBOX(mShouldAutosaveCheckbox, "autosave", &ModularSynth::sShouldAutosave);
+   BUTTON_SIZE(mMenuButton, "menu", 50, 32);
    ENDUIBLOCK0();
 
    mDisplayHelpButton = new ClickButton(this, " ? ", 380, 1);
    mDisplayUserPrefsEditorButton = new ClickButton(this, "settings", 330, 1);
-   mHomeButton = new ClickButton(this, "home", 330, 1);
+   mPlayPauseButton = new ClickButton(this, "play/pause", 300, 1, ButtonDisplayStyle::kPause);
    mLoadLayoutDropdown = new DropdownList(this, "load layout", 140, 20, &mLoadLayoutIndex);
    mSaveLayoutButton = new ClickButton(this, "save layout", 280, 19);
 
@@ -173,7 +156,7 @@ void TitleBar::CreateUIControls()
 
    ListLayouts();
 
-   mNewPatchConfirmPopup.CreateUIControls();
+   mMenuPopup.CreateUIControls();
 }
 
 TitleBar::~TitleBar()
@@ -324,11 +307,6 @@ bool TitleBar::MouseMoved(float x, float y)
    return false;
 }
 
-namespace
-{
-   const float kDoubleHeightThreshold = 1200;
-}
-
 float TitleBar::GetPixelWidth() const
 {
    return ofGetWidth() / GetOwningContainer()->GetDrawScale();
@@ -367,36 +345,26 @@ void TitleBar::DrawModule()
 
    DrawTextRightJustify(info, pixelWidth - 140, 32);
 
+   mMenuButton->Draw();
    mSaveLayoutButton->Draw();
-   mSaveStateButton->Draw();
-   mSaveStateAsButton->Draw();
-   if (mLoadStateButton)
-      mLoadStateButton->Draw();
-   mWriteAudioButton->Draw();
    mLoadLayoutDropdown->Draw();
-   if (mResetLayoutButton)
-      mResetLayoutButton->Draw();
-   if (mWelcomeScreenButton)
-      mWelcomeScreenButton->Draw();
-   if (TheSynth->IsAudioPaused())
-      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPlay);
-   else
-      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPause);
    mPlayPauseButton->Draw();
 
-   float startX = 400;
+   float startX = 200;
    float startY = 2;
 
-   if (pixelWidth < kDoubleHeightThreshold)
-   {
-      startX = 10;
-      startY += 16 * 2 + 4;
-   }
-
+   bool newline = true;
+   mNumDropdownRows = 0;
    float x = startX;
    float y = startY;
    for (auto* spawnList : mSpawnLists.GetDropdowns())
    {
+      if (newline)
+      {
+         newline = false;
+         ++mNumDropdownRows;
+      }
+
       spawnList->SetPosition(x, y);
       float w, h;
       spawnList->GetList()->GetDimensions(w, h);
@@ -406,6 +374,7 @@ void TitleBar::DrawModule()
       {
          x = startX;
          y += 18;
+         newline = true;
       }
    }
 
@@ -431,10 +400,12 @@ void TitleBar::DrawModule()
    mDisplayHelpButton->Draw();
    mDisplayUserPrefsEditorButton->SetPosition(mDisplayHelpButton->GetPosition(true).x - mDisplayUserPrefsEditorButton->GetRect().width - 5, 4);
    mDisplayUserPrefsEditorButton->Draw();
-   mHomeButton->SetPosition(mDisplayUserPrefsEditorButton->GetPosition(true).x - mHomeButton->GetRect().width - 5, 4);
-   mHomeButton->Draw();
-   mEventLookaheadCheckbox->Draw();
-   mShouldAutosaveCheckbox->Draw();
+   if (TheSynth->IsAudioPaused())
+      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPlay);
+   else
+      mPlayPauseButton->SetDisplayStyle(ButtonDisplayStyle::kPause);
+   mPlayPauseButton->SetPosition(mDisplayUserPrefsEditorButton->GetPosition(true).x - mPlayPauseButton->GetRect().width - 5, 4);
+   mPlayPauseButton->Draw();
 }
 
 void TitleBar::DrawModuleUnclipped()
@@ -547,10 +518,7 @@ void TitleBar::GetModuleDimensions(float& width, float& height)
    }
 
    width = ofGetWidth() / GetOwningContainer()->GetDrawScale() + 5;
-   if (GetPixelWidth() < kDoubleHeightThreshold)
-      height = 36 * 2;
-   else
-      height = 36;
+   height = std::max(mNumDropdownRows, 2) * 18;
 }
 
 void TitleBar::CheckboxUpdated(Checkbox* checkbox, double time)
@@ -588,29 +556,17 @@ void TitleBar::ButtonClicked(ClickButton* button, double time)
       else
          TheSynth->SaveLayout();
    }
-   if (button == mSaveStateButton)
-      TheSynth->SaveCurrentState();
-   if (button == mSaveStateAsButton)
-      TheSynth->SaveStatePopup();
-   if (button == mLoadStateButton)
-      TheSynth->LoadStatePopup();
-   if (button == mWriteAudioButton)
-      TheSynth->SaveOutput();
    if (button == mDisplayHelpButton)
       ShowHelp();
    if (button == mDisplayUserPrefsEditorButton)
       TheSynth->GetUserPrefsEditor()->Show();
-   if (button == mHomeButton)
-      TheSynth->GetLocationZoomer()->GoHome();
-   if (button == mResetLayoutButton)
+   if (button == mMenuButton)
    {
-      auto buttonRect = mResetLayoutButton->GetRect();
-      mNewPatchConfirmPopup.SetOwningContainer(GetOwningContainer());
-      mNewPatchConfirmPopup.SetPosition(buttonRect.x, buttonRect.y + buttonRect.height + 2);
-      TheSynth->PushModalFocusItem(&mNewPatchConfirmPopup);
+      auto buttonRect = mMenuButton->GetRect();
+      mMenuPopup.SetOwningContainer(GetOwningContainer());
+      mMenuPopup.SetPosition(buttonRect.x, buttonRect.y + buttonRect.height + 2);
+      TheSynth->PushModalFocusItem(&mMenuPopup);
    }
-   if (button == mWelcomeScreenButton)
-      TheSynth->GetWelcomeScreen()->Show();
    if (button == mPlayPauseButton)
       TheSynth->SetAudioPaused(!TheSynth->IsAudioPaused());
 }
@@ -654,4 +610,86 @@ void NewPatchConfirmPopup::ButtonClicked(ClickButton* button, double time)
       TheSynth->ReloadInitialLayout();
    if (button == mCancelButton)
       TheSynth->PopModalFocusItem();
+}
+
+MenuPopup::MenuPopup()
+{
+   mNewPatchConfirmPopup.SetTypeName("newpatchconfirm", kModuleCategory_Other);
+   mNewPatchConfirmPopup.SetName("newpatchconfirm");
+}
+
+void MenuPopup::CreateUIControls()
+{
+   const float kButtonWidth = 130;
+
+   UIBLOCK0();
+   BUTTON_SIZE(mWelcomeScreenButton, "recents", kButtonWidth, 32);
+   BUTTON_SIZE(mResetLayoutButton, "new", kButtonWidth, 32);
+   BUTTON_SIZE(mLoadStateButton, "load", kButtonWidth, 32);
+   BUTTON_SIZE(mSaveStateButton, "save", kButtonWidth, 32);
+   BUTTON_SIZE(mSaveStateAsButton, "save as", kButtonWidth, 32);
+   BUTTON_SIZE(mWriteAudioButton, "write audio", kButtonWidth, 32);
+   BUTTON_SIZE(mHomeButton, "move canvas home", kButtonWidth, 32);
+   CHECKBOX(mEventLookaheadCheckbox, "lookahead (exp.)", &Transport::sDoEventLookahead);
+   CHECKBOX(mShouldAutosaveCheckbox, "autosave", &ModularSynth::sShouldAutosave);
+   CHECKBOX(mShowTooltipsCheckbox, "show tooltips", &HelpDisplay::sShowTooltips);
+   ENDUIBLOCK(mWidth, mHeight);
+
+   mNewPatchConfirmPopup.CreateUIControls();
+}
+
+void MenuPopup::DrawModule()
+{
+   mWelcomeScreenButton->Draw();
+   mSaveStateButton->Draw();
+   mSaveStateAsButton->Draw();
+   mLoadStateButton->Draw();
+   mResetLayoutButton->Draw();
+   mWriteAudioButton->Draw();
+   mHomeButton->Draw();
+   mEventLookaheadCheckbox->Draw();
+   mShouldAutosaveCheckbox->Draw();
+   mShowTooltipsCheckbox->Draw();
+}
+
+void MenuPopup::ButtonClicked(ClickButton* button, double time)
+{
+   if (button == mSaveStateButton)
+   {
+      TheSynth->SaveCurrentState();
+      TheSynth->PopModalFocusItem();
+   }
+   if (button == mSaveStateAsButton)
+   {
+      TheSynth->SaveStatePopup();
+      TheSynth->PopModalFocusItem();
+   }
+   if (button == mLoadStateButton)
+   {
+      TheSynth->LoadStatePopup();
+      TheSynth->PopModalFocusItem();
+   }
+   if (button == mWriteAudioButton)
+   {
+      TheSynth->SaveOutput();
+      TheSynth->PopModalFocusItem();
+   }
+   if (button == mHomeButton)
+   {
+      TheSynth->GetLocationZoomer()->GoHome();
+      TheSynth->PopModalFocusItem();
+   }
+   if (button == mResetLayoutButton)
+   {
+      auto buttonRect = mResetLayoutButton->GetRect();
+      mNewPatchConfirmPopup.SetOwningContainer(GetOwningContainer());
+      mNewPatchConfirmPopup.SetPosition(buttonRect.x, buttonRect.y + buttonRect.height + 2);
+      TheSynth->PushModalFocusItem(&mNewPatchConfirmPopup);
+      //TheSynth->ReloadInitialLayout();
+   }
+   if (button == mWelcomeScreenButton)
+   {
+      TheSynth->PopModalFocusItem();
+      TheSynth->GetWelcomeScreen()->Show();
+   }
 }

--- a/Source/TitleBar.h
+++ b/Source/TitleBar.h
@@ -114,6 +114,38 @@ private:
    ClickButton* mCancelButton{ nullptr };
 };
 
+class MenuPopup : public IDrawableModule, public IButtonListener
+{
+public:
+   MenuPopup();
+   void CreateUIControls() override;
+   void DrawModule() override;
+   bool HasTitleBar() const override { return false; }
+
+   void GetDimensions(float& width, float& height) override
+   {
+      width = mWidth;
+      height = mHeight;
+   }
+
+   void ButtonClicked(ClickButton* button, double time) override;
+
+private:
+   ClickButton* mSaveLayoutButton{ nullptr };
+   ClickButton* mResetLayoutButton{ nullptr };
+   ClickButton* mWelcomeScreenButton{ nullptr };
+   ClickButton* mSaveStateButton{ nullptr };
+   ClickButton* mSaveStateAsButton{ nullptr };
+   ClickButton* mLoadStateButton{ nullptr };
+   ClickButton* mWriteAudioButton{ nullptr };
+   ClickButton* mHomeButton{ nullptr };
+   Checkbox* mEventLookaheadCheckbox{ nullptr };
+   Checkbox* mShouldAutosaveCheckbox{ nullptr };
+   Checkbox* mShowTooltipsCheckbox{ nullptr };
+
+   NewPatchConfirmPopup mNewPatchConfirmPopup;
+};
+
 class TitleBar : public IDrawableModule, public IDropdownListener, public IButtonListener, public IFloatSliderListener, public WindowCloseListener
 {
 public:
@@ -161,20 +193,12 @@ private:
    float GetPixelWidth() const;
 
    ClickButton* mPlayPauseButton{ nullptr };
+   ClickButton* mMenuButton{ nullptr };
    ClickButton* mSaveLayoutButton{ nullptr };
-   ClickButton* mResetLayoutButton{ nullptr };
-   ClickButton* mWelcomeScreenButton{ nullptr };
-   ClickButton* mSaveStateButton{ nullptr };
-   ClickButton* mSaveStateAsButton{ nullptr };
-   ClickButton* mLoadStateButton{ nullptr };
-   ClickButton* mWriteAudioButton{ nullptr };
    DropdownList* mLoadLayoutDropdown{ nullptr };
    ClickButton* mDisplayHelpButton{ nullptr };
    ClickButton* mDisplayUserPrefsEditorButton{ nullptr };
-   ClickButton* mHomeButton{ nullptr };
-   Checkbox* mEventLookaheadCheckbox{ nullptr };
    int mLoadLayoutIndex{ -1 };
-   Checkbox* mShouldAutosaveCheckbox{ nullptr };
 
    HelpDisplay* mHelpDisplay{ nullptr };
 
@@ -184,10 +208,12 @@ private:
 
    std::unique_ptr<PluginListWindow> mPluginListWindow;
 
-   NewPatchConfirmPopup mNewPatchConfirmPopup;
+   MenuPopup mMenuPopup;
 
    std::string mDisplayMessage;
    double mDisplayMessageTime;
+
+   int mNumDropdownRows{ 2 };
 };
 
 extern TitleBar* TheTitleBar;

--- a/Source/UIControlMacros.h
+++ b/Source/UIControlMacros.h
@@ -145,6 +145,12 @@
    lastUIControl = button;                                  \
    UIBLOCK_SHIFTDOWN();                                     \
    UIBLOCK_UPDATEEXTENTS();
+#define BUTTON_SIZE(button, name, width, height)     \
+   button = new ClickButton(UICONTROL_BASICS(name)); \
+   button->SetDimensions(width, height);             \
+   lastUIControl = button;                           \
+   UIBLOCK_SHIFTDOWN();                              \
+   UIBLOCK_UPDATEEXTENTS();
 
 #define TEXTENTRY(entry, name, length, var)                    \
    entry = new TextEntry(UICONTROL_BASICS(name), length, var); \

--- a/Source/WelcomeScreen.cpp
+++ b/Source/WelcomeScreen.cpp
@@ -61,7 +61,6 @@ namespace
    const float kSaveStateButtonPadY = 10;
 }
 
-
 bool WelcomeScreen::AlreadyHasFile(const juce::File& file)
 {
    for (const auto& recentFile : mRecentFiles)
@@ -77,10 +76,6 @@ void WelcomeScreen::CreateUIControls()
    IDrawableModule::CreateUIControls();
 
    UIBLOCK(kSaveStateButtonStartX, 30);
-   BUTTON(mNewPatchButton, "new patch");
-   UIBLOCK_SHIFTRIGHT();
-   BUTTON(mLoadPatchButton, "load patch");
-   UIBLOCK_SHIFTRIGHT();
    BUTTON(mShowHelpButton, "help");
    UIBLOCK_SHIFTRIGHT();
    BUTTON(mShowSettingsButton, "settings");
@@ -91,8 +86,11 @@ void WelcomeScreen::CreateUIControls()
    mDiscordLinkButton = new ClickButton(this, "bespoke discord", 324, 53);
    mTutorialVideoLinkButton = new ClickButton(this, "youtu.be/SYBc8X2IxqM", 176, 72);
 
-   mWidth = ofGetWidth() / TheSynth->GetUIScale() - 100;
-   mHeight = ofGetHeight() / TheSynth->GetUIScale() - 200;
+   float uiScreenWidth = ofGetWidth() / TheSynth->GetUIScale();
+   float uiScreenHeight = ofGetHeight() / TheSynth->GetUIScale();
+   mWidth = uiScreenWidth - 100;
+   mHeight = uiScreenHeight - 200;
+   SetPosition(uiScreenWidth / 2 - mWidth / 2, uiScreenHeight / 2 - mHeight / 2);
 
    const int kMaxDesiredFiles = 10;
 
@@ -166,12 +164,13 @@ void WelcomeScreen::CreateUIControls()
       }
    }
 
+   int i = 1;
    for (auto& recentFile : mRecentFiles)
    {
       if (y + kSaveStateButtonHeight + 20 > mHeight)
          break;
 
-      recentFile.mButton = new ClickButton(this, ("recentfile" + ofToString((int)mRecentFiles.size())).c_str(), x, y);
+      recentFile.mButton = new ClickButton(this, ("recentfile" + ofToString(i)).c_str(), x, y);
       recentFile.mButton->SetOverrideDisplayName("");
       recentFile.mButton->SetDimensions(kSaveStateButtonWidth, kSaveStateButtonHeight);
 
@@ -181,6 +180,8 @@ void WelcomeScreen::CreateUIControls()
          x = kSaveStateButtonStartX;
          y += kSaveStateButtonHeight + kSaveStateButtonPadY;
       }
+
+      ++i;
    }
 
    mCloseButton = new ClickButton(this, "close", 10, mHeight - 20);
@@ -188,10 +189,7 @@ void WelcomeScreen::CreateUIControls()
 
 void WelcomeScreen::Show()
 {
-   SetPosition(50 / TheSynth->GetUIScale() - TheSynth->GetDrawOffset().x, 150 / TheSynth->GetUIScale() - TheSynth->GetDrawOffset().y);
-
-   SetShowing(true);
-   TheSynth->MoveToFront(this);
+   TheSynth->PushModalFocusItem(this);
 }
 
 void WelcomeScreen::DrawModule()
@@ -208,8 +206,6 @@ void WelcomeScreen::DrawModule()
 
    DrawTextBold("welcome to bespoke!", 15, 20, 18);
 
-   mNewPatchButton->Draw();
-   mLoadPatchButton->Draw();
    mShowHelpButton->Draw();
    mShowSettingsButton->Draw();
 
@@ -295,17 +291,19 @@ void WelcomeScreen::ButtonClicked(ClickButton* button, double time)
       HelpDisplay::OpenDocsLink();
    if (button == mDiscordLinkButton)
       HelpDisplay::OpenDiscordLink();
-   if (button == mNewPatchButton)
-      TheSynth->ReloadInitialLayout();
-   if (button == mLoadPatchButton)
-      TheSynth->LoadStatePopup();
    if (button == mShowHelpButton)
+   {
+      TheSynth->PopModalFocusItem();
       TheTitleBar->ShowHelp();
+   }
    if (button == mShowSettingsButton)
+   {
+      TheSynth->PopModalFocusItem();
       TheSynth->GetUserPrefsEditor()->Show();
+   }
 
    if (button == mCloseButton)
-      SetShowing(false);
+      TheSynth->PopModalFocusItem();
 }
 
 void WelcomeScreen::CheckboxUpdated(Checkbox* checkbox, double time)

--- a/Source/WelcomeScreen.h
+++ b/Source/WelcomeScreen.h
@@ -50,6 +50,7 @@ public:
    bool AlwaysOnTop() override { return true; }
    bool CanMinimize() override { return false; }
    bool IsSingleton() const override { return true; }
+   bool HasTitleBar() const override { return false; }
 
    void Show();
 
@@ -91,8 +92,6 @@ private:
    ClickButton* mTutorialVideoLinkButton{ nullptr };
    ClickButton* mDocsLinkButton{ nullptr };
    ClickButton* mDiscordLinkButton{ nullptr };
-   ClickButton* mNewPatchButton{ nullptr };
-   ClickButton* mLoadPatchButton{ nullptr };
    ClickButton* mShowHelpButton{ nullptr };
    ClickButton* mShowSettingsButton{ nullptr };
    ClickButton* mCloseButton{ nullptr };

--- a/resource/tooltips_eng.txt
+++ b/resource/tooltips_eng.txt
@@ -1908,18 +1908,11 @@ arpeggiator~arpeggiates held notes. there are several vestigial features in this
 
 
 titlebar~
+~menu~show the main menu
 ~save layout~[none]
-~load~load a saved .bsk file to restore state
-~save~save current state as .bsk file, to be restored later
-~save as~save current state as a new .bsk file
-~new patch~reset to the layout specified in "layout" in userprefs.json
-~write audio~write the last 30 minutes of audio to your specified recordings_path
 ~ ? ~show help
 ~settings~adjust preferences, saved as userprefs.json
-~home~Moves the viewport to the "home" position, useful if you lost where you are in your savestate
 ~load layout~[none]
-~lookahead (exp.)~use lookahead scheduling, which is necessary for scriptmodule. gets automatically turned on when you use scriptmodule. so far, lookahead scheduling seems to not create any issues, but leaving this checkbox here just in case.
-~autosave~every time a new module is added, trigger a save to data/savestate/autosave/, to help reload state in the event of a crash. can be quite slow if using modules with large samples.
 ~play/pause~stop all audio processing (shift-p)
 
 
@@ -1927,6 +1920,20 @@ titlebar~
 newpatchconfirm~
 ~confirm~clear everything and start fresh
 ~cancel~dismiss this
+
+
+
+menupopup~
+~recents~show the welcome panel, with recently used files
+~load~load a saved .bsk file to restore state
+~save~save current state as .bsk file, to be restored later
+~save as~save current state as a new .bsk file
+~new~reset to the layout specified in "layout" in userprefs.json
+~write audio~write the last 30 minutes of audio to your specified recordings_path
+~move canvas home~Moves the viewport to the "home" position, useful if you lost where you are in your savestate
+~lookahead (exp.)~use lookahead scheduling, which is necessary for scriptmodule. gets automatically turned on when you use scriptmodule. so far, lookahead scheduling seems to not create any issues, but leaving this checkbox here just in case.
+~autosave~every time a new module is added, trigger a save to data/savestate/autosave/, to help reload state in the event of a crash. can be quite slow if using modules with large samples.
+~show tooltips~displays these tooltips. you can also toggle them with the F1 key, and you can turn these on or off by default in the "settings" menu.
 
 
 


### PR DESCRIPTION
also adjusted the behavior of the welcome screen in the process, so it's now a modal popup at UI scale (independent of canvas position), and put the new/load buttons back in the title bar (in the new menu) rather than the welcome screen
