### PR TITLE
add continuous mode to `whitekeys`

### DIFF
--- a/Source/WhiteKeys.cpp
+++ b/Source/WhiteKeys.cpp
@@ -32,11 +32,19 @@ WhiteKeys::WhiteKeys()
 {
 }
 
+void WhiteKeys::CreateUIControls()
+{
+   IDrawableModule::CreateUIControls();
+
+   mContinuousCheckbox = new Checkbox(this, "continuous", 4, 3, &mContinuous);
+}
+
 void WhiteKeys::DrawModule()
 {
-
    if (Minimized() || IsVisible() == false)
       return;
+
+   mContinuousCheckbox->Draw();
 }
 
 void WhiteKeys::CheckboxUpdated(Checkbox* checkbox, double time)
@@ -69,8 +77,14 @@ void WhiteKeys::PlayNote(NoteMessage note)
 
    if (degree != -1)
    {
-      note.pitch = TheScale->GetPitchFromTone(degree);
-      note.pitch += octave * TheScale->GetPitchesPerOctave();
+      if (mContinuous)
+      {
+         note.pitch = TheScale->GetPitchFromTone(degree + octave * 7);
+      }
+      else
+      {
+         note.pitch = TheScale->GetPitchFromTone(degree) + octave * TheScale->GetPitchesPerOctave();
+      }
       PlayNoteOutput(note);
    }
 }

--- a/Source/WhiteKeys.h
+++ b/Source/WhiteKeys.h
@@ -37,6 +37,8 @@ public:
    static bool AcceptsNotes() { return true; }
    static bool AcceptsPulses() { return false; }
 
+   void CreateUIControls() override;
+
    void SetEnabled(bool enabled) override { mEnabled = enabled; }
 
    //INoteReceiver
@@ -55,6 +57,9 @@ private:
    void GetModuleDimensions(float& width, float& height) override
    {
       width = 110;
-      height = 0;
+      height = 21;
    }
+
+   bool mContinuous{ false };
+   Checkbox* mContinuousCheckbox{ nullptr };
 };


### PR DESCRIPTION
Right now `whitekeys` module maps white keys not in a continuously increasing manner. Right now all C's are anchors because they determine the base pitch from which offset in the current scale happens based on an index of a white key. It means that if a scale has more than 7 tones in it then they won't be accessible, and if it has less than 7 tones then some keys to the left of C's will have pitch higher or equal to it.

The idea is to introduce "continuous" mode in which there is no anchoring of octaves to each C and instead all white keys are mapped in continuous ascending order.

The PR adds a checkbox to activate said module and an almost one line change to apply new logic instead of previous one if the checkbox is checked.

First PR here - don't know if I must add documentation text (tooltip content) for the checkbox. I'm not a native speaker and not experienced in music terminology so don't want to subtly screw it up... I'm also not attached to the term of "continuous" mode - if there is a better name for this, I'm open to the change.