### PR TITLE
MainComponent: update mouse position on click

### DIFF
--- a/Source/ModularSynth.cpp
+++ b/Source/ModularSynth.cpp
@@ -1813,8 +1813,7 @@ void ModularSynth::MousePressed(int intX, int intY, int button, const juce::Mous
 
    mZoomer.ExitVanityPanningMode();
 
-   mMousePos.x = intX;
-   mMousePos.y = intY;
+   MouseMoved(intX, intY);
    mLastClickWasEmptySpace = false;
 
    if (button >= 0 && button < (int)mIsMouseButtonHeld.size())


### PR DESCRIPTION
Fixes (one-finger) touch support on Linux.

The problem before was that the click event would always happen before the movement event. This change ensures that the movement event is triggered before the click event, so clicks happen at the correct coordinates.