### PR TITLE
add python get functions for notesequencer

### DIFF
--- a/Source/NoteStepSequencer.cpp
+++ b/Source/NoteStepSequencer.cpp
@@ -541,6 +541,42 @@ void NoteStepSequencer::SetPitch(int index, int pitch, int velocity, float lengt
    }
 }
 
+int NoteStepSequencer::GetRow(int index)
+{
+   if (index >= 0 && index < NSS_MAX_STEPS)
+   {
+      return mTones[index];
+   }
+   return -1;
+}
+
+int NoteStepSequencer::GetPitch(int index)
+{
+   if (index >= 0 && index < NSS_MAX_STEPS)
+   {
+      return NoteStepSequencer::RowToPitch(mNoteMode, mTones[index], mOctave, mRowOffset);
+   }
+   return -1;
+}
+
+int NoteStepSequencer::GetVelocity(int index)
+{
+   if (index >= 0 && index < NSS_MAX_STEPS)
+   {
+      return mVels[index];
+   }
+   return -1;
+}
+
+float NoteStepSequencer::GetLength(int index)
+{
+   if (index >= 0 && index < NSS_MAX_STEPS)
+   {
+      return mNoteLengths[index];
+   }
+   return -1;
+}
+
 void NoteStepSequencer::GetPush2Layout(AbletonDeviceType deviceType, int& sequenceRows, int& pitchCols, int& pitchRows)
 {
    if (deviceType == AbletonDeviceType::Move)

--- a/Source/NoteStepSequencer.h
+++ b/Source/NoteStepSequencer.h
@@ -77,6 +77,11 @@ public:
    int PitchToRow(int pitch);
    void SetStep(int index, int step, int velocity, float length);
    void SetPitch(int index, int pitch, int velocity, float length);
+   int GetRow(int index);
+   int GetPitch(int index);
+   int GetVelocity(int index);
+   float GetLength(int index);
+
 
    //IDrawableModule
    bool IsResizable() const override { return true; }

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -150,6 +150,7 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
       ScriptModule::sBackgroundTextPos.set(xPos, yPos);
       ScriptModule::sBackgroundTextColor.set(red * 255, green * 255, blue * 255);
    }, "str"_a, "size"_a=50, "xPos"_a = 150, "yPos"_a = 250, "red"_a = 1, "green"_a = 1, "blue"_a = 1);
+   ///example: bespoke.set_background_text('"' + '"\n"'.join(bespoke.get_controls("transport")) + '"', 14, 0, 50, 1, 1, 1)
    m.def("random", [](int seed, int index)
    {
       return DeterministicRandom(seed, index);
@@ -179,7 +180,6 @@ PYBIND11_EMBEDDED_MODULE(bespoke, m) {
       }
       return paths;
    });
-   ///example: bespoke.set_background_text('"' + '"\n"'.join(bespoke.get_controls("transport")) + '"', 14, 0, 50, 1, 1, 1)
    m.def("location_recall", [](char location)
    {
       TheSynth->GetLocationZoomer()->MoveToLocation(location);
@@ -366,6 +366,7 @@ PYBIND11_EMBEDDED_MODULE(notesequencer, m)
               seq.GetLength(step)
           );
       });
+      ///example: row, pitch, velocity, length = n.get_step(3)
 }
 
 PYBIND11_EMBEDDED_MODULE(drumsequencer, m)

--- a/Source/ScriptModule_PythonInterface.i
+++ b/Source/ScriptModule_PythonInterface.i
@@ -340,7 +340,32 @@ PYBIND11_EMBEDDED_MODULE(notesequencer, m)
       .def("set_pitch", [](NoteStepSequencer& seq, int step, int pitch, int velocity, float length)
       {
          seq.SetPitch(step, pitch, velocity, length);
-      }, "step"_a, "pitch"_a, "velocity"_a = 127, "length"_a = 1.0);
+      }, "step"_a, "pitch"_a, "velocity"_a = 127, "length"_a = 1.0)
+      .def("get_row", [](NoteStepSequencer& seq, int step)
+      {
+         return seq.GetRow(step);
+      })
+      .def("get_pitch", [](NoteStepSequencer& seq, int step)
+      {
+         return seq.GetPitch(step);
+      })
+      .def("get_velocity", [](NoteStepSequencer& seq, int step)
+      {
+         return seq.GetVelocity(step);
+      })
+      .def("get_length", [](NoteStepSequencer& seq, int step)
+      {
+         return seq.GetLength(step);
+      })
+      .def("get_step", [](NoteStepSequencer& seq, int step)
+      {
+          return py::make_tuple(
+              seq.GetRow(step),
+              seq.GetPitch(step),
+              seq.GetVelocity(step),
+              seq.GetLength(step)
+          );
+      });
 }
 
 PYBIND11_EMBEDDED_MODULE(drumsequencer, m)

--- a/resource/python_stubs/notesequencer/__init__.pyi
+++ b/resource/python_stubs/notesequencer/__init__.pyi
@@ -10,3 +10,18 @@ class notesequencer:
    def set_pitch(this, step, pitch, velocity = 127, length = 1.0):
       pass
 
+   def get_row(this, step):
+      pass
+
+   def get_pitch(this, step):
+      pass
+
+   def get_velocity(this, step):
+      pass
+
+   def get_length(this, step):
+      pass
+
+   def get_step(this, step):
+      pass
+

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -92,6 +92,12 @@ import notesequencer
          optional: velocity = 127, length = 1.0
       n.set_pitch(step, pitch, velocity, length)
          optional: velocity = 127, length = 1.0
+      n.get_row(step)
+      n.get_pitch(step)
+      n.get_velocity(step)
+      n.get_length(step)
+      n.get_step(step)
+         example: row, pitch, velocity, length = n.get_step(3)
 
 
 import drumsequencer

--- a/resource/scripting_reference.txt
+++ b/resource/scripting_reference.txt
@@ -34,10 +34,10 @@ globals:
    bespoke.get_tempo()
    bespoke.set_background_text(str, size, xPos, yPos, red, green, blue)
       optional: size=50, xPos = 150, yPos = 250, red = 1, green = 1, blue = 1
+      example: bespoke.set_background_text('"' + '"\n"'.join(bespoke.get_controls("transport")) + '"', 14, 0, 50, 1, 1, 1)
    bespoke.random(seed, index)
    bespoke.get_modules()
    bespoke.get_controls(path)
-      example: bespoke.set_background_text('"' + '"\n"'.join(bespoke.get_controls("transport")) + '"', 14, 0, 50, 1, 1, 1)
    bespoke.location_recall(location)
       move to saved location (0-255). "1" - "9" match the minimap and function key shortcuts: SHIFT+"1" - "9"
       example: bespoke.location_recall("1")


### PR DESCRIPTION
To be able to retrieve grid data from the NoteSequencer in Python, I have created get_* functions:
```
      n.get_row(step)
      n.get_pitch(step)
      n.get_velocity(step)
      n.get_length(step)
      n.get_step(step)
        example: row, pitch, velocity, length = n.get_step(3)
```