### PR TITLE
Fix a settings label overlapping with a control element

### DIFF
--- a/Source/UserPrefsEditor.cpp
+++ b/Source/UserPrefsEditor.cpp
@@ -284,7 +284,7 @@ void UserPrefsEditor::DrawModule()
 
    mCategorySelector->Draw();
 
-   int controlX = 175;
+   int controlX = 205;
    int controlY = 50;
    bool hasPrefThatRequiresRestart = false;
    for (auto* pref : UserPrefs.mUserPrefs)


### PR DESCRIPTION
This change increases the width of the leftmost labels found in the settings module so that none of the labels overlap with any of the controls on the right.

Before:

<img width="567" height="523" alt="bespoke-settings-label-overlap-before" src="https://github.com/user-attachments/assets/a2134704-09c0-481e-a94a-246eafb5da16" />

After:

<img width="600" height="534" alt="bespoke-settings-label-overlap-after" src="https://github.com/user-attachments/assets/81aea3fd-7b29-4c01-8270-91729da03ced" />
